### PR TITLE
fix: planner review loop, codex agent UX, workflow scope gate

### DIFF
--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -1,5 +1,15 @@
 # Conventions
 
+## Git Workflow
+
+- **`main`**: Release branch. Always deployable. Never commit directly.
+- **`dev`**: Integration branch. Feature branches merge here.
+- **Feature branches**: Branch from `dev`, merge back to `dev` via PR or merge.
+- **Release**: When `dev` is stable, merge `dev` → `main` and bump version.
+- **Hotfix**: Fix on `dev`, merge to `main`. Cherry-pick if `dev` has unreleased WIP.
+
+Branch naming: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/` prefixes.
+
 ## Commit Style
 
 - Prefix: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`

--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -10,6 +10,8 @@
 
 Branch naming: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/` prefixes.
 
+Merge policy: **rebase only**. Keep linear history on `main` and `dev`.
+
 ## Commit Style
 
 - Prefix: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -27,17 +27,23 @@
    - Session writes are atomic (`.tmp` + rename)
    - Hook scripts are POSIX-portable
 
-## Phase 3: After Implementation
+## Phase 3: After Implementation (strict order, fail-fast by cost)
 
-1. Run validation:
+1. **Lint**: Run linter if configured (cheapest check first)
+
+2. **Review Gate** (before build): Invoke review-orchestrator for final validation (mandatory for non-trivial work). BLOCKING items must pass before proceeding to build.
+
+3. **Build**:
    ```bash
    npm run build    # tsc + esbuild -- must pass clean
+   ```
+
+4. **Test**:
+   ```bash
    npm test         # vitest -- all tests must pass
    ```
 
-2. Invoke review-orchestrator for final validation (mandatory for non-trivial work)
-
-3. KB update check: review work for `.claude/coral/kb/` promotion if non-obvious lessons were learned
+5. **KB update**: Review work for `.claude/coral/kb/` promotion if non-obvious lessons were learned
 
 ## Build Commands
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -29,6 +29,8 @@
 
 ## Phase 3: After Implementation (strict order, fail-fast by cost)
 
+**Scope gate**: Steps 1-4 apply only when source-affecting files are modified (`src/`, `scripts/`, `package.json`, `tsconfig.json`). Non-source changes (`agents/`, `skills/`, `docs/`, `hooks/`, `.claude/`) skip to step 5.
+
 1. **Lint**: Run linter if configured (cheapest check first)
 
 2. **Review Gate** (before build): Invoke review-orchestrator for final validation (mandatory for non-trivial work). BLOCKING items must pass before proceeding to build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ If Explanatory/Learning output style is active, also memo any Insights worth pre
 Before debugging from scratch, check `{project}/.claude/coral/kb/` for relevant entries.
 On plan/coplan start, review domain-related kb files.
 
-## Promotion — on task completion or plan approval
+## Promotion — on task/plan completion, or in common conversation when a memo captures a reusable lesson
 Review all memos + MEMORY.md. Check existing kb entries first — discard duplicates,
 update existing entries if the memo refines them, only create new files for genuinely absent knowledge.
 

--- a/agents/codex-analyst.md
+++ b/agents/codex-analyst.md
@@ -5,10 +5,11 @@ description: "Deep analysis and investigation via Codex delegation. Use when Cod
 tools: mcp__plugin_coral_cx__codex_session_create, mcp__plugin_coral_cx__codex_session_send
 ---
 
-**RULE: Your first action MUST be a tool call.** You are a proxy with no knowledge — you cannot
+**RULE: Your first response MUST contain a tool call.** You are a proxy with no knowledge — you cannot
 answer questions, perform analysis, or generate content. A response without a tool call is always
-wrong, regardless of how simple the task appears. Call `codex_session_create` or `codex_session_send`
-immediately. Then return the Codex response verbatim.
+wrong, regardless of how simple the task appears. Output a single line `Delegating to Codex…` then
+call `codex_session_create` or `codex_session_send` in the SAME response. Then return the Codex
+response verbatim.
 
 <Agent_Prompt>
   <Role>

--- a/agents/codex-architect.md
+++ b/agents/codex-architect.md
@@ -5,10 +5,11 @@ description: "Architecture analysis via Codex delegation. Use when Codex-specifi
 tools: mcp__plugin_coral_cx__codex_session_create, mcp__plugin_coral_cx__codex_session_send
 ---
 
-**RULE: Your first action MUST be a tool call.** You are a proxy with no knowledge — you cannot
+**RULE: Your first response MUST contain a tool call.** You are a proxy with no knowledge — you cannot
 answer questions, perform analysis, or generate content. A response without a tool call is always
-wrong, regardless of how simple the task appears. Call `codex_session_create` or `codex_session_send`
-immediately. Then return the Codex response verbatim.
+wrong, regardless of how simple the task appears. Output a single line `Delegating to Codex…` then
+call `codex_session_create` or `codex_session_send` in the SAME response. Then return the Codex
+response verbatim.
 
 <Agent_Prompt>
   <Role>

--- a/agents/codex-critic.md
+++ b/agents/codex-critic.md
@@ -5,10 +5,11 @@ description: "Critical review via Codex delegation. Use when Codex-specific pers
 tools: mcp__plugin_coral_cx__codex_session_create, mcp__plugin_coral_cx__codex_session_send
 ---
 
-**RULE: Your first action MUST be a tool call.** You are a proxy with no knowledge — you cannot
+**RULE: Your first response MUST contain a tool call.** You are a proxy with no knowledge — you cannot
 answer questions, perform analysis, or generate content. A response without a tool call is always
-wrong, regardless of how simple the task appears. Call `codex_session_create` or `codex_session_send`
-immediately. Then return the Codex response verbatim.
+wrong, regardless of how simple the task appears. Output a single line `Delegating to Codex…` then
+call `codex_session_create` or `codex_session_send` in the SAME response. Then return the Codex
+response verbatim.
 
 <Agent_Prompt>
   <Role>

--- a/agents/codex-ralph.md
+++ b/agents/codex-ralph.md
@@ -5,10 +5,11 @@ description: "Single-shot Codex execution for persistent tasks. Claude controls 
 tools: mcp__plugin_coral_cx__codex_session_create, mcp__plugin_coral_cx__codex_session_send
 ---
 
-**RULE: Your first action MUST be a tool call.** You are a proxy with no knowledge — you cannot
+**RULE: Your first response MUST contain a tool call.** You are a proxy with no knowledge — you cannot
 answer questions, perform analysis, or generate content. A response without a tool call is always
-wrong, regardless of how simple the task appears. Call `codex_session_create` or `codex_session_send`
-immediately. Then return the Codex response verbatim.
+wrong, regardless of how simple the task appears. Output a single line `Delegating to Codex…` then
+call `codex_session_create` or `codex_session_send` in the SAME response. Then return the Codex
+response verbatim.
 
 <Agent_Prompt>
   <Role>

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -92,11 +92,12 @@ model: opus
       ### Synthesis: Adopt/Adapt/Defer/Diverge items
 
     **3f. Exit Condition**
-    - Pass: No CRITICAL or HIGH findings from either reviewer
-    - Continue: Any CRITICAL/HIGH Adopted or Adapted → re-verify (go to 3a)
-    - Max rounds: 5 → ask user to continue or finalize
+    Evaluate based on what reviewers RETURNED this round (not your post-edit assessment):
+    - **Continue**: Either reviewer returned CRITICAL or HIGH findings → edit plan (3d), then go to 3a for re-verification. If you edited the plan this round, you MUST re-verify.
+    - **Pass**: Both reviewers returned NO CRITICAL or HIGH findings → exit loop (proceed to step 4 if multi-phase, else step 5)
+    - **Max rounds**: 5 → ask user to continue or finalize
 
-    Changes that have not been re-verified by reviewers are not considered validated.
+    NEVER exit the loop on a round where you edited the plan. Edits require re-verification.
 
     ### 4. Multi-Phase Review (if specified by caller)
     After the primary review loop converges, run ONE additional review round with different reviewers:

--- a/skills/init-project/templates/rules/workflow.md.template
+++ b/skills/init-project/templates/rules/workflow.md.template
@@ -10,6 +10,8 @@
 
 ## After Implementation (strict order, fail-fast by cost)
 
+**Scope gate**: Steps 1-4 apply only when source-affecting files are modified (e.g., source code, build config, dependencies). Non-source changes (docs, agent definitions, config prose) skip steps 1-4 entirely.
+
 ### 1. Lint
 - Run linter if available
 - Cheapest check — catches trivial issues immediately


### PR DESCRIPTION
## Summary
- **planner.md**: fix exit condition that caused premature phase transition — now evaluates reviewer output (not post-edit state) and mandates re-verification after plan edits
- **codex-\* agents**: output "Delegating to Codex…" before tool call to replace "Initializing…" in subagent status UI
- **workflow scope gate**: skip lint/build/test for non-source changes (agents, skills, docs, hooks)
- **CLAUDE.md**: broaden KB promotion trigger to include common conversation
- **conventions.md**: add git workflow branching rules

## Test plan
- [x] Run `/coral:coplan` and verify codex reviewers loop until no CRITICAL/HIGH before phase 2
- [x] Verify codex-* subagent status shows "Delegating to Codex…" instead of "Initializing…"
- [x] Confirm non-source-only changes skip build/test in post-implementation workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)