### PR TITLE
fix: planner max rounds must use AskUserQuestion

### DIFF
--- a/agents/planner.md
+++ b/agents/planner.md
@@ -95,7 +95,7 @@ model: opus
     Evaluate based on what reviewers RETURNED this round (not your post-edit assessment):
     - **Continue**: Either reviewer returned CRITICAL or HIGH findings → edit plan (3d), then go to 3a for re-verification. If you edited the plan this round, you MUST re-verify.
     - **Pass**: Both reviewers returned NO CRITICAL or HIGH findings → exit loop (proceed to step 4 if multi-phase, else step 5)
-    - **Max rounds**: 5 → ask user to continue or finalize
+    - **Max rounds**: 5 → use `AskUserQuestion` to let the user choose: continue reviewing, finalize as-is, or abort
 
     NEVER exit the loop on a round where you edited the plan. Edits require re-verification.
 


### PR DESCRIPTION
## Summary
- **planner.md**: max rounds (5) 도달 시 모호한 "ask user" 대신 `AskUserQuestion` 도구를 명시하여 사용자에게 continue/finalize/abort 선택지 제공

## Test plan
- [x] Run `/coral:coplan` with a plan that triggers 5+ review rounds, verify AskUserQuestion prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)