### PR TITLE
feat: add sandbox bypass logic to all Codex skills

### DIFF
--- a/agents/codex-proxy.md
+++ b/agents/codex-proxy.md
@@ -184,7 +184,7 @@ tools: mcp__plugin_coral_cx__codex_session_create, mcp__plugin_coral_cx__codex_s
   </Context_Assembly>
 
   <Sandbox_Mode>
-    When you are operating in bypass permissions mode (⏵⏵), pass `dangerously_bypass_sandbox: true`
+    When you are operating in bypass permissions mode, pass `dangerously_bypass_sandbox: true`
     to all `codex_session_create` and `codex_session_send` calls. This aligns Codex CLI's sandbox
     policy with the parent Claude Code session's permission level — allowing Codex to write files
     outside the working directory and skip approval prompts.

--- a/skills/codex-analyze/SKILL.md
+++ b/skills/codex-analyze/SKILL.md
@@ -24,6 +24,10 @@ Announce at start: "Using codex-analyze to investigate via Codex with Claude ver
    - **Restructure**: Present findings ordered by severity with verified references
    - **Synthesize**: Add a 2-3 sentence summary connecting findings to the original question
 
+## Sandbox bypass
+
+When operating in bypass permissions mode, pass `dangerously_bypass_sandbox: true` to all `codex_session_create` and `codex_session_send` calls. Otherwise, omit the field.
+
 ## Error Policy
 
 If `agents/codex-proxy.md` cannot be read, report the error to the user. Do not fall back to inline analysis — the agent protocol is a required dependency.

--- a/skills/codex-ralph/SKILL.md
+++ b/skills/codex-ralph/SKILL.md
@@ -46,6 +46,10 @@ After the loop exits:
    c. **Build**: Run the project's build command.
    d. **Test**: Run the test suite after build succeeds.
 
+## Sandbox bypass
+
+When operating in bypass permissions mode, pass `dangerously_bypass_sandbox: true` to all `codex_session_create` and `codex_session_send` calls. Otherwise, omit the field.
+
 ## Error Policy
 
 If `agents/codex-proxy.md` cannot be read, report the error to the user. Do not fall back to inline execution — the agent protocol is a required dependency.

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -49,6 +49,10 @@ Collect relevant context from the current conversation:
 - Current working directory
 - Constraints or requirements established earlier
 
+## Sandbox bypass
+
+When operating in bypass permissions mode, pass `dangerously_bypass_sandbox: true` to all `codex_session_create`, `codex_session_send`, and `codex_session_fork` calls. Otherwise, omit the field.
+
 ## 5a. Review (parallel subagent spawn)
 
 Spawn TWO Task agents in a SINGLE message (parallel):


### PR DESCRIPTION
## Summary
- Add `## Sandbox bypass` section to `/codex`, `/codex-analyze`, `/codex-ralph` skills — completing the bypass toggle feature across the full Codex call chain
- Remove non-portable unicode indicator (⏵⏵) from all bypass instructions (skills + codex-proxy agent)

## Test plan
- [x] Verify `/codex` in bypass mode passes `dangerously_bypass_sandbox: true`
- [x] Verify `/codex-analyze` and `/codex-ralph` follow the same pattern
- [x] Verify `/coplan` still works via codex-proxy agent (no skill-level change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)