### PR TITLE
refactor: migrate hooks to hooks.json with state file scoping

### DIFF
--- a/.claude/coral/kb/codex-union-migration-test-gaps.md
+++ b/.claude/coral/kb/codex-union-migration-test-gaps.md
@@ -1,0 +1,22 @@
+# Codex Union Migration — Test and Schema Gaps
+
+## Rule
+When migrating Codex MCP tools to a unified `codex` tool with `op` field, also update test files that hardcode old tool names in assertions, and decide explicitly whether union schemas should be strict.
+
+## Why
+`server-progress.test.ts` hardcodes `codex_session_create` in progress metadata assertions — these become stale after unification. Dropping `.strict()` on union shapes is a silent contract change: `{ op: 'list', extra: ... }` will parse without error, potentially masking caller bugs.
+
+## Pattern
+```typescript
+// WRONG: Hardcoded old tool names in tests (becomes stale)
+expect(notification.params.metadata).toEqual({ toolName: "codex_session_create" });
+
+// RIGHT: Update to unified name
+expect(notification.params.metadata).toEqual({ toolName: "codex" });
+
+// DECISION NEEDED: Schema strictness
+// Permissive (current): extra fields silently ignored
+codexExecSchema.or(codexListSchema)  // no .strict()
+// Strict: rejects unknown fields → catches caller bugs
+codexExecSchema.strict().or(codexListSchema.strict())
+```

--- a/.claude/coral/kb/hooks-skill-frontmatter-plugin-broken.md
+++ b/.claude/coral/kb/hooks-skill-frontmatter-plugin-broken.md
@@ -1,0 +1,33 @@
+# Plugin SKILL.md Frontmatter Hooks Do Not Fire
+
+## Rule
+Plugin skills' SKILL.md frontmatter hooks (PreToolUse, PostToolUse, Stop) do not fire. All hooks for plugin skills must be registered in `hooks/hooks.json`. Use script-internal conditions for scoping (state files, session flag files).
+
+## Why
+Frontmatter hooks appear to only work for project-level skills (`.claude/skills/`), not plugin skills. Assuming frontmatter hooks work and debugging from there wastes significant time — the hooks silently don't register.
+
+## Pattern
+```
+# WRONG: Frontmatter hooks in plugin SKILL.md (silently ignored)
+---
+name: ralph
+hooks:
+  Stop:
+    - command: "./hooks/kb-promote-reminder.sh"
+---
+
+# RIGHT: Register in hooks/hooks.json with script-level scoping
+# hooks/hooks.json
+"Stop": [{ "hooks": [{ "type": "command", "command": "...", "timeout": 5 }] }]
+
+# Script checks state file to scope to specific skills:
+STATE_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/coral/tmp/kb-active"
+[ ! -f "$STATE_FILE" ] && exit 0
+
+# SKILL.md creates state file via ! command:
+```!
+touch "${CLAUDE_PROJECT_DIR:-.}/.claude/coral/tmp/kb-active"
+```
+```
+
+Verified against claude-code v2.1.50: all official plugins (hookify, ralph-wiggum, security-guidance) register hooks exclusively in hooks.json. Zero plugins use SKILL.md frontmatter hooks.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -49,7 +49,7 @@ Before context compaction, checks for unprocessed memos in `.claude/coral/memo/`
 
 Script: `hooks/kb-memo-reminder.sh`. Fires once per session (flag file keyed by `session_id`). Injects `additionalContext` reminding Claude to write memos when discovering non-obvious lessons.
 
-**Throttled (30 min)**: Reads `session_id` from stdin JSON, creates `.claude/coral/tmp/memo-reminded-<session_id>` flag file. Subsequent calls within 30 minutes exit silently; after 30 minutes, `touch` refreshes the mtime and the reminder fires again.
+**Throttled (15 min)**: Reads `session_id` from stdin JSON, creates `.claude/coral/tmp/memo-reminded-<session_id>` flag file. Subsequent calls within 15 minutes exit silently; after 15 minutes, `touch` refreshes the mtime and the reminder fires again.
 
 ## Stop Hook (KB Promotion)
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -9,14 +9,11 @@ Claude Code's hook system executes shell scripts on specific events. Coral uses 
 **Plugin hooks** (`hooks/hooks.json`):
 1. **SessionStart** - Injects CLAUDE.md behavioral guidelines into every Claude session
 2. **SubagentStart** - Injects delegation instructions into agents with a `codex-` prefix (with or without `coral:` namespace)
-3. **PostToolUseFailure** - On any tool failure, reminds Claude to check `.claude/coral/kb/` before debugging
-4. **PreCompact** - Before context compaction, reminds about unprocessed memos for KB promotion
-5. **TeammateIdle** - Blocks idle when discuss agents have pending actions
-
-**Skill-level hooks** (in SKILL.md frontmatter):
-- Skills: ralph, codex-ralph, plan, coplan, debug, code-simplify, analyze, codex-analyze
-- **PreToolUse** (`once: true`): On first tool call, reminds Claude to write memos for non-obvious discoveries
-- **Stop** (`once: true`): On skill completion, blocks Claude from stopping if unprocessed memos exist in `.claude/coral/memo/`
+3. **PreToolUse** - On first tool call per session, reminds Claude to write memos for non-obvious discoveries
+4. **PostToolUseFailure** - On any tool failure, reminds Claude to check `.claude/coral/kb/` before debugging
+5. **Stop** - On response completion, blocks Claude from stopping if unprocessed memos exist in `.claude/coral/memo/`
+6. **PreCompact** - Before context compaction, reminds about unprocessed memos for KB promotion
+7. **TeammateIdle** - Blocks idle when discuss agents have pending actions
 
 ## Hook Configuration
 
@@ -48,23 +45,24 @@ Before context compaction, checks for unprocessed memos in `.claude/coral/memo/`
 
 **Fail-open**: If memo directory doesn't exist or has no files — silent exit 0.
 
-## Skill Hooks (KB Memo & Promotion)
+## PreToolUse Hook (Memo Reminder)
 
-Configured in SKILL.md frontmatter on: ralph, codex-ralph, plan, coplan, debug, code-simplify, analyze, codex-analyze.
+Script: `hooks/kb-memo-reminder.sh`. Fires once per session (flag file keyed by `session_id`). Injects `additionalContext` reminding Claude to write memos when discovering non-obvious lessons.
 
-### PreToolUse — Memo Reminder
+**Once-per-session**: Reads `session_id` from stdin JSON, creates `/tmp/coral-memo-reminded-<session_id>` flag file. Subsequent calls exit 0 silently.
 
-Script: `hooks/kb-memo-reminder.sh`. Fires once (`once: true`) before the first tool call. Injects `additionalContext` reminding Claude to write memos when discovering non-obvious lessons.
+## Stop Hook (KB Promotion)
 
-### Stop — Promotion Reminder
+Script: `hooks/kb-promote-reminder.sh`. Fires on every response completion, but **skill-scoped** via state file.
 
-Script: `hooks/kb-promote-reminder.sh`. Fires once (`once: true`) when Claude finishes responding.
+**State file pattern**: Skills (ralph, codex-ralph) create `.claude/coral/tmp/kb-active` on start via `!` command preprocessing. The Stop hook checks for this file — if absent, exits silently (normal conversation unaffected).
 
-When unprocessed memos exist in `.claude/coral/memo/`:
-- `decision: "block"` prevents Claude from stopping
-- `reason` instructs Claude to review memos for KB promotion (check existing KB entries, discard duplicates, promote new knowledge, delete processed memos)
+When state file exists and unprocessed memos found in `.claude/coral/memo/`:
+1. Delete state file (unconditionally)
+2. `decision: "block"` prevents Claude from stopping
+3. `reason` instructs Claude to review memos for KB promotion
 
-**Fail-open**: If memo directory doesn't exist or has no files — silent exit 0. Claude stops normally.
+**Fail-open**: If state file absent, or memo directory empty — silent exit 0.
 
 ## Detection Script
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -49,7 +49,7 @@ Before context compaction, checks for unprocessed memos in `.claude/coral/memo/`
 
 Script: `hooks/kb-memo-reminder.sh`. Fires once per session (flag file keyed by `session_id`). Injects `additionalContext` reminding Claude to write memos when discovering non-obvious lessons.
 
-**Once-per-session**: Reads `session_id` from stdin JSON, creates `/tmp/coral-memo-reminded-<session_id>` flag file. Subsequent calls exit 0 silently.
+**Once-per-session**: Reads `session_id` from stdin JSON, creates `.claude/coral/tmp/memo-reminded-<session_id>` flag file. Subsequent calls exit 0 silently.
 
 ## Stop Hook (KB Promotion)
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -49,7 +49,7 @@ Before context compaction, checks for unprocessed memos in `.claude/coral/memo/`
 
 Script: `hooks/kb-memo-reminder.sh`. Fires once per session (flag file keyed by `session_id`). Injects `additionalContext` reminding Claude to write memos when discovering non-obvious lessons.
 
-**Once-per-session**: Reads `session_id` from stdin JSON, creates `.claude/coral/tmp/memo-reminded-<session_id>` flag file. Subsequent calls exit 0 silently.
+**Throttled (30 min)**: Reads `session_id` from stdin JSON, creates `.claude/coral/tmp/memo-reminded-<session_id>` flag file. Subsequent calls within 30 minutes exit silently; after 30 minutes, `touch` refreshes the mtime and the reminder fires again.
 
 ## Stop Hook (KB Promotion)
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -36,6 +36,28 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/kb-memo-reminder.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "hooks": [

--- a/hooks/kb-memo-reminder.sh
+++ b/hooks/kb-memo-reminder.sh
@@ -1,8 +1,24 @@
 #!/bin/sh
 # kb-memo-reminder.sh - PreToolUse hook for memo writing reminder.
 # Reminds Claude to write memos when discovering non-obvious lessons.
-# Used with once: true in skill frontmatter (fires once at skill start).
+# Once per session: uses flag file keyed by session_id from stdin JSON.
 #
 # POSIX-portable: no bash-isms, no jq, no grep -P.
+
+set -e
+
+INPUT=$(cat)
+SESSION_ID=$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+FLAG="/tmp/coral-memo-reminded-${SESSION_ID}"
+if [ -f "$FLAG" ]; then
+  exit 0
+fi
+
+touch "$FLAG"
 
 printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"Memo reminder: When you discover something non-obvious during this task (painful root cause, unexpected gotcha, clever solution), write immediately to .claude/coral/memo/<timestamp>-<topic>.md. Keep brief - one paragraph + context."}}\n'

--- a/hooks/kb-memo-reminder.sh
+++ b/hooks/kb-memo-reminder.sh
@@ -14,11 +14,13 @@ if [ -z "$SESSION_ID" ]; then
   exit 0
 fi
 
-FLAG="/tmp/coral-memo-reminded-${SESSION_ID}"
+FLAG_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/coral/tmp"
+FLAG="${FLAG_DIR}/memo-reminded-${SESSION_ID}"
 if [ -f "$FLAG" ]; then
   exit 0
 fi
 
+mkdir -p "$FLAG_DIR"
 touch "$FLAG"
 
 printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"Memo reminder: When you discover something non-obvious during this task (painful root cause, unexpected gotcha, clever solution), write immediately to .claude/coral/memo/<timestamp>-<topic>.md. Keep brief - one paragraph + context."}}\n'

--- a/hooks/kb-memo-reminder.sh
+++ b/hooks/kb-memo-reminder.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # kb-memo-reminder.sh - PreToolUse hook for memo writing reminder.
 # Reminds Claude to write memos when discovering non-obvious lessons.
-# Once per session: uses flag file keyed by session_id from stdin JSON.
+# Throttled: once per 30 minutes per session via flag file mtime check.
 #
 # POSIX-portable: no bash-isms, no jq, no grep -P.
 
@@ -16,7 +16,8 @@ fi
 
 FLAG_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/coral/tmp"
 FLAG="${FLAG_DIR}/memo-reminded-${SESSION_ID}"
-if [ -f "$FLAG" ]; then
+# Skip if reminded within last 30 minutes (flag file mtime check)
+if [ -f "$FLAG" ] && [ -z "$(find "$FLAG" -mmin +30 2>/dev/null)" ]; then
   exit 0
 fi
 

--- a/hooks/kb-memo-reminder.sh
+++ b/hooks/kb-memo-reminder.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # kb-memo-reminder.sh - PreToolUse hook for memo writing reminder.
 # Reminds Claude to write memos when discovering non-obvious lessons.
-# Throttled: once per 30 minutes per session via flag file mtime check.
+# Throttled: once per 15 minutes per session via flag file mtime check.
 #
 # POSIX-portable: no bash-isms, no jq, no grep -P.
 
@@ -16,8 +16,8 @@ fi
 
 FLAG_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/coral/tmp"
 FLAG="${FLAG_DIR}/memo-reminded-${SESSION_ID}"
-# Skip if reminded within last 30 minutes (flag file mtime check)
-if [ -f "$FLAG" ] && [ -z "$(find "$FLAG" -mmin +30 2>/dev/null)" ]; then
+# Skip if reminded within last 15 minutes (flag file mtime check)
+if [ -f "$FLAG" ] && [ -z "$(find "$FLAG" -mmin +15 2>/dev/null)" ]; then
   exit 0
 fi
 

--- a/hooks/kb-promote-reminder.sh
+++ b/hooks/kb-promote-reminder.sh
@@ -1,13 +1,27 @@
 #!/bin/sh
 # kb-promote-reminder.sh - Stop/PreCompact hook for KB promotion.
-# Reminds Claude to review memos for KB promotion on skill completion
-# or before context compaction.
+# Stop: skill-scoped via .claude/coral-kb-active state file.
+# PreCompact: always checks for unprocessed memos.
 # Fail-open: errors default to exit 0 (no output).
 #
 # POSIX-portable: no bash-isms, no jq, no grep -P.
 
 set -e
 
+INPUT=$(cat)
+EVENT=$(printf '%s' "$INPUT" | sed -n 's/.*"hook_event_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+STATE_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/coral/tmp/kb-active"
+
+# Stop hook: skill-scoped via state file
+if [ "$EVENT" = "Stop" ]; then
+  if [ ! -f "$STATE_FILE" ]; then
+    exit 0
+  fi
+  rm -f "$STATE_FILE"
+fi
+
+# Check for unprocessed memos
 MEMO_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/coral/memo"
 if [ ! -d "$MEMO_DIR" ]; then
   exit 0
@@ -28,4 +42,8 @@ if [ -z "$memo_files" ]; then
   exit 0
 fi
 
-printf '{"decision":"block","reason":"Unprocessed memos found. Before completing, review .claude/coral/memo/ for KB promotion. Memos: %s. Check existing KB entries in .claude/coral/kb/ first - discard duplicates, update existing entries if a memo refines them, only create new files for genuinely absent knowledge. Delete processed memos after promotion.","systemMessage":"KB promotion reminder: unprocessed memos found in .claude/coral/memo/"}\n' "$memo_files"
+if [ "$EVENT" = "Stop" ]; then
+  printf '{"decision":"block","reason":"Unprocessed memos found. Before completing, review .claude/coral/memo/ for KB promotion. Memos: %s. Check existing KB entries in .claude/coral/kb/ first - discard duplicates, update existing entries if a memo refines them, only create new files for genuinely absent knowledge. Delete processed memos after promotion.","systemMessage":"KB promotion reminder: unprocessed memos found in .claude/coral/memo/"}\n' "$memo_files"
+else
+  printf '{"systemMessage":"KB promotion reminder: unprocessed memos found in .claude/coral/memo/ - %s"}\n' "$memo_files"
+fi

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -2,17 +2,6 @@
 name: analyze
 description: Deep analysis and investigation via Claude-native analysis
 argument-hint: "[investigation target or question]"
-hooks:
-  PreToolUse:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-memo-reminder.sh"
-          once: true
-  Stop:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.sh"
-          once: true
 ---
 
 # Deep Analysis & Investigation

--- a/skills/code-simplify/SKILL.md
+++ b/skills/code-simplify/SKILL.md
@@ -2,17 +2,6 @@
 name: code-simplify
 description: "Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise."
 argument-hint: "[codex:|claude:]<scope or prompt>"
-hooks:
-  PreToolUse:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-memo-reminder.sh"
-          once: true
-  Stop:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.sh"
-          once: true
 ---
 
 # Code Simplification

--- a/skills/codex-analyze/SKILL.md
+++ b/skills/codex-analyze/SKILL.md
@@ -2,17 +2,6 @@
 name: codex-analyze
 description: Deep analysis via Codex delegation with Claude post-processing
 argument-hint: "[investigation target or question]"
-hooks:
-  PreToolUse:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-memo-reminder.sh"
-          once: true
-  Stop:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.sh"
-          once: true
 ---
 
 # Deep Analysis via Codex

--- a/skills/codex-ralph/SKILL.md
+++ b/skills/codex-ralph/SKILL.md
@@ -4,18 +4,11 @@ description: Persistent execution via Codex delegation (sonnet) - best for imple
 argument-hint: "[--red] [task description]"
 model: sonnet
 disable-model-invocation: true
-hooks:
-  PreToolUse:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-memo-reminder.sh"
-          once: true
-  Stop:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.sh"
-          once: true
 ---
+
+```!
+mkdir -p "${CLAUDE_PROJECT_DIR:-.}/.claude/coral/tmp" && touch "${CLAUDE_PROJECT_DIR:-.}/.claude/coral/tmp/kb-active"
+```
 
 # Persistent Execution via Codex
 

--- a/skills/coplan/SKILL.md
+++ b/skills/coplan/SKILL.md
@@ -2,17 +2,6 @@
 name: coplan
 description: Collaborative planning with parallel Codex architect/critic reviews
 argument-hint: "[task description]"
-hooks:
-  PreToolUse:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-memo-reminder.sh"
-          once: true
-  Stop:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.sh"
-          once: true
 ---
 
 # Collaborative Planning

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -2,17 +2,6 @@
 name: debug
 description: "Systematic bug diagnosis, planning, and fix execution."
 argument-hint: "[codex:|claude:]<bug description or error message>"
-hooks:
-  PreToolUse:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-memo-reminder.sh"
-          once: true
-  Stop:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.sh"
-          once: true
 ---
 
 # Bug Debugging

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -2,17 +2,6 @@
 name: plan
 description: Claude-native planning with parallel architect/critic self-review
 argument-hint: "[task description]"
-hooks:
-  PreToolUse:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-memo-reminder.sh"
-          once: true
-  Stop:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.sh"
-          once: true
 ---
 
 # Planning

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -3,18 +3,11 @@ name: ralph
 description: Persistent execution loop with verification (sonnet) - best for implementing an existing plan
 argument-hint: "[--red] [task description]"
 model: sonnet
-hooks:
-  PreToolUse:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-memo-reminder.sh"
-          once: true
-  Stop:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.sh"
-          once: true
 ---
+
+```!
+mkdir -p "${CLAUDE_PROJECT_DIR:-.}/.claude/coral/tmp" && touch "${CLAUDE_PROJECT_DIR:-.}/.claude/coral/tmp/kb-active"
+```
 
 # Persistent Execution with Verification
 


### PR DESCRIPTION
## Summary
- Migrate skill hooks from SKILL.md frontmatter (broken for plugins) to hooks.json with script-level scoping
- Stop hook scoped to ralph/codex-ralph via `.claude/coral/tmp/kb-active` state file created by `!` command
- PreToolUse memo reminder throttled to once per 15 minutes per session (flag file mtime check)
- All coral runtime artifacts consolidated under `.claude/coral/tmp/`

## Test plan
- [x] Install plugin, run `/coral:ralph` with memo file present — Stop hook should block
- [x] Run `/coral:plan` — Stop hook should NOT fire (no state file)
- [x] Verify memo reminder fires on first tool call, then stays silent for 15 min
- [x] Verify PreCompact still warns about unprocessed memos

🤖 Generated with [Claude Code](https://claude.com/claude-code)