### PR TITLE
refactor: show KB topics instead of full filenames in error hook

### DIFF
--- a/hooks/kb-lookup-reminder.mjs
+++ b/hooks/kb-lookup-reminder.mjs
@@ -15,10 +15,12 @@ try {
   const files = readdirSync(kbDir).filter(f => f.endsWith('.md'));
   if (files.length === 0) process.exit(0);
 
+  const topics = [...new Set(files.map(f => f.replace(/\.md$/, '').replace(/-.*$/, '')))].sort();
+
   console.log(JSON.stringify({
     hookSpecificOutput: {
       hookEventName: 'PostToolUseFailure',
-      additionalContext: `Error detected. Before debugging from scratch, check .claude/coral/kb/ for relevant knowledge: ${files.join(', ')}`,
+      additionalContext: `Error detected. Before debugging from scratch, check .claude/coral/kb/ for relevant knowledge. KB topics: ${topics.join(', ')}`,
     },
   }));
 } catch {


### PR DESCRIPTION
## Summary

- Extract unique domain prefixes from KB filenames in `PostToolUseFailure` hook
- Before: 20 full filenames dumped into reminder
- After: `KB topics: agent, claude, codex, discuss, hooks, mcp, regex, rules, skill, typescript`

Reduces noise as KB grows — domains scale better than file lists.

## Test plan

- [x] Verified extraction logic with current 20 KB files → 10 unique topics
- [x] Hook is fail-open (exits silently on error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)