### PR TITLE
fix: clarify init-project Phase 2 review loop condition

### DIFF
--- a/skills/init-project/SKILL.md
+++ b/skills/init-project/SKILL.md
@@ -160,7 +160,7 @@ argument-hint: "[existing|new]"
      Task(subagent_type="coral:critic", prompt="Review plan: {plan_file_path}. Working dir: {project root}. ...")
      ```
   4. Synthesize feedback (Adopt/Adapt/Defer/Diverge per planner.md)
-  5. Update plan file, repeat review until no CRITICAL/HIGH (max 5 rounds)
+  5. If CRITICAL/HIGH findings were addressed, update plan file and go back to step 3 for another review round. Max 5 rounds.
 
   **Evidence gate**: Phase 2 is complete ONLY when a plan file exists at `.claude/coral/plans/init-*.md`.
   If no file exists on disk, Phase 2 did not execute correctly.


### PR DESCRIPTION
## Summary
- Clarify Phase 2 review loop: re-review triggers only when CRITICAL/HIGH findings were addressed, not as a blind loop
- "go back to step 3" replaces ambiguous "repeat review" wording

## Test plan
- [x] Verify SKILL.md step 5 reads clearly as conditional loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)