### PR TITLE
fix: replace $CLAUDE_PROJECT_DIR with relative paths in skill init blocks

### DIFF
--- a/.claude/coral/kb/hooks-skill-frontmatter-plugin-broken.md
+++ b/.claude/coral/kb/hooks-skill-frontmatter-plugin-broken.md
@@ -21,12 +21,12 @@ hooks:
 "Stop": [{ "hooks": [{ "type": "command", "command": "...", "timeout": 5 }] }]
 
 # Script checks state file to scope to specific skills:
-STATE_FILE="$CLAUDE_PROJECT_DIR/.claude/coral/tmp/kb-active"
+STATE_FILE=".claude/coral/tmp/kb-active"
 [ ! -f "$STATE_FILE" ] && exit 0
 
 # SKILL.md creates state file via ! command:
 ```!
-touch "$CLAUDE_PROJECT_DIR/.claude/coral/tmp/kb-active"
+mkdir -p .claude/coral/tmp && touch .claude/coral/tmp/kb-active
 ```
 ```
 

--- a/hooks/permission-handler.mjs
+++ b/hooks/permission-handler.mjs
@@ -7,8 +7,8 @@
  */
 
 const ALLOWED_PATTERNS = [
-  /^mkdir -p .+\.claude\/coral\/tmp/,
-  /^touch .+\.claude\/coral\/tmp\//,
+  /^mkdir -p \.claude\/coral\/tmp$/,
+  /^touch \.claude\/coral\/tmp\//,
 ];
 
 try {

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -5,7 +5,7 @@ argument-hint: "[--codex] <bug description or error message>"
 ---
 
 ```!
-mkdir -p "$CLAUDE_PROJECT_DIR/.claude/coral/tmp" && touch "$CLAUDE_PROJECT_DIR/.claude/coral/tmp/kb-active"
+mkdir -p .claude/coral/tmp && touch .claude/coral/tmp/kb-active
 ```
 
 # Bug Debugging

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -6,7 +6,7 @@ model: sonnet
 ---
 
 ```!
-mkdir -p "$CLAUDE_PROJECT_DIR/.claude/coral/tmp" && touch "$CLAUDE_PROJECT_DIR/.claude/coral/tmp/kb-active"
+mkdir -p .claude/coral/tmp && touch .claude/coral/tmp/kb-active
 ```
 
 # Persistent Execution with Verification


### PR DESCRIPTION
## Summary
- Replace `$CLAUDE_PROJECT_DIR` with relative paths (`.claude/coral/tmp`) in SKILL.md `!` init blocks
- `CLAUDE_PROJECT_DIR` env var is unset in Claude Code sessions, causing permission errors and root filesystem writes
- Update `permission-handler.mjs` regex to match exact relative paths
- Update KB example code

## Test plan
- [x] Run `/ralph` — verify `mkdir -p .claude/coral/tmp` executes without permission prompt
- [x] Run `/debug` — same verification
- [x] Verify `.claude/coral/tmp/kb-active` file is created in project root

🤖 Generated with [Claude Code](https://claude.com/claude-code)