### PR TITLE
fix: strip ! prefix from SKILL.md auto-execute blocks in permission handler

### DIFF
--- a/hooks/permission-handler.mjs
+++ b/hooks/permission-handler.mjs
@@ -16,8 +16,11 @@ try {
   const toolName = (input.tool_name || '').replace(/^proxy_/, '');
   if (toolName !== 'Bash') process.exit(0);
 
-  const command = input.tool_input?.command;
-  if (!command || typeof command !== 'string') process.exit(0);
+  const rawCommand = input.tool_input?.command;
+  if (!rawCommand || typeof rawCommand !== 'string') process.exit(0);
+
+  // Strip leading "! " from SKILL.md ```! auto-execute blocks
+  const command = rawCommand.replace(/^! /, '');
 
   // Check each part of chained commands (&&)
   const parts = command.split('&&').map(p => p.trim());


### PR DESCRIPTION
## Summary
- SKILL.md `\`\`\`!` blocks prepend `! ` to the command text passed to PermissionRequest hooks
- This broke permission-handler.mjs regex matching, causing "sensitive file" permission prompts
- Strip the `! ` prefix before pattern matching

Follows up on #32 (relative path fix).

## Test plan
- [x] Run `/ralph` in normal mode — verify no permission prompt for `.claude/coral/tmp` creation
- [x] Run `/debug` in normal mode — same verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)