### PR TITLE
feat: plan-guard hooks for compaction safety

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -10,6 +10,21 @@
             "timeout": 3
           }
         ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/plan-guard.mjs\"",
+            "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.mjs\"",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "SubagentStart": [
@@ -36,6 +51,17 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/plan-state-tracker.mjs\"",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "hooks": [
@@ -54,17 +80,11 @@
             "type": "command",
             "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.mjs\"",
             "timeout": 5
-          }
-        ]
-      }
-    ],
-    "PreCompact": [
-      {
-        "hooks": [
+          },
           {
             "type": "command",
-            "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-reminder.mjs\"",
-            "timeout": 5
+            "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/plan-state-tracker.mjs\"",
+            "timeout": 3
           }
         ]
       }

--- a/hooks/kb-promote-reminder.mjs
+++ b/hooks/kb-promote-reminder.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * Stop/PreCompact hook — enforces KB promotion for unprocessed memos.
+ * Stop/SessionStart(compact) hook — enforces KB promotion for unprocessed memos.
  * Stop: skill-scoped via .claude/coral/tmp/kb-active state file.
- * PreCompact: always checks for unprocessed memos.
+ * SessionStart(compact): always checks for unprocessed memos after compaction.
  * Fail-open: any error exits silently.
  */
 
@@ -39,9 +39,12 @@ try {
     }));
   } else {
     console.log(JSON.stringify({
-      systemMessage: memos.length > 0
-        ? `KB promotion reminder: promote only if useful across sessions. Also, ${sessionKb} Memos: ${list}`
-        : `KB reminder: ${sessionKb}`,
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: memos.length > 0
+          ? `KB promotion reminder: promote only if useful across sessions. Also, ${sessionKb} Memos: ${list}`
+          : `KB reminder: ${sessionKb}`,
+      },
     }));
   }
 } catch {

--- a/hooks/plan-guard.mjs
+++ b/hooks/plan-guard.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/**
+ * SessionStart(compact) hook — prevents premature implementation after compaction.
+ * When plan mode was active during compaction, injects context forcing Claude
+ * to continue planning instead of starting implementation.
+ * Fail-open: any error exits silently.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+try {
+  const input = JSON.parse(await readStdin());
+  const sessionId = input.session_id;
+  if (!sessionId) process.exit(0);
+
+  const flagDir = join(process.env.CLAUDE_PROJECT_DIR || '.', '.claude', 'coral', 'tmp');
+  const flag = join(flagDir, `plan-active-${sessionId}`);
+
+  if (!existsSync(flag)) process.exit(0);
+
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext: [
+        'PLAN MODE ACTIVE — DO NOT IMPLEMENT.',
+        'Context compaction just occurred while you were executing the /coral:plan skill.',
+        'Re-read skills/plan/SKILL.md and skills/plan/PROTOCOL.md to recover your role and protocol.',
+        'Re-read your plan file in .claude/coral/plans/ to recover your progress.',
+        'Resume from where you left off. Do NOT start over.',
+      ].join('\n'),
+    },
+  }));
+} catch {
+  process.exit(0);
+}
+
+function readStdin() {
+  return new Promise(resolve => {
+    let data = '';
+    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve('{}'));
+  });
+}

--- a/hooks/plan-state-tracker.mjs
+++ b/hooks/plan-state-tracker.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+/**
+ * UserPromptSubmit + Stop hook — tracks plan mode state via flag files.
+ * UserPromptSubmit: /coral:plan or /plan → create flag.
+ * Stop: delete flag (planning turn ended).
+ * Fail-open: any error exits silently.
+ */
+
+import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PLAN_START = /^\/(coral:)?plan(\s|$)/i;
+const FLAG_PREFIX = 'plan-active-';
+const STALE_MS = 24 * 60 * 60_000;
+
+try {
+  const input = JSON.parse(await readStdin());
+  const event = input.hook_event_name;
+  const sessionId = input.session_id;
+  if (!sessionId) process.exit(0);
+
+  const flagDir = join(process.env.CLAUDE_PROJECT_DIR || '.', '.claude', 'coral', 'tmp');
+  const flag = join(flagDir, `${FLAG_PREFIX}${sessionId}`);
+
+  if (event === 'UserPromptSubmit') {
+    const prompt = (input.prompt || '').trim();
+    if (PLAN_START.test(prompt)) {
+      mkdirSync(flagDir, { recursive: true });
+      writeFileSync(flag, new Date().toISOString());
+    }
+  } else if (event === 'Stop') {
+    if (existsSync(flag)) unlinkSync(flag);
+  }
+
+  // Clean up stale flags from expired sessions
+  try {
+    const now = Date.now();
+    for (const f of readdirSync(flagDir)) {
+      if (!f.startsWith(FLAG_PREFIX) || f === `${FLAG_PREFIX}${sessionId}`) continue;
+      const path = join(flagDir, f);
+      if (now - statSync(path).mtimeMs > STALE_MS) unlinkSync(path);
+    }
+  } catch { /* fail-open */ }
+} catch {
+  process.exit(0);
+}
+
+function readStdin() {
+  return new Promise(resolve => {
+    let data = '';
+    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve('{}'));
+  });
+}


### PR DESCRIPTION
## Summary
- Add plan-guard hooks that prevent Claude from starting implementation after context compaction during planning
- `plan-state-tracker.mjs`: UserPromptSubmit creates flag on `/plan`, Stop clears flag when planning turn ends
- `plan-guard.mjs`: SessionStart(compact) injects "continue planning" context when flag is active
- Fix `kb-promote-reminder.mjs` bug: PreCompact `systemMessage` (not injected into context) → SessionStart(compact) `additionalContext`

## Test plan
- [x] Run `/coral:plan`, trigger manual compaction mid-planning, verify Claude continues planning
- [x] Verify flag is cleared after planning turn completes (Stop hook)
- [x] Verify stale flags (>24h) are cleaned up automatically
- [x] Verify kb-promote-reminder context is injected after compaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)