### PR TITLE
docs: add discussant prompt requirements to discuss SKILL.md

### DIFF
--- a/skills/discuss/SKILL.md
+++ b/skills/discuss/SKILL.md
@@ -84,6 +84,12 @@ Before any other action, verify the Agent Teams environment:
      using `name: 'dc-{agent_name}'` (e.g., agent `park` → teammate `dc-park`).
      Skip `participation: 'observer'` agents —
      they interact via `/bid`, not as spawned teammates.
+     Each discussant prompt must include:
+     - Discussion topic and relevant context
+       (background information, constraints, or framing
+       that the main context gathered during topic analysis in step 2)
+     - Their full persona (generated in step 3)
+     - Session ID
 
 7. **If `--user`**: Return immediately to the user:
    "Discussion started! Use `/bid <score>, <thought>` to submit a bid,


### PR DESCRIPTION
## Summary
- Discuss SKILL.md의 Step 6에 discussant 스폰 시 prompt에 포함해야 할 항목 명시
  - Discussion topic and relevant context (배경 정보, 제약 조건, 프레이밍)
  - Full persona (step 3에서 생성)
  - Session ID

## Test plan
- [x] Verify SKILL.md renders correctly
- [x] Run `/discuss` and confirm discussants receive topic/context in their prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)