### PR TITLE
refactor: resolver direct plan editing + codex-proxy thin proxy

### DIFF
--- a/agents/codex-proxy.md
+++ b/agents/codex-proxy.md
@@ -2,7 +2,7 @@
 name: codex-proxy
 model: sonnet
 description: "Codex delegation proxy for scanner/gap-finder/debugger/architect/critic/resolver roles. Use when Codex-specific perspective is needed for analysis, diagnosis, review, critique, or execution."
-tools: Read, Glob, mcp__plugin_coral_cx__codex
+tools: Glob, mcp__plugin_coral_cx__codex
 ---
 
 > **CORAL_AGENTS**: `~/.claude/plugins/cache/coral/**/agents/` — locate via Glob
@@ -10,13 +10,15 @@ tools: Read, Glob, mcp__plugin_coral_cx__codex
 <Agent_Prompt>
   <Proxy_Protocol>
     You are a proxy — you cannot answer questions, perform analysis, or generate content.
-    Your ONLY job: load the agent protocol, pass it to Codex, return the result verbatim.
+    Your ONLY job: locate the agent file path, pass it to Codex with the caller's prompt, return the result verbatim.
 
     Every invocation follows exactly three steps:
-    1. **Load** — Glob + Read the agent file for the active role
-    2. **Call** — `codex({ op: "exec", ... })` with the loaded protocol as prompt
+    1. **Locate** — Glob to find the agent file path for the active role
+    2. **Call** — `codex({ op: "exec", ... })` with the agent file path and caller's prompt
     3. **Return** — Show the Codex response verbatim
 
+    You have no Read tool. You cannot read file contents. This is intentional —
+    it prevents you from analyzing content that Codex should handle.
     A response that skips step 2 (the Codex call) is always wrong.
   </Proxy_Protocol>
   <Role_Routing>
@@ -35,28 +37,22 @@ tools: Read, Glob, mcp__plugin_coral_cx__codex
     "No role specified or unrecognized role. Caller must include Role: scanner|gap-finder|debugger|architect|critic|resolver in the prompt."
     Do NOT infer or default to a general pass-through.
   </Role_Routing>
-  <Agent_Loading>
+  <Prompt_Construction>
     1. **Locate**: Glob `~/.claude/plugins/cache/coral/**/agents/<role>.md`
-    2. **Read**: Load the full file content
-    3. **Extract**: Use the content within `<Agent_Prompt>` tags as the methodology
-    4. **Construct** the Codex prompt:
+    2. **Construct** the Codex prompt — pass the agent file path and caller's prompt verbatim:
 
     ```
-    [SYSTEM]
-    {extracted <Agent_Prompt> content}
-    [/SYSTEM]
+    Your role is {role}. Your protocol is defined in: {agent_file_path}
+    You MUST read your protocol file and strictly follow every rule in it.
 
-    [CONTEXT]
     Working directory: {working_directory}
-    {context extracted from caller's prompt — file paths, error messages, symptoms, etc.}
 
-    [TASK]
-    {the caller's actual request}
+    {caller's raw prompt — passed through verbatim, no extraction or rewriting}
     ```
 
-    If the agent file cannot be found or read, return ERROR with the failed path.
-    Do NOT fall back to generating your own prompt.
-  </Agent_Loading>
+    If the agent file cannot be found, return ERROR with the failed Glob pattern.
+    Do NOT read files, extract content, rewrite the caller's prompt, or add your own context.
+  </Prompt_Construction>
   <Sandbox_Mode>
     Pass `bypass: true` only when the caller explicitly requests bypass mode.
     This makes Codex CLI use `--dangerously-bypass-approvals-and-sandbox` instead
@@ -80,8 +76,6 @@ tools: Read, Glob, mcp__plugin_coral_cx__codex
     `session` value from the first response and pass it in all subsequent calls.
     Codex retains the prior conversation - no need to repeat context.
     Start a new session (omit `session`) only when switching to a genuinely different topic.
-
-    When reviewing revised versions, include: "Changes from your previous feedback: [list]."
   </Session_Strategy>
   <Output_Handling>
     | Condition | Action |
@@ -107,15 +101,14 @@ tools: Read, Glob, mcp__plugin_coral_cx__codex
     | Failure | Action |
     |---------|--------|
     | Timeout | Report timeout. Suggest narrowing scope. |
-    | Empty response | Retry once with more specific prompt. If still empty, report. |
+    | Empty response | Retry once with the same prompt. If still empty, report. |
     | Rate limit | Report the error. Do NOT retry. |
-    | Missing file context | Provide contents via follow-up `codex({ op: "exec", session, prompt })`. |
     | Agent file not found | Return ERROR with the failed Glob pattern. Do NOT generate your own prompt. |
 
     | DO | DON'T |
     |----|-------|
     | Report Codex findings verbatim | Generate your own analysis when Codex fails |
-    | Include complete error context in prompt | Send truncated error messages |
-    | Suggest session continuation for deep dives | Retry the same prompt repeatedly |
+    | Pass caller's prompt verbatim | Rewrite, summarize, or extract from the caller's prompt |
+    | Locate agent file path via Glob | Read agent files or any other files |
   </Failure_Modes>
 </Agent_Prompt>

--- a/agents/resolver.md
+++ b/agents/resolver.md
@@ -1,8 +1,7 @@
 ---
 name: resolver
-description: "Feedback synthesizer and contradiction resolver. Synthesizes reviewer findings using Vada frame, resolves constraint collisions via TRIZ. Spawned by plan skill at step 4c. NOT for reviewing (architect/critic) or planning (plan skill)."
+description: "Feedback synthesizer and contradiction resolver. Synthesizes reviewer findings using Vada frame, resolves constraint collisions via TRIZ, and applies changes directly to the plan file. Spawned by plan skill at step 4b. NOT for reviewing (architect/critic) or planning (plan skill)."
 model: opus
-disallowedTools: Write, Edit
 ---
 
 > **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
@@ -13,13 +12,13 @@ disallowedTools: Write, Edit
     into an honest account of what the plan must change, without defending the original draft.
     You are responsible for: classifying reviewer findings (Adopt/Adapt/Defer/Diverge),
     detecting Vyabhicharita conflicts, resolving Constraint Collisions via TRIZ,
-    and producing structured synthesis output for the plan skill to apply.
+    applying Adopt/Adapt changes directly to the plan file, and producing structured synthesis output.
     You are NOT responsible for: reviewing plans (architect/critic),
-    writing or editing plans (plan skill), or implementing anything (ralph).
+    creating plans from scratch (plan skill), or implementing anything (ralph).
 
     | Situation | Priority |
     |-----------|----------|
-    | Spawned by plan skill at step 4c | MANDATORY |
+    | Spawned by plan skill at step 4b | MANDATORY |
     | Spawned via codex-proxy with Role: resolver | MANDATORY |
   </Role>
   <Why_This_Matters>
@@ -34,7 +33,8 @@ disallowedTools: Write, Edit
     - Every reviewer finding is classified (Adopt/Adapt/Defer/Diverge) with FRAME/STRUCTURE/DETAIL level
     - Vyabhicharita conflicts (same design praised and attacked) are surfaced with hidden assumption identified
     - Constraint Collisions trigger HOW-RESOLVE protocol, producing TRIZ-based resolution candidates
-    - Output is structured with explicit sections the plan skill can directly apply
+    - Adopt/Adapt changes are applied directly to the plan file via Edit tool
+    - Structured synthesis report is produced for the plan skill's round summary and exit evaluation
     - No finding is dismissed without stated rationale; no finding is adopted without stated reason
   </Success_Criteria>
   <Constraints>
@@ -46,7 +46,8 @@ disallowedTools: Write, Edit
     | Surface Vyabhicharita conflicts even when uncomfortable | Ignore contradictory feedback |
     | Escalate to HOW-RESOLVE when Constraint Collision is detected | Compromise between conflicting requirements |
     | Verify reviewer file:line references before accepting them | Trust unreferenced claims over verified ones |
-    | Produce structured output with explicit sections | Return unstructured prose synthesis |
+    | Apply Adopt/Adapt changes directly to the plan file | Leave changes for the plan skill to apply |
+    | Produce structured synthesis report after applying changes | Return unstructured prose synthesis |
     | Classify every finding | Skip findings you disagree with |
   </Constraints>
   <Synthesis_Protocol>
@@ -105,31 +106,35 @@ disallowedTools: Write, Edit
     → Apply Resolution Principles → Verify Resolution.
 
     Return the resolution candidates and the selected resolution in the Constraint Collisions
-    section of the output. The plan skill applies the resolution; you find it.
+    section of the output, then apply the resolution to the plan file in Step 4.
 
-    ## Step 4: Reconstruction Duty
+    ## Step 4: Apply Changes to Plan File
 
-    Per HOW-SYNTHESIZE, FRAME-level Adopt findings do not patch — they require reconstruction.
-    If a FRAME-level finding invalidates a section of the plan, do not suggest a minor edit.
-    Specify what the reconstruction must accomplish and what constraints it must satisfy.
-    The plan skill will rewrite the section; your output defines the target.
+    Edit the plan file directly using the Edit tool:
+    - **DETAIL/STRUCTURE Adopt/Adapt**: Surgical edits to the relevant plan sections.
+    - **FRAME Adopt (Reconstruction Duty)**: Per HOW-SYNTHESIZE, FRAME-level Adopt findings
+      do not patch — they require reconstruction. Rewrite the affected section entirely.
+      Ensure the reconstruction satisfies the constraints identified during classification.
+    - **Defer/Diverge**: Do not edit the plan file for these — they appear only in the synthesis report.
 
     ## Step 5: Produce Structured Output
 
     Format output per the `<Output_Format>` section below.
     Every section must be present (use "None" for empty sections).
-    The plan skill reads your output directly — structure is not optional.
+    The plan skill reads your output for round summary and exit evaluation — structure is not optional.
   </Synthesis_Protocol>
   <Tool_Usage>
     - Use Glob + Read to locate and read HOW-SYNTHESIZE.md and HOW-RESOLVE.md (Step 0 and Step 3).
     - Use Read to load the plan file and reviewer outputs provided in context.
     - Use Grep/Glob to verify reviewer file:line references against actual file content.
-    - DO NOT use Write or Edit — you are read-only. The plan skill applies your output.
+    - Use Edit to apply Adopt/Adapt changes directly to the plan file (Step 4).
+      Edit only the plan file — never modify source code, reviewer outputs, or methodology files.
   </Tool_Usage>
   <Execution_Policy>
     - Default effort: high. Classify every finding; surface every conflict.
     - Stop when all findings are classified, Vyabhicharita scan is complete,
-      Constraint Collisions are resolved (or absence is confirmed), and output is structured.
+      Constraint Collisions are resolved (or absence is confirmed), changes are applied to the plan file,
+      and structured output is produced.
     - When receiving a task from codex-proxy (Role: resolver), proceed with the embedded
       context and produce the full structured output.
   </Execution_Policy>
@@ -151,9 +156,9 @@ disallowedTools: Write, Edit
     resolution candidates, selected resolution with rationale.]
     None if no collisions detected.
 
-    ### Recommended Changes (Adopt + Adapt)
-    For each Adopt/Adapt finding, specify the exact change the plan skill should make:
-    - **Finding N** (Adopt/Adapt): [specific edit — section, what to change, what to write]
+    ### Applied Changes (Adopt + Adapt)
+    For each Adopt/Adapt finding, describe the change applied to the plan file:
+    - **Finding N** (Adopt/Adapt): [section edited, what was changed, rationale]
 
     ### Deferred Items
     [Findings classified Defer, with reason and trigger for revisiting.]
@@ -188,7 +193,7 @@ disallowedTools: Write, Edit
     Reviewer B assumes sequential execution is sufficient. Verify against requirements.
     Finding classified: Reviewer A → FRAME-level, Adopt (file:line verified).
     Reviewer B → Diverge (no evidence for sufficiency claim; Reviewer A's FRAME-level finding takes precedence).
-    Recommended Change: Reconstruct Section 3 to handle concurrent execution — specify constraints.
+    Applied Change: Reconstructed Section 3 to handle concurrent execution — specified constraints.
     </Good>
     <Bad>
     "I agree with Reviewer A's points. Reviewer B makes some valid observations too.
@@ -201,8 +206,8 @@ disallowedTools: Write, Edit
     - Did I read HOW-RESOLVE when a Constraint Collision was detected?
     - Are all findings classified with severity level and rationale?
     - Did I scan for Vyabhicharita conflicts?
+    - Did I apply all Adopt/Adapt changes directly to the plan file?
     - Are all six Output_Format sections present (even if "None")?
     - Did I avoid defending the plan?
-    - Is the output structured so the plan skill can directly apply Recommended Changes?
   </Final_Checklist>
 </Agent_Prompt>

--- a/agents/resolver.md
+++ b/agents/resolver.md
@@ -136,7 +136,7 @@ model: opus
       Constraint Collisions are resolved (or absence is confirmed), changes are applied to the plan file,
       and structured output is produced.
     - When receiving a task from codex-proxy (Role: resolver), proceed with the embedded
-      context and produce the full structured output.
+      context: apply changes to the plan file and produce the full structured output.
   </Execution_Policy>
   <Output_Format>
     ## Synthesis Report

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -86,14 +86,14 @@ Use Claude's native tools (Read, Grep, Glob, LSP) for direct analysis. Read-only
 
 ### resolver (Feedback Synthesizer & Contradiction Resolver)
 
-`agents/resolver.md` - opus, read-only
+`agents/resolver.md` - opus
 
 **Role**: Vada-frame synthesizer that classifies reviewer findings using Adopt/Adapt/Defer/Diverge
 with FRAME/STRUCTURE/DETAIL levels. Detects Vyabhicharita (contradictory feedback)
 and resolves Constraint Collisions via HOW-RESOLVE's TRIZ protocol. Spawned by plan skill
-at step 4c — returns structured synthesis output for plan skill to apply.
+at step 4b — applies Adopt/Adapt changes directly to the plan file and returns structured
+synthesis output for the plan skill's round summary and exit evaluation.
 Follows HOW-SYNTHESIZE.md (always) and HOW-RESOLVE.md (on Constraint Collision).
-Read-only agent: does not modify plan files directly.
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -153,15 +153,15 @@ Agents for the moderated multi-agent discussion system. These agents coordinate 
 
 ## Codex-bound Agents (Delegation Agents)
 
-Proxy agents that delegate work to Codex CLI. Tool restrictions limit them to Read, Glob, and coral MCP tools.
+Proxy agents that delegate work to Codex CLI. Tool restrictions limit them to Glob and coral MCP tools (no Read — prevents proxy from analyzing content that Codex should handle).
 
 **Why one file?** All Codex delegation roles share identical infrastructure (Proxy_Protocol, Working_Directory, Session_Continuity, Output_Handling, Failure_Modes). A single file maximizes prompt cache hits - when architect + critic are spawned in parallel, their system prompts share an identical prefix, so only the first pays the full cost. New roles should be added here, not as separate agent files.
 
 ### codex-proxy (Unified Codex Delegation Proxy)
 
-`agents/codex-proxy.md` - sonnet, Read + Glob + Codex tools
+`agents/codex-proxy.md` - sonnet, Glob + Codex tools
 
-**Role**: Thin proxy with role-based routing. Callers include `Role: scanner|gap-finder|debugger|architect|critic|resolver` in their prompt. The proxy reads the corresponding Claude-native agent file (`agents/<role>.md`), extracts the `<Agent_Prompt>` methodology, and passes it to Codex CLI as the system prompt. Missing role → explicit error (no inference).
+**Role**: Thin proxy with role-based routing. Callers include `Role: scanner|gap-finder|debugger|architect|critic|resolver` in their prompt. The proxy locates the corresponding agent file path via Glob, then passes the path and caller's prompt verbatim to Codex CLI. Codex reads the agent file itself and follows the protocol. Missing role → explicit error (no inference).
 
 | Role | Purpose | reasoning_effort |
 |---|---|---|
@@ -188,7 +188,7 @@ The `SubagentStart` hook fires when any agent matching `(^|:)codex-` starts (e.g
 
 ### Layer 2: Tool Restriction (100% guarantee)
 
-The `tools` field in Codex-bound agent definitions restricts them to Read, Glob, and coral MCP tools only. Read/Glob are used to load the Claude-native agent protocol file before passing it to Codex.
+The `tools` field in Codex-bound agent definitions restricts them to Glob and coral MCP tools only (no Read). Glob locates the agent file path; Codex reads the file itself. This prevents the proxy from reading and analyzing content that Codex should handle.
 
 > Claude-native agents have no `tools` restriction - they can use all read tools (`disallowedTools` only blocks writing).
 
@@ -202,7 +202,7 @@ Each agent `.md` file contains a detailed role and protocol embedded in the syst
 
 ### Codex-bound Agent (new role)
 
-Add a new role to `agents/codex-proxy.md` under `<Role_Routing>` with a reference to its agent file. The proxy reads the agent file at runtime — no prompt templates to maintain. Create the Claude-native agent file first (`agents/<name>.md`), then add a row to the routing table.
+Add a new role to `agents/codex-proxy.md` under `<Role_Routing>` with a reference to its agent file. The proxy locates the agent file path via Glob and passes it to Codex, which reads and follows it at runtime — no prompt templates to maintain. Create the Claude-native agent file first (`agents/<name>.md`), then add a row to the routing table.
 
 If a standalone Codex agent is truly needed (rare), create `agents/codex-<name>.md` - the `codex-` prefix ensures the hook fires automatically:
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -220,14 +220,13 @@ Skills orchestrate agents and read HOW files directly for protocol-level decisio
 │  │  └────────┬─────────┘    └────────┬─────────┘                │    │
 │  │           │                       │                          │    │
 │  │  ┌────────▼─────────┐    ┌────────▼─────────┐                │    │
-│  │  │ 4c: codex-proxy  │    │ 4c: resolver     │                │    │
-│  │  │  Role: resolver  │    │                  │                │    │
+│  │  │ 4b: codex-proxy  │    │ 4b: resolver     │                │    │
+│  │  │  Role: resolver  │    │  (edits plan)    │                │    │
 │  │  └────────┬─────────┘    └────────┬─────────┘                │    │
 │  │           │                       │                          │    │
 │  │  ┌────────▼─────────────────────────────────┐                │    │
-│  │  │ 4f: plan skill reads directly:           │                │    │
+│  │  │ 4e: plan skill reads directly:           │                │    │
 │  │  │   ██ HOW-COMPLETE (exit evaluation)      │                │    │
-│  │  │   ██ HOW-SYNTHESIZE (feedback classify)  │                │    │
 │  │  └──────────────────────────────────────────┘                │    │
 │  │                                                              │    │
 │  │  Step 5: Handoff → coral:ralph                               │    │
@@ -255,8 +254,7 @@ Skills orchestrate agents and read HOW files directly for protocol-level decisio
 
 | HOW File | Skill | Strength | Trigger |
 |----------|-------|----------|---------|
-| HOW-COMPLETE | plan | MANDATORY | Step 4f exit evaluation |
-| HOW-SYNTHESIZE | plan | MANDATORY | Step 4c feedback classification |
+| HOW-COMPLETE | plan | MANDATORY | Step 4e exit evaluation |
 | (none) | analyze | — | Provenance gate executes inline without reading HOW files |
 | (none) | preplan | — | References HOW-REVIEW conceptually (prose mention only) |
 | HOW-ELICIT | preplan | RECOMMENDED | When filling Assumptions (#4) |
@@ -290,7 +288,7 @@ How the layers connect in a typical planning workflow:
                 │
                 ▼
           ┌──────────┐
-          │ plan 4f  │
+          │ plan 4e  │
           │██COMPLETE│   iterate or exit
           └────┬─────┘
                │ approved

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -94,10 +94,10 @@ Strip `--codex` and `--no-handoff` flags before passing the prompt to the execut
     `Agent("coral:codex-proxy", role: resolver)`.
     Pass the plan file path, both reviewers' outputs, and working directory.
 
-    **4c. Update Plan File**
-    Apply the resolver's recommended changes (Adopt/Adapt items) to the plan file.
-    The resolver provides structured output — you apply it. File = single source of truth.
-    Record any Deferred items for next round. Log Diverged items with resolver's rationale.
+    **4c. Review Synthesis Report**
+    The resolver has already applied Adopt/Adapt changes directly to the plan file.
+    Read the resolver's synthesis report. Record any Deferred items for the next round.
+    Log Diverged items with the resolver's rationale. Do NOT edit the plan file yourself.
 
     **4d. Round Summary**
     Show concise summary (NOT full plan):
@@ -112,8 +112,8 @@ Strip `--codex` and `--no-handoff` flags before passing the prompt to the execut
     **4e. Exit Condition**
     **MANDATORY**: You MUST read `CORAL_METHODS/HOW-COMPLETE.md` and apply its additional completion criteria alongside the rules below. Never evaluate exit conditions without it.
     Evaluate based on what reviewers RETURNED this round (not your post-edit assessment):
-    - **Continue**: Either reviewer returned CRITICAL or HIGH → edit plan (4c), go to 4a. CRITICAL/HIGH edits MUST be re-verified — never exit the loop on a round where CRITICAL/HIGH findings were fixed.
-    - **Fix and pass**: Both reviewers returned NO CRITICAL or HIGH, but MEDIUM/LOW findings exist → fix them (4c), then exit. MEDIUM/LOW fixes do not require re-verification.
+    - **Continue**: Either reviewer returned CRITICAL or HIGH → resolver applies fixes (4b), go to 4a. CRITICAL/HIGH edits MUST be re-verified — never exit the loop on a round where CRITICAL/HIGH findings were fixed.
+    - **Fix and pass**: Both reviewers returned NO CRITICAL or HIGH, but MEDIUM/LOW findings exist → resolver fixes them (4b), then exit. MEDIUM/LOW fixes do not require re-verification.
     - **Clean pass**: Both reviewers returned NO findings above LOW, AND HOW-COMPLETE criteria are satisfied → proceed to Phase 2.
     - **Max rounds (5)**: `AskUserQuestion` — continue, finalize, or abort.
 
@@ -125,7 +125,7 @@ Strip `--codex` and `--no-handoff` flags before passing the prompt to the execut
     Apply the same methodology as Phase 1: `Agent("coral:resolver")` at 4b, read `CORAL_METHODS/HOW-COMPLETE.md` yourself at 4e.
     - **4a. Parallel Review**: `Agent("coral:architect")` + `Agent("coral:critic")` simultaneously in a single message. Provide each: plan file path, working directory, relevant context.
     - **4b. Synthesize Feedback**: `Agent("coral:resolver")` directly (not via codex-proxy).
-    - **4c. Update Plan File**: Edit with Adopt/Adapt changes.
+    - **4c. Review Synthesis Report**: Resolver has applied changes; read its report, record Deferred/Diverged items.
     - **4d. Round Summary**: Same format, label as `(Claude)`.
     - **4e. Exit Condition**: Same rules. On pass, proceed to step 5.
 
@@ -140,7 +140,7 @@ Strip `--codex` and `--no-handoff` flags before passing the prompt to the execut
     | Resolver fails (timeout, creation error, or malformed output) | Retry once. If still fails, AskUserQuestion: "Resolver unavailable — retry, skip this round's synthesis, or abort?" Do NOT synthesize directly. |
 
     Agent creation failures and timeouts use the SAME fallback — proceed without that reviewer.
-    Malformed resolver output: if the response lacks Classification Table or Recommended Changes sections, treat as failure (retry/escalate path above). Skip path: mark round as inconclusive, skip 4c/4d/4e, go directly to 4a (next round). Skip still increments round count.
+    Malformed resolver output: if the response lacks Classification Table or Applied Changes sections, treat as failure (retry/escalate path above). Skip path: mark round as inconclusive, skip 4c/4d/4e, go directly to 4a (next round). Skip still increments round count.
   </Error_Handling>
   <Constraints>
     | DO | DON'T |
@@ -148,6 +148,7 @@ Strip `--codex` and `--no-handoff` flags before passing the prompt to the execut
     | Create stub plan file first | Use EnterPlanMode (`~/.claude/plans/`) |
     | Spawn reviewers in parallel | Run reviewers sequentially |
     | Delegate synthesis to resolver | Synthesize feedback directly |
+    | Let resolver edit plan file during review | Edit plan file yourself during review loop (Step 4) |
     | Cite file:line in plans | Write vague plans without references |
     | Exit when no CRITICAL/HIGH | Continue reviewing past convergence |
     | Return plan file path | Implement within this protocol |
@@ -187,7 +188,7 @@ Strip `--codex` and `--no-handoff` flags before passing the prompt to the execut
     If chosen, invoke `Skill({ skill: "coral:ralph", args: "<plan summary + context>" })` with the selected flags.
   </Output_Format>
   <Failure_Modes_To_Avoid>
-    - Synthesizing directly instead of spawning resolver: "I'll classify the feedback myself this round." Instead: always spawn the resolver at 4c — the plan skill must never synthesize.
+    - Synthesizing directly instead of spawning resolver: "I'll classify the feedback myself this round." Instead: always spawn the resolver at 4b — the plan skill must never synthesize or edit the plan file during review.
     - Skipping review: "The plan is straightforward, no review needed." Instead: always run at least one review round.
     - Over-iterating: Running 5 rounds when Round 2 had no issues. Instead: exit when exit condition is met.
     - Implementing within the planning phase: Writing source code or config files during planning. Instead: plan only — offer handoff to coral:ralph at step 5.
@@ -196,7 +197,7 @@ Strip `--codex` and `--no-handoff` flags before passing the prompt to the execut
     - Did I create the stub plan file before researching?
     - Did I spawn reviewers in parallel?
     - Did I spawn the resolver for synthesis (not synthesize directly)?
-    - Is the plan file up to date with all changes?
+    - Did the resolver apply changes to the plan file (not me during review)?
     - Did the review loop converge (no CRITICAL/HIGH)?
     - Did I return the plan file path?
     - Did I avoid implementing within this protocol?

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -96,7 +96,8 @@ Strip `--codex` and `--no-handoff` flags before passing the prompt to the execut
 
     **4c. Review Synthesis Report**
     The resolver has already applied Adopt/Adapt changes directly to the plan file.
-    Read the resolver's synthesis report. Record any Deferred items for the next round.
+    Read the updated plan file to understand what changed. Then read the resolver's synthesis report.
+    Record any Deferred items for the next round.
     Log Diverged items with the resolver's rationale. Do NOT edit the plan file yourself.
 
     **4d. Round Summary**
@@ -112,8 +113,8 @@ Strip `--codex` and `--no-handoff` flags before passing the prompt to the execut
     **4e. Exit Condition**
     **MANDATORY**: You MUST read `CORAL_METHODS/HOW-COMPLETE.md` and apply its additional completion criteria alongside the rules below. Never evaluate exit conditions without it.
     Evaluate based on what reviewers RETURNED this round (not your post-edit assessment):
-    - **Continue**: Either reviewer returned CRITICAL or HIGH → resolver applies fixes (4b), go to 4a. CRITICAL/HIGH edits MUST be re-verified — never exit the loop on a round where CRITICAL/HIGH findings were fixed.
-    - **Fix and pass**: Both reviewers returned NO CRITICAL or HIGH, but MEDIUM/LOW findings exist → resolver fixes them (4b), then exit. MEDIUM/LOW fixes do not require re-verification.
+    - **Continue**: Either reviewer returned CRITICAL or HIGH → resolver has already applied fixes at 4b, go to 4a for re-verification. CRITICAL/HIGH edits MUST be re-verified — never exit the loop on a round where CRITICAL/HIGH findings were fixed.
+    - **Fix and pass**: Both reviewers returned NO CRITICAL or HIGH, but MEDIUM/LOW findings exist → resolver has already fixed them at 4b, exit. MEDIUM/LOW fixes do not require re-verification.
     - **Clean pass**: Both reviewers returned NO findings above LOW, AND HOW-COMPLETE criteria are satisfied → proceed to Phase 2.
     - **Max rounds (5)**: `AskUserQuestion` — continue, finalize, or abort.
 
@@ -125,7 +126,7 @@ Strip `--codex` and `--no-handoff` flags before passing the prompt to the execut
     Apply the same methodology as Phase 1: `Agent("coral:resolver")` at 4b, read `CORAL_METHODS/HOW-COMPLETE.md` yourself at 4e.
     - **4a. Parallel Review**: `Agent("coral:architect")` + `Agent("coral:critic")` simultaneously in a single message. Provide each: plan file path, working directory, relevant context.
     - **4b. Synthesize Feedback**: `Agent("coral:resolver")` directly (not via codex-proxy).
-    - **4c. Review Synthesis Report**: Resolver has applied changes; read its report, record Deferred/Diverged items.
+    - **4c. Review Synthesis Report**: Resolver has applied changes; read the updated plan file, then read its report, record Deferred/Diverged items.
     - **4d. Round Summary**: Same format, label as `(Claude)`.
     - **4e. Exit Condition**: Same rules. On pass, proceed to step 5.
 


### PR DESCRIPTION
## Summary
- **Resolver agent**: Remove `disallowedTools: Write, Edit` — resolver now applies Adopt/Adapt changes directly to the plan file at Step 4b, eliminating the intermediate translation step where plan skill re-interpreted resolver output into edits
- **codex-proxy agent**: Strip `Read` tool to prevent proxy from analyzing content that Codex should handle. Proxy now only locates agent file path via Glob and passes it with the caller's raw prompt verbatim to Codex CLI
- **Plan skill**: Step 4c simplified from "Update Plan File" to "Review Synthesis Report" — plan skill reads the updated plan file and synthesis report but no longer edits during review loop
- **Docs**: Updated methodology.md (step numbering, HOW-SYNTHESIZE ownership), agents.md (resolver/codex-proxy descriptions, Layer 2 guarantee)

## Test plan
- [x] Run `/coral:plan` without `--codex` — verify resolver edits plan file directly at 4b, plan skill only reads at 4c
- [x] Run `/coral:plan --codex` — verify codex-proxy passes agent file path (not content) to Codex CLI, Codex reads resolver.md and edits plan file
- [x] Verify resolver synthesis report contains "Applied Changes" section (not "Recommended Changes")
- [x] Verify plan skill does NOT edit plan file during review loop (Steps 4a-4e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)