### PR TITLE
refactor: plan skill refinements, resolver scope, Glob pattern fix

### DIFF
--- a/.claude/rules/plugin-extension.md
+++ b/.claude/rules/plugin-extension.md
@@ -33,9 +33,9 @@ plugin files from project files. Three read patterns and one spawn pattern exist
 
 - Every file using these aliases must define them at the top (after frontmatter):
   ```
-  > **CORAL_AGENTS**: `~/.claude/plugins/cache/coral/**/agents/` — locate via Glob
-  > **CORAL_SKILLS**: `~/.claude/plugins/cache/coral/**/skills/` — locate via Glob
-  > **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+  > **CORAL_AGENTS**: `Glob(pattern: "**/agents/", path: "~/.claude/plugins/cache/coral/")`
+  > **CORAL_SKILLS**: `Glob(pattern: "**/skills/", path: "~/.claude/plugins/cache/coral/")`
+  > **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
   ```
 - Never use bare `agents/xxx.md`, `skills/xxx/`, or `methods/xxx.md` — these resolve relative
   to the user's project directory, which breaks when the plugin is used outside its own repo.

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -5,7 +5,7 @@ model: opus
 disallowedTools: Write, Edit
 ---
 
-> **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+> **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
 
 <Agent_Prompt>
   <Role>

--- a/agents/codex-proxy.md
+++ b/agents/codex-proxy.md
@@ -5,7 +5,7 @@ description: "Codex delegation proxy for scanner/gap-finder/debugger/architect/c
 tools: Glob, mcp__plugin_coral_cx__codex
 ---
 
-> **CORAL_AGENTS**: `~/.claude/plugins/cache/coral/**/agents/` — locate via Glob
+> **CORAL_AGENTS**: `Glob(pattern: "**/agents/", path: "~/.claude/plugins/cache/coral/")`
 
 <Agent_Prompt>
   <Proxy_Protocol>

--- a/agents/critic.md
+++ b/agents/critic.md
@@ -5,7 +5,7 @@ model: opus
 disallowedTools: Write, Edit
 ---
 
-> **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+> **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
 
 <Agent_Prompt>
   <Role>

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -5,7 +5,7 @@ model: opus
 disallowedTools: Write, Edit
 ---
 
-> **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+> **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
 
 <Agent_Prompt>
   <Role>

--- a/agents/gap-finder.md
+++ b/agents/gap-finder.md
@@ -5,7 +5,7 @@ model: opus
 disallowedTools: Write, Edit
 ---
 
-> **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+> **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
 
 <Agent_Prompt>
   <Role>

--- a/agents/resolver.md
+++ b/agents/resolver.md
@@ -15,6 +15,7 @@ model: opus
     applying Adopt/Adapt changes directly to the plan file, and producing structured synthesis output.
     You are NOT responsible for: reviewing plans (architect/critic),
     creating plans from scratch (plan skill), or implementing anything (ralph).
+    Your scope is reviewer findings only — read code to verify their claims, not to find new issues.
 
     | Situation | Priority |
     |-----------|----------|
@@ -49,6 +50,7 @@ model: opus
     | Apply Adopt/Adapt changes directly to the plan file | Leave changes for the plan skill to apply |
     | Produce structured synthesis report after applying changes | Return unstructured prose synthesis |
     | Classify every finding | Skip findings you disagree with |
+    | Scope analysis to reviewer findings — read code only to verify their claims | Perform independent analysis or raise new issues beyond what reviewers found |
   </Constraints>
   <Synthesis_Protocol>
     ## Step 0: Read HOW-SYNTHESIZE (MANDATORY)

--- a/agents/resolver.md
+++ b/agents/resolver.md
@@ -4,7 +4,7 @@ description: "Feedback synthesizer and contradiction resolver. Synthesizes revie
 model: opus
 ---
 
-> **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+> **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
 
 <Agent_Prompt>
   <Role>

--- a/agents/scanner.md
+++ b/agents/scanner.md
@@ -5,7 +5,7 @@ model: opus
 disallowedTools: Write, Edit
 ---
 
-> **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+> **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
 
 <Agent_Prompt>
   <Role>

--- a/methods/HOW-CONFIDENCE.md
+++ b/methods/HOW-CONFIDENCE.md
@@ -1,6 +1,6 @@
 # HOW to Grade Evidence Confidence
 
-> **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+> **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
 
 A conclusion without calibrated confidence is bluster; excessive uncertainty is paralysis.
 From GRADE (Grading of Recommendations Assessment, Development, and Evaluation):

--- a/methods/HOW-PROVENANCE.md
+++ b/methods/HOW-PROVENANCE.md
@@ -1,6 +1,6 @@
 # HOW to Verify Evidence Provenance
 
-> **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+> **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
 
 A citation is a delegation of trust. An unverified citation dresses hallucination in the robes of authority.
 In the LLM context this is especially dangerous — nonexistent files, wrong line numbers, and

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: "Deep analysis - project scanning, requirement gaps, root cause inv
 argument-hint: "[--codex] [investigation target or question]"
 ---
 
-> **CORAL_AGENTS**: `~/.claude/plugins/cache/coral/**/agents/` — locate via Glob
+> **CORAL_AGENTS**: `Glob(pattern: "**/agents/", path: "~/.claude/plugins/cache/coral/")`
 
 # Deep Analysis & Investigation
 

--- a/skills/bugfix/SKILL.md
+++ b/skills/bugfix/SKILL.md
@@ -4,7 +4,7 @@ description: "Systematic bug diagnosis, planning, and fix execution."
 argument-hint: "[--codex] <bug description or error message>"
 ---
 
-> **CORAL_AGENTS**: `~/.claude/plugins/cache/coral/**/agents/` — locate via Glob
+> **CORAL_AGENTS**: `Glob(pattern: "**/agents/", path: "~/.claude/plugins/cache/coral/")`
 
 # Bug Debugging
 

--- a/skills/code-simplify/SKILL.md
+++ b/skills/code-simplify/SKILL.md
@@ -4,7 +4,7 @@ description: "Simplifies and refines code for clarity, consistency, and maintain
 argument-hint: "[--codex] <scope or prompt>"
 ---
 
-> **CORAL_AGENTS**: `~/.claude/plugins/cache/coral/**/agents/` — locate via Glob
+> **CORAL_AGENTS**: `Glob(pattern: "**/agents/", path: "~/.claude/plugins/cache/coral/")`
 
 # Code Simplification
 

--- a/skills/discuss/SKILL.md
+++ b/skills/discuss/SKILL.md
@@ -4,7 +4,7 @@ description: Moderated multi-agent discussion via Agent Teams
 argument-hint: "[--user] [topic] [--hints axis1:pos1,pos2 axis2:pos1,pos2]"
 ---
 
-> **CORAL_AGENTS**: `~/.claude/plugins/cache/coral/**/agents/` — locate via Glob
+> **CORAL_AGENTS**: `Glob(pattern: "**/agents/", path: "~/.claude/plugins/cache/coral/")`
 
 # Moderated Multi-Agent Discussion
 

--- a/skills/init-project/SKILL.md
+++ b/skills/init-project/SKILL.md
@@ -4,7 +4,7 @@ description: Initialize project for AI-assisted development with rules, agents, 
 argument-hint: "[existing|new]"
 ---
 
-> **CORAL_SKILLS**: `~/.claude/plugins/cache/coral/**/skills/` — locate via Glob
+> **CORAL_SKILLS**: `Glob(pattern: "**/skills/", path: "~/.claude/plugins/cache/coral/")`
 
 # Project Initialization
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -93,8 +93,8 @@ Strip `--codex`, `--fast`, and `--no-handoff` flags before passing the prompt to
 
     **4b. Synthesize Feedback**
 
-    **If `--fast`**: Synthesize directly — classify each finding as Adopt/Adapt/Defer/Diverge,
-    edit the plan file yourself with Adopt/Adapt changes, then go to 4d (skip 4c).
+    **If `--fast`**: Synthesize directly — classify each finding as Adopt (take as-is) / Adapt (take insight, own solution) / Defer (next round) / Diverge (reject with rationale).
+    Reviewers can be wrong — verify against actual code. When reviewers contradict each other, neither is right; find the hidden assumption. Edit the plan file yourself, then go to 4d (skip 4c).
 
     **Otherwise**: `Agent("coral:codex-proxy", role: resolver)`.
     Pass the plan file path, both reviewers' outputs, and working directory.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -4,7 +4,7 @@ description: "Planning with parallel architect/critic review. Pass --codex for c
 argument-hint: "[--fast] [--codex] [task description]"
 ---
 
-> **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+> **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
 
 # Planning
 

--- a/skills/preplan/SKILL.md
+++ b/skills/preplan/SKILL.md
@@ -4,7 +4,7 @@ description: "Structured problem-definition conversation before planning. Aligns
 argument-hint: "<issue or topic>"
 ---
 
-> **CORAL_METHODS**: `~/.claude/plugins/cache/coral/**/methods/` — locate via Glob
+> **CORAL_METHODS**: `Glob(pattern: "**/methods/", path: "~/.claude/plugins/cache/coral/")`
 
 # Pre-plan
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -5,7 +5,7 @@ argument-hint: "[--red] [--codex] [task description]"
 model: sonnet
 ---
 
-> **CORAL_AGENTS**: `~/.claude/plugins/cache/coral/**/agents/` — locate via Glob
+> **CORAL_AGENTS**: `Glob(pattern: "**/agents/", path: "~/.claude/plugins/cache/coral/")`
 
 # Persistent Execution with Verification
 


### PR DESCRIPTION
## Summary
- **`--fast` flag**: Add `--fast` to plan skill — skips resolver, synthesizes directly with lightweight HOW-SYNTHESIZE guidance
- **Resolver scope**: Constrain resolver to evaluate reviewer findings only — no independent analysis
- **Round summary**: Format as tables (reviewer table + synthesis classification table)
- **Phase exit**: Move max-rounds `AskUserQuestion` to Phase 2 only; Phase 1 proceeds to Phase 2
- **Glob fix**: Change all 18 CORAL_AGENTS/METHODS/SKILLS aliases from pattern-only format to `Glob(pattern, path)` — `~` doesn't expand in pattern, only in path
- **README cleanup**: Remove `ENABLE_TOOL_SEARCH` and `CORAL_DISCUSS_BID_THRESHOLD` from configuration docs
- **Fresh resolver spawn**: Enforce no session continuity per round to prevent author bias

## Test plan
- [x] `Glob(pattern: "**/agents/", path: "~/.claude/plugins/cache/coral/")` resolves correctly
- [x] `/coral:plan --fast <task>` skips resolver, synthesizes directly with Adopt/Adapt/Defer/Diverge
- [x] `/coral:plan <task>` resolver stays scoped to reviewer findings (no independent analysis)
- [x] Round summary renders as two tables
- [x] Phase 1 max rounds → proceeds to Phase 2 without asking user
- [x] Phase 2 max rounds → `AskUserQuestion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)