### PR TITLE
fix: TeammateIdle hook not firing for discuss agents

### DIFF
--- a/hooks/discuss-idle-guard.mjs
+++ b/hooks/discuss-idle-guard.mjs
@@ -2,7 +2,7 @@
 
 /**
  * TeammateIdle hook — blocks idle when a discuss agent has a pending action.
- * Checks session state for pending bids, speeches, or votes.
+ * Checks session state for pending bids or speeches.
  * Fail-open: any error exits silently (allow idle).
  */
 
@@ -29,7 +29,7 @@ try {
   const sessionId = teamName.slice('coral-dc-'.length);
 
   // Resolve session directory
-  const sessionDir = readdirSync(discussDir).find(d => d.startsWith(`${sessionId}_`) || d.startsWith(`${sessionId}-`));
+  const sessionDir = readdirSync(discussDir).find(d => d.startsWith(`${sessionId}-`));
   if (!sessionDir) process.exit(0);
 
   const statePath = join(discussDir, sessionDir, 'state.json');
@@ -47,12 +47,6 @@ try {
   // Speaking: agent has the floor
   if (status === 'speaking' && current_speaker === agentName) {
     process.stderr.write('Call `discuss` with op: "speak" to deliver your speech.\n');
-    process.exit(2);
-  }
-
-  // Voting: agent hasn't voted yet
-  if (status === 'voting' && pending_bidders.includes(agentName)) {
-    process.stderr.write('Termination vote: call `discuss` with op: "bid" - 0=agree to end, 1=disagree.\n');
     process.exit(2);
   }
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -91,7 +91,6 @@
     ],
     "TeammateIdle": [
       {
-        "matcher": "dc-*",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Remove `"matcher": "dc-*"` from TeammateIdle hook in `hooks.json` — TeammateIdle does not support matchers, so the hook was silently ignored
- Remove dead `voting` status branch from `discuss-idle-guard.mjs` (state machine only has `setup | bidding | speaking | ended`)
- Remove unnecessary `_` prefix matching in session directory lookup (server always uses `-`)

## Root Cause
After a discuss agent delivered a speech and its LLM turn ended, it went idle. The `discuss-idle-guard.mjs` TeammateIdle hook should have blocked the idle (exit 2) and prompted the agent to bid. But the `"matcher": "dc-*"` in `hooks.json` prevented the hook from registering — TeammateIdle hooks do not support matchers and fire on every occurrence. The agent stayed idle, never bid, got expelled, and the session cascaded to failure.

## Test plan
- [x] Spawned test teammate with fake discuss session state — hook fired and blocked idle
- [x] Run a full discuss session after Claude restart to verify end-to-end fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)