### PR TITLE
refactor: show full document at approval gates in preplan and plan skills

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -196,8 +196,9 @@ Strip `--codex`, `--deep`, and `--no-handoff` flags before passing the prompt to
     - Final verdict: [APPROVED / APPROVED WITH CONDITIONS]
     - Key changes from review: [brief list]
 
-    ### Plan Overview
-    [2-3 sentence summary of the plan]
+    ### Final Plan
+    Read the plan file and display its full content to the user
+    (render the complete `.claude/coral/plans/{name}.md` — not a summary or excerpt).
 
     ### Implementation Handoff
 

--- a/skills/preplan/SKILL.md
+++ b/skills/preplan/SKILL.md
@@ -105,7 +105,8 @@ Structured problem-definition conversation with the user before planning begins.
     ### 4. Transition Proposal
 
     When all required items are free of "unconfirmed" markers:
-    - Present final agreement summary
+    - Read the agreement file and display its full content to the user
+      (render the complete `.claude/coral/plans/pre-{topic}.md` — not a summary or excerpt)
     - Ask via AskUserQuestion:
       - question: "Proceed to coral:plan?"
       - options: "Proceed (Recommended)", "Proceed --deep", "Proceed --codex", "Proceed --deep --codex"


### PR DESCRIPTION
## Summary
- **preplan**: When all required items are confirmed, display the full agreement file content (not a summary) before asking the user to proceed to plan
- **plan**: At completion, display the full plan file content (not a 2-3 sentence summary) before the implementation handoff

Both changes ensure users see the complete document they're approving at each phase gate.

## Test plan
- [x] Run preplan skill, confirm all items → verify full agreement file is rendered
- [x] Run plan skill to completion → verify full plan file is rendered before handoff prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)