### PR TITLE
Fix CORAL_DISCUSS_TTL_DAYS default to 0 (disabled)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -189,7 +189,7 @@ Claude가 놓치기 쉬운 것을 발견하면 (근본 원인, 주의사항, 기
 |------|--------|------|
 | `CORAL_CODEX_MODEL` | `gpt-5.3-codex` | Codex CLI 기본 모델 |
 | `CORAL_DISCUSS_MAX_EPOCHS` | `2` | 토론 자동 종료 전 최대 에포크 (1–10) |
-| `CORAL_DISCUSS_TTL_DAYS` | `30` | 완료된 토론 세션 자동 정리 기한 (일) |
+| `CORAL_DISCUSS_TTL_DAYS` | `0` | 완료된 토론 세션 자동 정리 기한 (일, 0 = 비활성화) |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | _(미설정)_ | `/coral:discuss` **필수**. `1`로 설정. |
 `.claude/settings.json`에 설정 (세션 간 유지):
 
@@ -198,7 +198,7 @@ Claude가 놓치기 쉬운 것을 발견하면 (근본 원인, 주의사항, 기
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CORAL_DISCUSS_MAX_EPOCHS": "2",
-    "CORAL_DISCUSS_TTL_DAYS": "30"
+    "CORAL_DISCUSS_TTL_DAYS": "0"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Mistakes aren't repeated across sessions.
 |---|---|---|
 | `CORAL_CODEX_MODEL` | `gpt-5.3-codex` | Default Codex CLI model |
 | `CORAL_DISCUSS_MAX_EPOCHS` | `2` | Max epochs before discussion auto-ends (1–10) |
-| `CORAL_DISCUSS_TTL_DAYS` | `30` | Days before completed discuss sessions are auto-pruned |
+| `CORAL_DISCUSS_TTL_DAYS` | `0` | Days before completed discuss sessions are auto-pruned (0 = disabled) |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | _(unset)_ | **Required** for `/coral:discuss`. Set to `1`. |
 Set in `.claude/settings.json` (persists across sessions):
 
@@ -204,7 +204,7 @@ Set in `.claude/settings.json` (persists across sessions):
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CORAL_DISCUSS_MAX_EPOCHS": "2",
-    "CORAL_DISCUSS_TTL_DAYS": "30"
+    "CORAL_DISCUSS_TTL_DAYS": "0"
   }
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Environment variables, config files, and the plugin manifest.
 | `CORAL_DISCUSS_BID_THRESHOLD` | `30` | Minimum bid score (1–100) for floor eligibility. Stored per-session at creation time. |
 | `CORAL_DISCUSS_MAX_EPOCHS` | `2` | Maximum epochs before discussion ends automatically (1–10). Stored per-session at creation time. |
 | `CORAL_DISCUSS_QUOTA_PER_EPOCH` | `3` | Speaking turns per agent per epoch (1–10). Stored per-session at creation time. |
-| `CORAL_DISCUSS_TTL_DAYS` | `30` | Days before completed discuss sessions are eligible for pruning |
+| `CORAL_DISCUSS_TTL_DAYS` | `0` | Days before completed discuss sessions are eligible for pruning (0 = disabled) |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | _(unset)_ | Required for `/coral:discuss`. Set to `1`. |
 
 ### Usage - Shell

--- a/src/discuss/__tests__/session-store.test.ts
+++ b/src/discuss/__tests__/session-store.test.ts
@@ -183,6 +183,9 @@ describe('save and load', () => {
 
 
 describe('cleanupExpiredSessions', () => {
+  beforeEach(() => { process.env.CORAL_DISCUSS_TTL_DAYS = '30'; });
+  afterEach(() => { delete process.env.CORAL_DISCUSS_TTL_DAYS; });
+
   function saveSessionWithStatus(topic: string, status: string, lastActivity: Date) {
     const { sessionId, fullPath } = store.createSessionDir(topic);
     const state = initSession({ topic, agents: AGENTS, min_bid_delay_ms: 0 }, new Date().toISOString());
@@ -217,6 +220,15 @@ describe('cleanupExpiredSessions', () => {
 
   it('should return 0 when no sessions exist', () => {
     expect(store.cleanupExpiredSessions()).toBe(0);
+  });
+
+  it('should skip cleanup when TTL is 0 (disabled)', () => {
+    process.env.CORAL_DISCUSS_TTL_DAYS = '0';
+    const old = daysAgo(365);
+    const { fullPath } = saveSessionWithStatus('Ancient Topic', 'ended', old);
+    const removed = store.cleanupExpiredSessions();
+    expect(removed).toBe(0);
+    expect(existsSync(fullPath)).toBe(true);
   });
 });
 

--- a/src/discuss/session-store.ts
+++ b/src/discuss/session-store.ts
@@ -97,8 +97,9 @@ export class SessionStore {
   }
 
   cleanupExpiredSessions(): number {
-    const ttlDays = Number.parseInt(process.env.CORAL_DISCUSS_TTL_DAYS ?? '', 10);
-    const ttl = Number.isFinite(ttlDays) && ttlDays > 0 ? ttlDays : 30;
+    const ttlDays = Number.parseInt(process.env.CORAL_DISCUSS_TTL_DAYS ?? '0', 10);
+    const ttl = Number.isFinite(ttlDays) && ttlDays > 0 ? ttlDays : 0;
+    if (ttl === 0) return 0;
     const cutoff = Date.now() - ttl * 24 * 60 * 60 * 1000;
     let removed = 0;
 


### PR DESCRIPTION
## Summary
- Default `CORAL_DISCUSS_TTL_DAYS` from `30` to `0` (auto-pruning disabled by default)
- Guard `0` and negative values as "disabled" instead of falling back to 30 days
- Add test for TTL=0 disabling cleanup on year-old sessions
- Update docs (README, README.ko, configuration.md)

## Test plan
- [x] `npm test` — 1133 passed (32 session-store tests including new TTL=0 case)
- [x] `npm run build` — clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)