### PR TITLE
fix: plugin.json hooks error, gitattributes, ralph task registration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,6 +19,5 @@
     "bridge"
   ],
   "skills": "./skills/",
-  "hooks": "./hooks/hooks.json",
   "mcpServers": "./.mcp.json"
 }

--- a/.claude/coral/kb/hooks-plugin-install-required.md
+++ b/.claude/coral/kb/hooks-plugin-install-required.md
@@ -1,33 +1,35 @@
-# Plugin Hook Registration — Install vs plugin-dir Mode
+# Plugin Hook Registration — hooks.json Only, Not plugin.json
 
 ## Rule
-For hooks to work in `--plugin-dir ./` development mode, `plugin.json` must explicitly declare `"hooks": "./hooks/hooks.json"`. Without this declaration, some hooks (e.g., SessionStart) may work by coincidence or not fire at all. Manually copying to the cache directory also does not register new hook events — a proper install is required.
+Plugin hooks are registered via `hooks/hooks.json` in the plugin directory. Do NOT add a `"hooks"` field to `plugin.json` — this causes `PreToolUse hook error` on every tool call in installed plugin mode. The Claude Code plugin system discovers `hooks/hooks.json` automatically from the plugin directory structure.
+
+For `--plugin-dir ./` development mode, hooks from `hooks/hooks.json` may not register for all events. Use `.claude/settings.local.json` to register hooks directly during development testing.
 
 ## Why
-Without the `"hooks"` field in `plugin.json`, hooks.json is ignored in `--plugin-dir` mode. You end up debugging code and hook logic while missing the root cause entirely.
+Adding `"hooks": "./hooks/hooks.json"` to `plugin.json` was attempted to fix `--plugin-dir` hook registration. It appeared to work in dev mode but caused `PreToolUse:Read hook error` (and similar) on every tool call when the plugin is installed normally. The `plugin.json` `hooks` field is not a supported plugin manifest key.
 
 ## Pattern
 ```json
-// WRONG: no hooks declaration in plugin.json — PreToolUse etc. not registered in --plugin-dir mode
-{
-  "skills": "./skills/",
-  "mcpServers": "./.mcp.json"
-}
-
-// RIGHT: hooks field explicitly declared
+// WRONG: hooks field in plugin.json — causes hook errors in installed mode
 {
   "skills": "./skills/",
   "hooks": "./hooks/hooks.json",
   "mcpServers": "./.mcp.json"
 }
+
+// RIGHT: hooks.json lives in hooks/ directory, discovered automatically
+// plugin.json has NO hooks field
+{
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}
 ```
 
-For quick hook logic verification during development, you can register hooks directly in `.claude/settings.local.json`:
+For dev-mode hook testing, use `.claude/settings.local.json` (gitignored):
 ```json
 {
   "hooks": {
-    "PreToolUse": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "node ...", "timeout": 5 }] }]
+    "PreToolUse": [{ "matcher": "Skill", "hooks": [{ "type": "command", "command": "node hooks/kb-promote-reminder.mjs", "timeout": 5 }] }]
   }
 }
 ```
-Note: this file is gitignored, so final registration must go through `plugin.json` + `hooks/hooks.json`.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 bridge/coral-ax.cjs -diff linguist-generated=true
+bridge/coral-backend.cjs -diff linguist-generated=true
+bridge/coral-discuss.cjs -diff linguist-generated=true

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -50,6 +50,8 @@ Strip `--codex` and `--red` flags before passing the prompt to the execution pat
   </Constraints>
   <Protocol>
     1) Review task requirements and any existing progress.
+       If a plan file exists with `## Acceptance Criteria`, register each criterion as a Task.
+       Track completion status throughout execution — update each Task as it's verified.
     2) Break work into concrete steps with acceptance criteria.
     3) Execute steps, delegating to specialist agents where appropriate.
        `--codex`: follow `<Codex_Mode>` (end of `<Ralph_Protocol>`) for execution and verification, then continue with step 5.


### PR DESCRIPTION
## Summary
- **Remove `hooks` field from plugin.json** — caused `PreToolUse hook error` on every tool call in installed mode. Hooks are auto-discovered from `hooks/hooks.json`.
- **Register all bundle files in `.gitattributes`** — `coral-backend.cjs` and `coral-discuss.cjs` were missing `-diff` and `linguist-generated` markers.
- **Ralph task registration** — ralph now registers plan acceptance criteria as Tasks when a plan file exists.
- **KB updates** — corrected hooks-plugin-install-required entry, translated remaining Korean text in KB files, analyze `--deep` removal.

## Test plan
- [x] `npm test` — 1066 passed
- [x] Hook error gone after removing `plugin.json` hooks field
- [x] Squash merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)