### PR TITLE
Fix ralph-loop hookEventName and protocol gate

### DIFF
--- a/.claude/coral/kb/hooks-stdout-flush.md
+++ b/.claude/coral/kb/hooks-stdout-flush.md
@@ -1,0 +1,41 @@
+# Hook hookSpecificOutput: hookEventName required + event support matrix
+
+## Rule
+1. `hookSpecificOutput` requires `hookEventName` field — without it, Claude Code raises HookError.
+2. `hookSpecificOutput` is only supported on specific events. The validated schema per event:
+
+| Event | hookSpecificOutput fields |
+|---|---|
+| `UserPromptSubmit` | `hookEventName` (required), `additionalContext` (required) |
+| `PreToolUse` | `hookEventName`, `permissionDecision`, `permissionDecisionReason`, `updatedInput` |
+| `PostToolUse` | `hookEventName`, `additionalContext` (optional) |
+| `Stop` | **Not supported** — use top-level `decision`, `reason`, `systemMessage` instead |
+
+## Why
+- Missing `hookEventName`: Claude Code can't route the output, treats it as malformed JSON → HookError (silent, not visible to user or model).
+- Using `hookSpecificOutput` on `Stop`: JSON validation fails against the schema. Stop hooks only accept top-level fields like `decision: "block"`, `reason`, `systemMessage`.
+
+## Pattern
+```js
+// WRONG — missing hookEventName
+console.log(JSON.stringify({
+  hookSpecificOutput: { additionalContext: 'text' },
+}));
+
+// WRONG — hookSpecificOutput on Stop event
+console.log(JSON.stringify({
+  hookSpecificOutput: { hookEventName: 'Stop', additionalContext: 'text' },
+}));
+
+// RIGHT — UserPromptSubmit/PostToolUse with hookEventName
+console.log(JSON.stringify({
+  hookSpecificOutput: { hookEventName: 'UserPromptSubmit', additionalContext: 'text' },
+}));
+
+// RIGHT — Stop event with top-level fields
+console.log(JSON.stringify({
+  decision: 'block',
+  reason: 'Review needed',
+  systemMessage: 'Please review before stopping.',
+}));
+```

--- a/.claude/coral/kb/skill-protocol-bootstrap-gate.md
+++ b/.claude/coral/kb/skill-protocol-bootstrap-gate.md
@@ -1,0 +1,32 @@
+# Protocol Bootstrap Steps Need Hard Gates
+
+## Rule
+When a skill protocol has a numbered bootstrap step (e.g. "Step 1: determine execution mode"), LLMs will skip it and jump to habitual behavior (codebase analysis, file reads, planning) unless the step is enforced with an explicit hard gate that prohibits other tool calls until the step completes.
+
+## Why
+LLMs have a strong prior toward "understand the problem first" — reading files, exploring code, gathering context. A numbered step buried inside a `<Protocol>` block competes with this prior and loses. The result: the bootstrap step is skipped entirely, and the LLM only realizes it when called out.
+
+## Pattern
+
+**Wrong** — bootstrap step is just another numbered item in `<Protocol>`:
+```
+<Protocol>
+1) Determine execution mode.
+   ...check state file, decide prompt vs plan mode...
+2) Break work into steps.
+3) Execute.
+</Protocol>
+```
+LLM reads the protocol, then immediately starts reading source files.
+
+**Right** — hard gate before any work:
+```
+<Protocol>
+⛔ HARD GATE: Complete Step 1 BEFORE any file reads, searches, or analysis.
+No tool calls except state file lookup until execution mode is determined.
+
+1) Determine execution mode.
+   ...
+</Protocol>
+```
+Or: extract Step 1 into a separate `<Bootstrap>` section before `<Protocol>`.

--- a/hooks/ralph-loop.mjs
+++ b/hooks/ralph-loop.mjs
@@ -13,7 +13,6 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { EOL } from 'node:os';
 
 const DEFAULT_STATE = {
   prompt: '',
@@ -35,6 +34,7 @@ try {
     const statePath = createStateFile(projectDir, sessionId);
     writeJson({
       hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
         additionalContext: buildAdditionalContext(statePath),
       },
     });
@@ -48,6 +48,7 @@ try {
     const statePath = createStateFile(projectDir, sessionId);
     writeJson({
       hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
         additionalContext: buildAdditionalContext(statePath),
       },
     });
@@ -209,7 +210,7 @@ function normalizeWhitespace(text) {
 }
 
 function writeJson(value) {
-  process.stdout.write(JSON.stringify(value) + EOL);
+  console.log(JSON.stringify(value));
 }
 
 function readStdin() {

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -46,6 +46,9 @@ Strip ALL flags before passing the prompt to execution or state file.
     | Output `<promise>` only after ALL verification passes | Output false promise to escape the loop |
   </Constraints>
   <Protocol>
+    ⛔ HARD GATE: Complete Step 1 BEFORE any file reads, searches, or analysis.
+    No tool calls except Glob/Read for state file until execution mode is determined.
+
     1) Determine execution mode.
        **Ralph loop state file**: If additionalContext mentions a ralph state file path, OR `.claude/coral/tmp/ralph-state-*` glob finds a file:
 
@@ -53,7 +56,7 @@ Strip ALL flags before passing the prompt to execution or state file.
           Arguments contain a plan file path, OR `## Acceptance Criteria` in context,
           OR invoked by plan/bugfix/init-project handoff → delete state file, proceed below.
 
-       b. **LLM judgment** (only when plan precedence does not apply):
+       b. **Otherwise**:
           Concrete new task = prompt mode. Reference to prior discussion = plan mode.
           Plan mode → delete state file.
           Prompt mode → write cleaned prompt + parsed options to state file. Execute task.


### PR DESCRIPTION
## Summary
- **fix: add required hookEventName to ralph-loop hookSpecificOutput** — `hookSpecificOutput` without `hookEventName` causes silent HookError in Claude Code. Added `hookEventName` field to both UserPromptSubmit and PreToolUse branches. Switched `writeJson` from `process.stdout.write` to `console.log` for consistency with other hooks.
- **fix: add hard gate to ralph protocol** — enforce Step 1 execution order in SKILL.md

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 1076 tests pass (`npm test`)
- [x] `/coral:ralph test` no longer produces HookError
- [x] `additionalContext` properly injected into conversation context

🤖 Generated with [Claude Code](https://claude.com/claude-code)