### PR TITLE
feat: resolver severity column and plan round summary cleanup

### DIFF
--- a/agents/resolver.md
+++ b/agents/resolver.md
@@ -24,7 +24,7 @@ methods: [HOW-SYNTHESIZE, HOW-RESOLVE]
     | Spawned via coral:resolver op | MANDATORY |
   </Role>
   <Success_Criteria>
-    - Every reviewer finding is classified (Adopt/Adapt/Defer/Diverge) with FRAME/STRUCTURE/DETAIL level
+    - Every reviewer finding preserves original reviewer severity (CRITICAL/HIGH/MEDIUM/LOW) and is classified (Adopt/Adapt/Defer/Diverge) with FRAME/STRUCTURE/DETAIL level
     - Vyabhicharita conflicts (same design praised and attacked) are surfaced with hidden assumption identified
     - Constraint Collisions trigger HOW-RESOLVE protocol, producing TRIZ-based resolution candidates
     - Adopt/Adapt changes are applied directly to the plan file via Edit tool
@@ -86,13 +86,16 @@ methods: [HOW-SYNTHESIZE, HOW-RESOLVE]
     ## Synthesis Report
 
     ### Classification Table
-    | # | Reviewer | Finding summary | Severity | Classification | Rationale | Provenance | Confidence |
-    |---|----------|-----------------|----------|---------------|-----------|------------|------------|
-    | 1 | A | [finding] | FRAME/STRUCTURE/DETAIL | Adopt/Adapt/Defer/Diverge | [reason] | [type label] | [tier] |
+    Reviewer column uses full reviewer names (e.g., Architect, Critic). A = first reviewer, B = second reviewer in the workflow expression.
+
+    | # | Reviewer | Finding summary | Reviewer Severity | Level | Classification | Rationale | Provenance | Confidence |
+    |---|----------|-----------------|-------------------|-------|---------------|-----------|------------|------------|
+    | 1 | Architect | [finding] | CRITICAL/HIGH/MEDIUM/LOW | FRAME/STRUCTURE/DETAIL | Adopt/Adapt/Defer/Diverge | [reason] | [type label] | [tier] |
+    | 2 | Critic | [finding] | CRITICAL/HIGH/MEDIUM/LOW | FRAME/STRUCTURE/DETAIL | Adopt/Adapt/Defer/Diverge | [reason] | [type label] | [tier] |
 
     ### Vyabhicharita Findings
     [Conflicts where the same element is simultaneously praised and attacked.
-    Include: element, reviewer A's position, reviewer B's position, hidden assumption.]
+    Include: element, A's position, B's position, hidden assumption.]
     None if no conflicts detected.
 
     ### Constraint Collisions

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -129,6 +129,10 @@ Strip `--codex`, `--deep`, and `--no-handoff` flags before passing the prompt to
 
       ## Round N ({Round Label})
 
+      **If `--deep`**: use the resolver's Synthesis Report directly (Classification Table, Vyabhicharita, Constraint Collisions, Applied Changes, Deferred/Diverged items).
+
+      **Otherwise**: produce the summary yourself after synthesis:
+
       | # | Source | Finding | Severity | Level | Classification |
       |---|--------|---------|----------|-------|----------------|
       | 1 | Critic #1/#4 | Description | HIGH | FRAME | Adopt |
@@ -137,7 +141,7 @@ Strip `--codex`, `--deep`, and `--no-handoff` flags before passing the prompt to
       - Deduplicate overlapping findings (use "Both" as source)
       - Order by Severity (CRITICAL > HIGH > MEDIUM > LOW)
 
-      **Changes Applied**: [what was edited]
+      **Changes Applied**: [what was edited, with rationale for each change]
 
     **4d. Exit Condition**
     **If `--deep`**: Read `CORAL_METHODS/HOW-COMPLETE.md` and apply its additional completion criteria alongside the rules below.


### PR DESCRIPTION
## Summary
- Resolver Classification Table adds `Reviewer Severity` column (CRITICAL/HIGH/MEDIUM/LOW) preserving original reviewer assessment
- Plan 4c `--deep` mode uses resolver Synthesis Report directly instead of re-processing
- Plan round summary table: rationale moved to Changes Applied section for cleaner table

## Test plan
- [x] Manual: `/coral:plan --deep` — verify resolver output includes Reviewer Severity column
- [x] Manual: plan 4d exit condition reads severity from resolver table without searching original output

🤖 Generated with [Claude Code](https://claude.com/claude-code)