### PR TITLE
fix: skill description trap prevention

### DIFF
--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze
-description: "Deep analysis - project scanning, requirement gaps, root cause investigation. HOW methods always applied. Pass --codex to delegate to Codex CLI."
+description: "Use when deep investigation is needed — project structure, requirement gaps, or root cause diagnosis. Supports --codex."
 argument-hint: "[--codex] [investigation target or question]"
 ---
 

--- a/skills/bugfix/SKILL.md
+++ b/skills/bugfix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bugfix
-description: "Systematic bug diagnosis, planning, and fix execution."
+description: "Use when encountering a bug, error, or unexpected behavior that needs diagnosis and fix."
 argument-hint: "[--codex] <bug description or error message>"
 ---
 

--- a/skills/code-simplify/SKILL.md
+++ b/skills/code-simplify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-simplify
-description: "Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise."
+description: "Use when code needs simplification — recently modified code by default, or a specified scope."
 argument-hint: "[--codex] <scope or prompt>"
 ---
 

--- a/skills/discuss/SKILL.md
+++ b/skills/discuss/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discuss
-description: Moderated multi-agent discussion via Agent Teams
+description: "Use when a topic benefits from multiple perspectives debating before a decision."
 argument-hint: "[--user] [topic] [--hints axis1:pos1,pos2 axis2:pos1,pos2]"
 ---
 

--- a/skills/init-project/SKILL.md
+++ b/skills/init-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: init-project
-description: Initialize project for AI-assisted development with rules, agents, CLAUDE.md, and docs
+description: "Use when setting up a new or existing project for AI-assisted development."
 argument-hint: "[existing|new]"
 ---
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: "Planning with parallel architect/critic review. Pass --deep for methodology-driven synthesis, --codex for cross-model reviews."
+description: "Use when a task needs structured planning before implementation. Supports --deep and --codex flags."
 argument-hint: "[--deep] [--codex] [task description]"
 ---
 

--- a/skills/preplan/SKILL.md
+++ b/skills/preplan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preplan
-description: "Structured problem-definition conversation before planning. Aligns understanding with the user before triggering coral:plan."
+description: "Use when a problem needs clarification and agreement before planning begins."
 argument-hint: "<issue or topic>"
 ---
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralph
-description: Persistent execution loop with verification (sonnet) - implements plans or iterates on prompts
+description: "Use when implementing a plan or executing a prompt that requires verified completion."
 argument-hint: "[--red] [--codex] [--team] [task description]"
 model: sonnet
 ---


### PR DESCRIPTION
## Summary
- Rewrote all 8 SKILL.md descriptions to trigger-only "Use when..." format
- Prevents Description Trap: when descriptions summarize workflow, Claude skips reading the full skill body
- Discovery from superpowers project analysis (`.claude/coral/analysis/2026-03-08-superpowers-comparison.md`)

## Test plan
- [x] Verify skill loading still triggers correctly for each skill
- [x] Confirm Claude reads full skill body instead of relying on description

🤖 Generated with [Claude Code](https://claude.com/claude-code)