### PR TITLE
feat: preplan UX, statusline coral color, kb memo-first rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,11 +73,18 @@ When you discover something non-obvious (painful root cause, unexpected gotcha,
 Keep brief - one paragraph + context.
 If Explanatory/Learning output style is active, also memo any Insights worth preserving.
 
+**Never write directly to `kb/` during work.** Always write to `memo/` first.
+This applies to all execution contexts including subagents and delegated tasks.
+
 ## Lookup - on error
 Before debugging from scratch, check `{project}/.claude/coral/kb/` for relevant entries.
 On plan start, review domain-related kb files.
 
-## Promotion - before commit, on task completion, or when a memo captures a reusable lesson
+## Promotion - orchestrator only, after all work completes
+Only the top-level orchestrator (the main session driving the task) promotes memos to kb.
+Subagents and delegated tasks must never promote — they only write memos.
+
+Promotion triggers: before commit, on task completion, or when a memo captures a reusable lesson.
 Review all memos. Check existing kb entries first - discard duplicates,
 update existing entries if the memo refines them, only create new files for genuinely absent knowledge.
 

--- a/skills/preplan/SKILL.md
+++ b/skills/preplan/SKILL.md
@@ -58,9 +58,9 @@ Structured problem-definition conversation with the user before planning begins.
     - Do the items tell a coherent story? (Problem → Criteria → Scope → Assumptions → Systems)
     - Are there contradictions between items? (e.g., scope excludes something that success criteria requires)
     - Is the problem statement actually the root problem, or a symptom?
-    - Would the Alt 2 (radical) option make you reconsider the problem statement itself?
-    - Even for confirmed items: is there a radical alternative so valuable that the user should know about it?
-      If yes, flag it in the presentation — the user may not have considered it.
+    - Do any radical alternatives make you reconsider the problem statement itself?
+    - Even for confirmed sub-items: is there a radical alternative so valuable that the user should know about it?
+      If yes, mark it unconfirmed and add the three-point spectrum — the user may not have considered it.
 
     Fix inconsistencies before presenting. This step is silent — no output to the user.
 
@@ -68,14 +68,23 @@ Structured problem-definition conversation with the user before planning begins.
 
     Present complete draft. The user's role is to **correct**, not to fill from scratch.
 
-    For each unconfirmed item, commit to the best choice and present it as the default,
-    then offer 2 alternatives inline:
-    - **Default**: narrowest scope that solves the problem without introducing unnecessary complexity.
-    - **Alt 1**: minimal — quickest path, least disruption, accepts known tradeoffs.
-    - **Alt 2**: radical — rethink the entire approach. Breaking changes, major refactors, or architectural rewrites that eliminate the root cause permanently. High upfront cost, but the codebase emerges fundamentally better. Propose this even if it feels disproportionate to the original ask.
+    For each unconfirmed **sub-item** (not the section as a whole), commit to the best choice.
+    Two kinds of unconfirmed:
+    - **Needs decision** (strongly preferred) — actively search for alternatives. Most unconfirmed items
+      have meaningful alternatives if you think harder. Mark `[unconfirmed]` with three alternatives:
+      - **default**: narrowest scope that solves the problem without introducing unnecessary complexity.
+      - **minimal**: quickest path, least disruption, accepts known tradeoffs.
+      - **radical**: rethink the entire approach. Breaking changes, major refactors, or architectural rewrites that eliminate the root cause permanently. High upfront cost, but the codebase emerges fundamentally better. Propose this even if it feels disproportionate to the original ask.
+    - **Needs verification** (rare) — purely factual, no meaningful alternatives possible
+      (e.g. "is this ESM or CJS?"). Mark `[unconfirmed]` with no nested list.
+      Use sparingly — default to providing alternatives unless the item is strictly factual.
 
-    Each represents a different point on the scope/investment spectrum, not minor variations of the same idea.
-    > **Success Criteria** [unconfirmed — picked A, alternatives: B, C]
+    Each alternative represents a different point on the scope/investment spectrum, not minor variations of the same idea.
+    Confirmed sub-items have no marker and no alternatives. Unconfirmed sub-items with alternatives show as nested list:
+    > - [ ] Response time under 200ms [unconfirmed]
+    >   - default: 200ms
+    >   - minimal: 500ms (accept higher latency)
+    >   - radical: 50ms with cache layer
     The user can accept (silence), pick an alternative, or propose their own.
 
     ### 4. Conversation Loop
@@ -89,8 +98,9 @@ Structured problem-definition conversation with the user before planning begins.
     as "unconfirmed" — the user cannot confirm what they don't know is uncertain.
     If ambiguous about a specific item, call it out and ask for clarification.
 
-    After each exchange, assess: are all 5 required items free of "unconfirmed" markers?
-    If yes — including after a previously confirmed item was changed and re-confirmed —
+    After each exchange, count remaining `[unconfirmed]` sub-items and show progress
+    (e.g. "3 unconfirmed items remaining"). When zero remain —
+    including after a previously unconfirmed item was resolved —
     **always** present the agreement summary and call `AskUserQuestion`:
     ```
     AskUserQuestion({
@@ -113,7 +123,7 @@ Structured problem-definition conversation with the user before planning begins.
     | DO | DON'T |
     |----|-------|
     | Fill items autonomously before asking | Ask item-by-item like a form |
-    | Commit to the best choice for unconfirmed items, offer 2 alternatives | Leave unconfirmed items blank or ask open-ended questions |
+    | Commit to the best choice per unconfirmed sub-item, offer minimal + radical alternatives | Leave unconfirmed items blank or offer alternatives per section |
     | Mark uncertain items as "unconfirmed" | Present guesses as confirmed facts |
     | Flag ambiguous items explicitly to the user | Assume the user noticed uncertainty |
     | Update agreement file on every change | Keep agreement only in conversation |
@@ -130,23 +140,28 @@ Structured problem-definition conversation with the user before planning begins.
     ```markdown
     # Pre-plan: {topic}
 
-    ## Problem Statement [confirmed]
-    [Current state vs desired state]
+    ## Problem Statement
+    - Current state: ...
+    - Desired state: ... [unconfirmed]
+      - default: X
+      - minimal: Y
+      - radical: Z
 
-    ## Success Criteria [unconfirmed]
+    ## Success Criteria
     - [ ] Criterion 1
-    - [ ] Criterion 2
+    - [ ] Criterion 2 [unconfirmed]
+      - default: ...
+      - minimal: ...
+      - radical: ...
+    - [ ] Criterion 3 [unconfirmed]  <!-- needs verification, no alternatives -->
 
-    ## Scope [confirmed]
-    **Included**: ...
-    **Excluded**: ...
-
-    ## Assumptions [confirmed]
-    - Assumption 1 [confirmed]
-    - Assumption 2 [unconfirmed]
-
-    ## Affected Systems [confirmed]
-    - `file:path` — reason
+    ## Scope
+    ...
+    ## Assumptions
+    ...
+    ## Affected Systems
+    ...
+    <!-- remaining sections use the same sub-item pattern -->
 
     ## Constraints
     [If applicable, else N/A]
@@ -159,7 +174,7 @@ Structured problem-definition conversation with the user before planning begins.
     e.g. user preferences, tangential observations, rejected alternatives and why.]
     ```
 
-    Markers: `[confirmed]`/`[unconfirmed]` on all required headings and individual sub-items. Optional items need no markers.
+    Markers: only `[unconfirmed]` is marked — no marker means confirmed. Unconfirmed sub-items that need a decision list three alternatives as nested items (default, minimal, radical). Unconfirmed sub-items that need verification have no nested list. Section headings carry no markers. Optional items need no markers.
 
     ### Transition Handoff
 

--- a/skills/statusline/coral-hud.mjs
+++ b/skills/statusline/coral-hud.mjs
@@ -739,12 +739,12 @@ async function renderCoralLine() {
       signal: AbortSignal.timeout(CORAL_HEALTH_TIMEOUT_MS),
     });
     if (!resp.ok) {
-      const line = `coral ${DIM}○ offline${RESET}`;
+      const line = `${DIM}coral${RESET}`;
       writeBackendSlot(line, false);
       return line;
     }
     const data = await resp.json();
-    const parts = [`coral ${GREEN}●${RESET}`];
+    const parts = [`\x1b[38;2;255;133;89mcoral${RESET}`];
     if (data.activeChildren > 0) parts.push(`${MAGENTA}⚙ ${data.activeChildren}${RESET}`);
     if (data.queueDepth > 0) parts.push(`queue:${data.queueDepth}`);
 
@@ -756,11 +756,11 @@ async function renderCoralLine() {
       } catch {}
     }
 
-    const line = parts.join(SEP);
+    const line = parts.join(" ");
     writeBackendSlot(line, true);
     return line;
   } catch {
-    const line = `coral ${DIM}○ offline${RESET}`;
+    const line = `${DIM}coral${RESET}`;
     writeBackendSlot(line, false);
     return line;
   } finally {


### PR DESCRIPTION
## Summary
- **Preplan sub-item alternatives**: alternatives per sub-item (not per section), `alt1`/`alt2` → `minimal`/`radical` labels, two unconfirmed types (needs-decision vs needs-verification), drop `[confirmed]` noise, show remaining count
- **Statusline coral color**: backend line uses truecolor coral (#FF8559) instead of green dot, space separator instead of │
- **KB memo-first rule**: CLAUDE.md now explicitly restricts kb/ writes to orchestrator only — subagents and delegated tasks must write to memo/ first

## Test plan
- [x] `/preplan` — unconfirmed sub-items show default/minimal/radical nested list, confirmed items have no marker
- [x] Statusline line 3 — `coral` in coral color when online, dim when offline, space-separated parts
- [x] Codex delegation — verify subagent writes to memo/ not kb/

🤖 Generated with [Claude Code](https://claude.com/claude-code)