### PR TITLE
fix: MCP config shell fallback + warm-start lock guard

### DIFF
--- a/.claude-plugin/mcp.json
+++ b/.claude-plugin/mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "ax": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/bridge/coral-ax.cjs"]
-    }
-  }
-}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,5 +19,5 @@
     "bridge"
   ],
   "skills": "./skills/",
-  "mcpServers": "./.claude-plugin/mcp.json"
+  "mcpServers": "./.mcp.json"
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ax": {
+      "command": "sh",
+      "args": ["-c", "node \"${CLAUDE_PLUGIN_ROOT:-.}/bridge/coral-ax.cjs\""]
+    }
+  }
+}

--- a/hooks/backend-warm-start.mjs
+++ b/hooks/backend-warm-start.mjs
@@ -24,11 +24,22 @@ try {
   }
 
   const namespace = createHash('sha256').update(canonicalPluginRoot).digest('hex').slice(0, 12);
-  const infoPath = join(homedir(), '.claude', 'coral', 'installations', namespace, 'backend.json');
+  const installDir = join(homedir(), '.claude', 'coral', 'installations', namespace);
+
+  // Skip if backend already running (backend.json with live pid)
   try {
-    const info = JSON.parse(readFileSync(infoPath, 'utf-8'));
+    const info = JSON.parse(readFileSync(join(installDir, 'backend.json'), 'utf-8'));
     if (info && typeof info.pid === 'number' && info.pid > 0) {
       process.kill(info.pid, 0);
+      process.exit(0);
+    }
+  } catch {}
+
+  // Skip if another process is already starting a backend (lock with live pid)
+  try {
+    const lock = JSON.parse(readFileSync(join(installDir, 'backend.lock'), 'utf-8'));
+    if (lock && typeof lock.pid === 'number' && lock.pid > 0) {
+      process.kill(lock.pid, 0);
       process.exit(0);
     }
   } catch {}


### PR DESCRIPTION
## Summary
- **MCP config**: Restore `.mcp.json` to project root with `sh -c "${CLAUDE_PLUGIN_ROOT:-.}/bridge/..."` shell fallback — works as both plugin config and project config without `/doctor` warning
- **Warm-start hook**: Check `backend.lock` in addition to `backend.json` before spawning, preventing duplicate backend process storms during concurrent session starts

## Test plan
- [x] Build passes, 864 tests passing
- [x] Plugin cache manually verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)