### PR TITLE
fix: revert .mcp.json shell fallback

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "ax": {
-      "command": "sh",
-      "args": ["-c", "node \"${CLAUDE_PLUGIN_ROOT:-.}/bridge/coral-ax.cjs\""]
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/bridge/coral-ax.cjs"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Revert `.mcp.json` shell fallback (`sh -c "${CLAUDE_PLUGIN_ROOT:-.}/..."`) back to original `node "${CLAUDE_PLUGIN_ROOT}/bridge/coral-ax.cjs"`
- The fallback caused duplicate MCP server name conflict when the plugin is installed and the coral workspace is opened

## Test plan
- [x] Plugin installed + workspace open: no duplicate `ax` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)