### PR TITLE
fix: revert .mcp.json shell fallback + fix backend startup hang

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "ax": {
-      "command": "sh",
-      "args": ["-c", "node \"${CLAUDE_PLUGIN_ROOT:-.}/bridge/coral-ax.cjs\""]
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/bridge/coral-ax.cjs"]
     }
   }
 }

--- a/src/execution/discuss-manager.ts
+++ b/src/execution/discuss-manager.ts
@@ -906,7 +906,13 @@ export class DiscussManager {
           if (current.abortEnded) {
             return;
           }
+          const beforePhase = snapshot.runtime.controlPhase;
           await this.handleSynthesis(sessionId, ctx);
+          const after = this.sessions.get(sessionId);
+          if (after?.snapshot.runtime.controlPhase === beforePhase) {
+            await this.forceEndAfterLoopFailure(sessionId, new Error('synthesis failed to advance'));
+            return;
+          }
           continue;
         }
 

--- a/src/execution/server.ts
+++ b/src/execution/server.ts
@@ -1584,6 +1584,7 @@ export function createBackendServer(options: BackendServerOptions = {}): Backend
 
     try {
       await acquireLockFn(resolvedPluginRoot, instanceId, version, bundleHash);
+      registerBuiltInProviders();
       recoverOrphanedJobsFn(namespace);
       for (const projectRoot of knownDiscussProjectRoots()) {
         const ctx: CallerContext = {


### PR DESCRIPTION
## Summary
- **Revert .mcp.json**: restore original `${CLAUDE_PLUGIN_ROOT}` reference — shell fallback caused duplicate MCP server detection
- **Fix startup hang**: call `registerBuiltInProviders()` before discuss recovery so synthesis resume has providers available; add progress guard in `continueLoop` to force-end sessions that fail to advance

## Root cause (startup hang)
Backend startup ran discuss recovery before `registerBuiltInProviders()`. Sessions with `controlPhase: 'synthesize'` attempted agent execution with no providers registered, causing `rejectLaunch` → `catch { return }` → `continue` infinite loop at 100% CPU. Backend never reached `listen()` or `writeBackendInfo()`.

## Test plan
- [x] Build passes, 864 tests passing
- [x] Manual: `timeout 10 node bridge/coral-backend.cjs` — starts and writes `backend.json` within 3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)