### PR TITLE
Shared session state, cli-resolve fix, skill guards

### DIFF
--- a/.claude/coral/kb/hooks-pretooluse-bash-updatedinput.md
+++ b/.claude/coral/kb/hooks-pretooluse-bash-updatedinput.md
@@ -1,30 +1,42 @@
-# Bash PreToolUse Rewrites Must Use `updatedInput`
-Promoted: 2026-03-13 | Updated: 2026-03-13
+# Bash PreToolUse Rewrites — updatedInput Shape
+Promoted: 2026-03-13 | Updated: 2026-03-16
 ## Rule
-A `PreToolUse` hook that rewrites a Bash command must read the pending command from `input.tool_input.command` and return the mutation through `hookSpecificOutput.updatedInput.tool_input.command`. Writing only generic `hookSpecificOutput` text does not change the tool invocation.
+A `PreToolUse` hook that rewrites a Bash command must return `hookSpecificOutput.updatedInput` as a **flat tool_input object** (spread original, override `command`). The `updatedInput` value IS `tool_input` — do not nest `tool_input` inside it. Must include `hookEventName: "PreToolUse"`.
 ## Why
-Coral hook scripts often emit `hookSpecificOutput.additionalContext`, which is valid for reminders and annotations but not for command mutation. Reusing that pattern for a CLI rewrite silently produces a no-op hook: the hook runs, but Claude still executes the original Bash command.
+Wrapping as `updatedInput: { tool_input: { command } }` causes Claude Code to error (`undefined is not an object (evaluating 'H.includes')`) because it expects `updatedInput` to be the tool_input shape directly. Omitting `hookEventName` causes the `updatedInput` to be silently ignored.
 ## Pattern
-Right:
+Right — spread original tool_input, override command:
+```js
+const updatedInput = { ...input.tool_input, command: rewritten };
+process.stdout.write(JSON.stringify({
+  hookSpecificOutput: {
+    hookEventName: 'PreToolUse',
+    updatedInput,
+  },
+}));
+```
+
+Wrong — nested tool_input (causes runtime error):
 ```json
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "updatedInput": {
       "tool_input": {
-        "command": "CORAL_PLUGIN_ROOT=\"$CLAUDE_PLUGIN_ROOT\" node \"$CLAUDE_PLUGIN_ROOT/bridge/coral-cli.cjs\" backend status"
+        "command": "rewritten command"
       }
     }
   }
 }
 ```
 
-Wrong:
+Wrong — missing hookEventName (rewrite silently ignored):
 ```json
 {
   "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "additionalContext": "Use node bridge/coral-cli.cjs instead"
+    "updatedInput": {
+      "command": "rewritten command"
+    }
   }
 }
 ```

--- a/.claude/coral/kb/hooks-statusline-data-asymmetry.md
+++ b/.claude/coral/kb/hooks-statusline-data-asymmetry.md
@@ -1,0 +1,29 @@
+# Hooks vs Statusline Data Asymmetry
+
+Promoted: 2026-03-16 | Updated: 2026-03-16
+
+## Rule
+
+Hook event payloads and statusline input have different data available. Statusline receives `context_window` (with `used_percentage`, token counts) and `session_id` via stdin, but hooks only get `session_id`, `transcript_path`, `cwd`, `permission_mode`, and event-specific fields — no context metrics. To share data between them, use `~/.claude/hud/.coral-sessions.json` as a shared session state file keyed by `session_id`.
+
+## Why
+
+Without this knowledge, you might assume hooks can access context window data directly (they can't), or try to parse the transcript for token info (unreliable). The shared file pattern was designed to bridge this gap — statusline writes ctx% on each render, hooks read it.
+
+## Pattern
+
+Right — statusline writes, hook reads via shared file:
+```javascript
+// In statusline (coral-hud.mjs) — writer
+writeSession(sessionId, { ctx, prompt, activity, agents, transcriptSize });
+
+// In hook (ralph-loop.mjs) — reader
+const sessionsPath = join(homedir(), '.claude', 'hud', '.coral-sessions.json');
+const entry = JSON.parse(readFileSync(sessionsPath, 'utf8'))[sessionId];
+```
+
+Wrong — assuming hook has context data:
+```javascript
+// Hook does NOT receive this
+const pct = input.context_window.used_percentage; // undefined
+```

--- a/hooks/cli-resolve.mjs
+++ b/hooks/cli-resolve.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
 // Fail-open: any error -> silent exit 0
 try {
@@ -10,9 +13,6 @@ try {
   if (input.hook_event_name !== 'PreToolUse' || input.tool_name !== 'Bash') {
     process.exit(0);
   }
-
-  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
-  if (!pluginRoot) process.exit(0);
 
   const command = input.tool_input?.command;
   if (typeof command !== 'string') process.exit(0);
@@ -24,16 +24,14 @@ try {
   const match = command.match(/^(\s*)coral-cli(\s|$)(.*)/s);
   if (!match) process.exit(0);
 
-  const cliPath = join(pluginRoot, 'bridge', 'coral-cli.cjs');
+  const cliPath = join(PLUGIN_ROOT, 'bridge', 'coral-cli.cjs');
   const rewritten = `${match[1]}node "${cliPath}"${match[2]}${match[3]}`;
 
+  const updatedInput = { ...input.tool_input, command: rewritten };
   process.stdout.write(JSON.stringify({
     hookSpecificOutput: {
-      updatedInput: {
-        tool_input: {
-          command: rewritten,
-        },
-      },
+      hookEventName: 'PreToolUse',
+      updatedInput,
     },
   }));
 } catch {

--- a/hooks/ralph-loop.mjs
+++ b/hooks/ralph-loop.mjs
@@ -99,6 +99,8 @@ try {
     } else {
       ctxNote = `\n\nContext usage is currently ${ctxPct}%. Do NOT stop due to context concerns.`;
     }
+  } else {
+    ctxNote = '\n\nDo NOT stop due to context concerns — auto-compact handles context management automatically.';
   }
   writeJson({
     decision: 'block',

--- a/hooks/ralph-loop.mjs
+++ b/hooks/ralph-loop.mjs
@@ -12,6 +12,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
 const DEFAULT_STATE = {
@@ -89,13 +90,36 @@ try {
     iteration: state.iteration + 1,
   };
   atomicWriteJson(statePath, nextState);
+  const ctxPct = readCtxPct(sessionId);
+  let ctxNote = '';
+  if (ctxPct != null) {
+    const compactPct = parseInt(process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE, 10) || 95;
+    if (ctxPct >= compactPct - 10) {
+      ctxNote = `\n\nContext usage is at ${ctxPct}%. Continue working — auto-compact will trigger automatically.`;
+    } else {
+      ctxNote = `\n\nContext usage is currently ${ctxPct}%. Do NOT stop due to context concerns.`;
+    }
+  }
   writeJson({
     decision: 'block',
-    reason: `${state.prompt}\n\nIf already complete, output <promise>${state.completionPromise}</promise> immediately. If not complete, continue from where you left off.`,
+    reason: `${state.prompt}\n\nIf already complete, output <promise>${state.completionPromise}</promise> immediately. If not complete, continue from where you left off.${ctxNote}`,
     systemMessage: `🔄 Ralph iteration ${nextState.iteration}`,
   });
 } catch {
   process.exit(0);
+}
+
+function readCtxPct(sessionId) {
+  try {
+    const sessionsPath = join(homedir(), '.claude', 'hud', '.coral-sessions.json');
+    const all = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+    const entry = all[sessionId];
+    if (!entry || entry.ctx == null) return null;
+    if (Date.now() - (entry.ts || 0) > 5 * 60 * 1000) return null;
+    return entry.ctx;
+  } catch {
+    return null;
+  }
 }
 
 function createStateFile(projectDir, sessionId) {

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -112,9 +112,9 @@ Strip `--codex`, `--deep`, and `--no-handoff` flags before passing the prompt to
       provider: "{phase provider}"
     })
     ```
-    - **If `--deep`**: `wait({ jobs: [job], inline: false })` →
-      `{ start, end } = result.workflow.steps.find(s => s.agent === "resolver")` → `Read(result.content, start, end - start + 1)`.
-    - **Otherwise**: `wait({ jobs: [job], inline: true })` → read `result.content`.
+    - **If `--deep`**: `wait({ jobs: [job] })` →
+      `{ start, end } = result.workflow.steps.find(s => s.agent === "resolver")` → `Read(result.path, start, end - start + 1)`.
+    - **Otherwise**: `wait({ jobs: [job] })` → use `result.content ?? Read(result.path)`.
 
     **4b. Post-Round Processing**
 
@@ -122,7 +122,7 @@ Strip `--codex`, `--deep`, and `--no-handoff` flags before passing the prompt to
     Read the updated plan file, then the resolver's synthesis report from the workflow result.
     Record Deferred/Diverged items.
 
-    **Otherwise**: `result.content` is `<architect>…</architect>` + `<critic>…</critic>`.
+    **Otherwise**: `result.content ?? Read(result.path)` is `<architect>…</architect>` + `<critic>…</critic>`.
     Read `CORAL_METHODS/HOW-SYNTHESIZE.md` and resolve the findings yourself. Edit the plan file.
 
     **4c. Round Summary** (AFTER 4b)

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -112,9 +112,9 @@ Strip `--codex`, `--deep`, and `--no-handoff` flags before passing the prompt to
       provider: "{phase provider}"
     })
     ```
-    - **If `--deep`**: `wait({ jobs: [job] })` →
-      `{ start, end } = result.workflow.steps.find(s => s.agent === "resolver")` → `Read(result.path, start, end - start + 1)`.
-    - **Otherwise**: `wait({ jobs: [job] })` → use `result.content ?? Read(result.path)`.
+    - **If `--deep`**: `wait({ jobs: [job], inline: false })` →
+      `{ start, end } = result.workflow.steps.find(s => s.agent === "resolver")` → `Read(result.content, start, end - start + 1)`.
+    - **Otherwise**: `wait({ jobs: [job], inline: true })` → read `result.content`.
 
     **4b. Post-Round Processing**
 
@@ -122,7 +122,7 @@ Strip `--codex`, `--deep`, and `--no-handoff` flags before passing the prompt to
     Read the updated plan file, then the resolver's synthesis report from the workflow result.
     Record Deferred/Diverged items.
 
-    **Otherwise**: `result.content ?? Read(result.path)` is `<architect>…</architect>` + `<critic>…</critic>`.
+    **Otherwise**: `result.content` is `<architect>…</architect>` + `<critic>…</critic>`.
     Read `CORAL_METHODS/HOW-SYNTHESIZE.md` and resolve the findings yourself. Edit the plan file.
 
     **4c. Round Summary** (AFTER 4b)
@@ -149,7 +149,7 @@ Strip `--codex`, `--deep`, and `--no-handoff` flags before passing the prompt to
     - **Continue**: Either reviewer returned CRITICAL or HIGH → go to 4a for re-verification (plan was modified to address findings, but the modifications themselves may introduce new issues).
     - **Fix and pass**: No CRITICAL/HIGH but MEDIUM/LOW exist → fixes applied, exit.
     - **Clean pass**: No findings above LOW (and HOW-COMPLETE satisfied, if `--deep`) → proceed to next phase (or step 5 if last phase).
-    - **Max rounds (5)**: Proceed to next phase (or `AskUserQuestion` — continue, finalize, or abort — if last phase).
+    - **Max rounds (5)**: Proceed to next phase using workflow with that phase's provider (or `AskUserQuestion` — continue, finalize, or abort — if last phase).
 
     ### 4e. Execution Order
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -2,6 +2,7 @@
 name: ralph
 description: "Use when implementing a plan or executing a prompt that requires verified completion."
 argument-hint: "[--red] [--codex] [--team] [task description]"
+model: sonnet
 ---
 
 > **CORAL_AGENTS**: `Bash("echo ~/.claude/plugins/cache/coral/coral/*/agents/")`
@@ -38,6 +39,7 @@ Strip flags before passing the prompt to execution. Preserve original flags in t
   <Constraints>
     | DO | DON'T |
     |----|-------|
+    | Start executing immediately — the user already decided | Ask for confirmation, warn about scope/time/feasibility, or give estimates |
     | Run build/test only in post-implementation | Run build or test during implementation |
     | Verify subagent output independently | Trust "agent said success" |
     | Escalate to architect after 3 failed fix attempts | Try variations of the same fix |
@@ -69,6 +71,9 @@ Strip flags before passing the prompt to execution. Preserve original flags in t
     - Each batch lists its tasks with affected file paths.
 
     ### Step 3 — Execute
+
+    ⛔ DO NOT ask the user for confirmation, warn about task size, estimate time, or question feasibility.
+    The user invoked ralph — that IS the decision. Execute all batches in order. Start now.
 
     **Task Registration** (both modes, before dispatch):
     Break work into discrete units and register each via `TaskCreate`:
@@ -139,7 +144,7 @@ Strip flags before passing the prompt to execution. Preserve original flags in t
        go into one Codex call; independent ACs get separate parallel calls.
        `codex({ op: "bypass_exec", prompt: "<ACs + file paths + constraints>", work_dir: "<project root>" })`
        Do NOT pass `session`. Collect all job IDs.
-    2. `wait({ jobs: [job1, job2, ...] })` → read each `result.content`; if absent, `Read(result.path)` is best-effort recovery.
+    2. `wait({ jobs: [job1, job2, ...], inline: true })` → read results for all jobs.
     3. Verify changes yourself: read changed files, compare against acceptance criteria.
     4. All criteria pass → read all modified files, compare against plan, fix discrepancies yourself. Then continue to Step 4.
        Failed criteria → re-launch only the failed ACs, loop to 1.
@@ -161,7 +166,7 @@ Strip flags before passing the prompt to execution. Preserve original flags in t
        For each assigned AC, delegate implementation to Codex.
        Include the plan file path in the prompt so Codex can read it for context.
        1. codex({ op: "bypass_exec", prompt: "<AC description + file paths + constraints>", work_dir: "<project root>" })
-          → wait({ jobs: [job] }) → read `result.content`; if absent, `Read(result.path)` is best-effort recovery.
+          → wait({ jobs: [job], inline: true }) → read result.
           Do NOT pass `session`.
        2. Verify changes yourself: read changed files, compare against AC.
        3. If AC not met → re-run codex. If met → report completion.

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -2,7 +2,6 @@
 name: ralph
 description: "Use when implementing a plan or executing a prompt that requires verified completion."
 argument-hint: "[--red] [--codex] [--team] [task description]"
-model: sonnet
 ---
 
 > **CORAL_AGENTS**: `Bash("echo ~/.claude/plugins/cache/coral/coral/*/agents/")`
@@ -39,7 +38,6 @@ Strip flags before passing the prompt to execution. Preserve original flags in t
   <Constraints>
     | DO | DON'T |
     |----|-------|
-    | Start executing immediately — the user already decided | Ask for confirmation, warn about scope/time/feasibility, or give estimates |
     | Run build/test only in post-implementation | Run build or test during implementation |
     | Verify subagent output independently | Trust "agent said success" |
     | Escalate to architect after 3 failed fix attempts | Try variations of the same fix |
@@ -144,7 +142,7 @@ Strip flags before passing the prompt to execution. Preserve original flags in t
        go into one Codex call; independent ACs get separate parallel calls.
        `codex({ op: "bypass_exec", prompt: "<ACs + file paths + constraints>", work_dir: "<project root>" })`
        Do NOT pass `session`. Collect all job IDs.
-    2. `wait({ jobs: [job1, job2, ...], inline: true })` → read results for all jobs.
+    2. `wait({ jobs: [job1, job2, ...] })` → read each `result.content`; if absent, `Read(result.path)` is best-effort recovery.
     3. Verify changes yourself: read changed files, compare against acceptance criteria.
     4. All criteria pass → read all modified files, compare against plan, fix discrepancies yourself. Then continue to Step 4.
        Failed criteria → re-launch only the failed ACs, loop to 1.
@@ -166,7 +164,7 @@ Strip flags before passing the prompt to execution. Preserve original flags in t
        For each assigned AC, delegate implementation to Codex.
        Include the plan file path in the prompt so Codex can read it for context.
        1. codex({ op: "bypass_exec", prompt: "<AC description + file paths + constraints>", work_dir: "<project root>" })
-          → wait({ jobs: [job], inline: true }) → read result.
+          → wait({ jobs: [job] }) → read `result.content`; if absent, `Read(result.path)` is best-effort recovery.
           Do NOT pass `session`.
        2. Verify changes yourself: read changed files, compare against AC.
        3. If AC not met → re-run codex. If met → report completion.

--- a/skills/statusline/coral-hud.mjs
+++ b/skills/statusline/coral-hud.mjs
@@ -4,7 +4,7 @@
 // Line 1: model │ limits │ ctx │ session │ skill
 // Line 2: codex model │ codex limits │ spark limits
 
-import { readFileSync, readdirSync, existsSync, writeFileSync, mkdirSync, openSync, fstatSync, readSync, closeSync, renameSync, unlinkSync } from "fs";
+import { readFileSync, readdirSync, existsSync, writeFileSync, mkdirSync, openSync, fstatSync, statSync, readSync, closeSync, renameSync, unlinkSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { execSync } from "child_process";
@@ -142,6 +142,8 @@ function renderContext(input) {
 }
 
 const STALE_AGENT_MS = 30 * 60 * 1000;
+const SESSION_PRUNE_MS = 60 * 60 * 1000;
+const ACTIVITY_TTL_MS = 60 * 60 * 1000;
 
 function readTranscriptTail(transcriptPath) {
   if (!transcriptPath) return null;
@@ -268,21 +270,61 @@ function parseLastUserMessage(lines) {
   return null;
 }
 
-function parseTranscript(input) {
-  const lines = readTranscriptTail(input.transcript_path);
-  if (!lines) return { activity: null, lastUserMessage: null };
-  const running = parseRunningAgents(lines);
-  let activity = null;
-  if (running.length > 0) {
-    const counts = {};
-    for (const a of running) counts[a.subagent_type] = (counts[a.subagent_type] || 0) + 1;
-    const str = Object.entries(counts).map(([t, c]) => c > 1 ? `${t}×${c}` : t).join(" ");
-    activity = `${DIM}${str}${RESET}`;
-  } else {
-    const skill = parseLastSkill(lines);
-    if (skill) activity = `${CYAN}${skill}${RESET}`;
+function formatAgentCounts(agents) {
+  const counts = {};
+  for (const a of agents) counts[a.subagent_type] = (counts[a.subagent_type] || 0) + 1;
+  return `${DIM}${Object.entries(counts).map(([t, c]) => c > 1 ? `${t}×${c}` : t).join(" ")}${RESET}`;
+}
+
+function renderActivityStr(agents, activity) {
+  const agentList = Array.isArray(agents) ? agents : Object.values(agents || {});
+  if (agentList.length > 0) return formatAgentCounts(agentList);
+  if (activity?.name && activity?.ts && (Date.now() - activity.ts < ACTIVITY_TTL_MS)) {
+    return `${CYAN}${activity.name}${RESET}`;
   }
-  return { activity, lastUserMessage: parseLastUserMessage(lines) };
+  return null;
+}
+
+function parseTranscript(input) {
+  const sessionId = input.session_id;
+  const transcriptPath = input.transcript_path;
+
+  let transcriptSize = 0;
+  try { transcriptSize = statSync(transcriptPath).size; } catch {}
+
+  const cached = sessionId ? readSessionEntry(sessionId) : null;
+
+  if (cached && cached.transcriptSize === transcriptSize) {
+    const agents = cached.agents || {};
+    return {
+      activity: renderActivityStr(agents, cached.activity),
+      lastUserMessage: cached.prompt,
+      _session: { activity: cached.activity, agents, prompt: cached.prompt, transcriptSize },
+    };
+  }
+
+  const lines = readTranscriptTail(transcriptPath);
+  if (!lines) return { activity: null, lastUserMessage: null, _session: { activity: null, agents: {}, prompt: null, transcriptSize } };
+
+  const running = parseRunningAgents(lines);
+  const skill = parseLastSkill(lines);
+  const prompt = parseLastUserMessage(lines);
+
+  const agentsMap = {};
+  running.forEach((a, i) => {
+    agentsMap[i] = { subagent_type: a.subagent_type, ts: a.startTime?.getTime() || Date.now() };
+  });
+
+  const now = Date.now();
+  const activity = skill
+    ? { name: skill, ts: (cached?.activity?.name === skill ? cached.activity.ts : now) }
+    : (cached?.activity || null);
+
+  return {
+    activity: renderActivityStr(running, activity),
+    lastUserMessage: prompt,
+    _session: { activity, agents: agentsMap, prompt, transcriptSize },
+  };
 }
 
 // --- cache ---
@@ -299,6 +341,43 @@ const LOCK_STALE_MS = 10_000;
 const CORAL_ONLINE_TTL_MS = 5_000;
 const CORAL_OFFLINE_TTL_MS = 2_000;
 const CORAL_HEALTH_TIMEOUT_MS = 200;
+
+// --- session state ---
+
+const SESSIONS_FILE = join(CACHE_DIR, ".coral-sessions.json");
+let _sessionsCache = null;
+
+function readSessions() {
+  if (_sessionsCache) return _sessionsCache;
+  try {
+    _sessionsCache = JSON.parse(readFileSync(SESSIONS_FILE, "utf-8"));
+  } catch {
+    _sessionsCache = {};
+  }
+  return _sessionsCache;
+}
+
+function readSessionEntry(sessionId) {
+  return readSessions()[sessionId] || null;
+}
+
+function writeSession(sessionId, data) {
+  try {
+    const all = readSessions();
+    const existing = all[sessionId];
+    if (existing && existing.ctx === data.ctx && existing.transcriptSize === data.transcriptSize) return;
+    all[sessionId] = { ...data, ts: Date.now() };
+    const now = Date.now();
+    for (const key of Object.keys(all)) {
+      if (now - (all[key]?.ts || 0) > SESSION_PRUNE_MS) delete all[key];
+    }
+    mkdirSync(CACHE_DIR, { recursive: true });
+    const tmpPath = `${SESSIONS_FILE}.tmp-${process.pid}`;
+    writeFileSync(tmpPath, JSON.stringify(all), { mode: 0o600 });
+    renameSync(tmpPath, SESSIONS_FILE);
+    _sessionsCache = all;
+  } catch {}
+}
 
 function readFullCache() {
   try {
@@ -969,6 +1048,13 @@ async function main() {
       }
     }
     output += "\n" + coralFinal;
+  }
+
+  // Write session state
+  const sessionId = input.session_id;
+  if (sessionId && transcript._session) {
+    const ctx = input.context_window?.used_percentage ?? null;
+    writeSession(sessionId, { ctx, ...transcript._session });
   }
 
   output = output

--- a/skills/statusline/coral-hud.mjs
+++ b/skills/statusline/coral-hud.mjs
@@ -608,6 +608,11 @@ function formatErrorIndicator(cache) {
   }
 }
 
+function cacheError(slot, errorKind, rateLimit = 0) {
+  writeCacheSlot(slot, null, true, rateLimit, errorKind);
+  return formatErrorIndicator({ error: true, errorKind, ts: Date.now(), rateLimit });
+}
+
 async function renderLimits() {
   const cached = readCacheSlot("claude");
   if (cached) {
@@ -628,19 +633,9 @@ async function renderLimits() {
     if (!token) return null;
 
     const resp = await fetchUsage(token, controller.signal);
-    if (resp?.unauthorized) {
-      writeCacheSlot("claude", null, true, 0, "auth");
-      return formatErrorIndicator({ error: true, errorKind: "auth", ts: Date.now(), rateLimit: 0 });
-    }
-    if (resp?.rateLimited) {
-      const newRL = readBackoffState("claude") + 1;
-      writeCacheSlot("claude", null, true, newRL, "rateLimit");
-      return formatErrorIndicator({ error: true, errorKind: "rateLimit", ts: Date.now(), rateLimit: newRL });
-    }
-    if (!resp) {
-      writeCacheSlot("claude", null, true, 0, "generic");
-      return formatErrorIndicator({ error: true, errorKind: "generic", ts: Date.now(), rateLimit: 0 });
-    }
+    if (resp?.unauthorized) return cacheError("claude", "auth");
+    if (resp?.rateLimited) return cacheError("claude", "rateLimit", readBackoffState("claude") + 1);
+    if (!resp) return cacheError("claude", "generic");
 
     const data = {
       fiveHour: resp.five_hour?.utilization,
@@ -799,51 +794,23 @@ async function renderCodexData() {
 
     if (result?.unauthorized) {
       const refreshed = await refreshCodexToken(creds.refreshToken, creds.clientId, controller.signal);
-      if (!refreshed) {
-        writeCacheSlot("codex", null, true, 0, "generic");
-        return {
-          kind: "error",
-          message: formatErrorIndicator({ error: true, errorKind: "generic", ts: Date.now(), rateLimit: 0 }),
-        };
-      }
+      if (!refreshed) return { kind: "error", message: cacheError("codex", "generic") };
       token = refreshed.accessToken;
       if (refreshed.refreshToken) writeBackCodexCredentials(creds, refreshed);
       result = await fetchCodexUsage(token, creds.accountId, controller.signal);
     }
 
-    if (result?.unauthorized) {
-      writeCacheSlot("codex", null, true, 0, "auth");
-      return {
-        kind: "error",
-        message: formatErrorIndicator({ error: true, errorKind: "auth", ts: Date.now(), rateLimit: 0 }),
-      };
-    }
+    if (result?.unauthorized) return { kind: "error", message: cacheError("codex", "auth") };
+    if (result?.rateLimited) return { kind: "error", message: cacheError("codex", "rateLimit", readBackoffState("codex") + 1) };
 
-    if (result?.rateLimited) {
-      const newRL = readBackoffState("codex") + 1;
-      writeCacheSlot("codex", null, true, newRL, "rateLimit");
-      return {
-        kind: "error",
-        message: formatErrorIndicator({ error: true, errorKind: "rateLimit", ts: Date.now(), rateLimit: newRL }),
-      };
-    }
-
-    if (result && !result.unauthorized && !result.rateLimited) {
+    if (result) {
       writeCacheSlot("codex", result);
       return { kind: "data", ...result };
     }
 
-    writeCacheSlot("codex", null, true, 0, "generic");
-    return {
-      kind: "error",
-      message: formatErrorIndicator({ error: true, errorKind: "generic", ts: Date.now(), rateLimit: 0 }),
-    };
+    return { kind: "error", message: cacheError("codex", "generic") };
   } catch {
-    writeCacheSlot("codex", null, true, 0, "generic");
-    return {
-      kind: "error",
-      message: formatErrorIndicator({ error: true, errorKind: "generic", ts: Date.now(), rateLimit: 0 }),
-    };
+    return { kind: "error", message: cacheError("codex", "generic") };
   } finally {
     clearTimeout(timer);
     releaseFetchLock(lock);
@@ -979,12 +946,11 @@ async function main() {
   const claudeModel = renderModel(input);
   const envModel = process.env.CORAL_CODEX_MODEL || "gpt-5.4";
   let col1Claude, col1Codex, col2Claude, col2Codex;
+  const addonTier = codexData.additionalLabel?.toLowerCase() || null;
+  const hasAddon = addonTier ? envModel.toLowerCase().endsWith(`-${addonTier}`) : false;
 
   if (codexData.kind === "data") {
-    const addonTier = codexData.additionalLabel?.toLowerCase() || null;
-    const hasAddon = addonTier ? envModel.toLowerCase().endsWith(`-${addonTier}`) : false;
-    const baseModel = hasAddon ? envModel.slice(0, envModel.lastIndexOf("-")) : envModel;
-    const codexModel = baseModel;
+    const codexModel = hasAddon ? envModel.slice(0, envModel.lastIndexOf("-")) : envModel;
 
     [col1Claude, col1Codex] = alignColumns(claudeModel, codexModel);
     const codexLimits = formatLimits(codexData.codex);
@@ -1013,8 +979,6 @@ async function main() {
 
   // Line 2: Codex
   if (codexData.kind === "data") {
-    const addonTier = codexData.additionalLabel?.toLowerCase() || null;
-    const hasAddon = addonTier ? envModel.toLowerCase().endsWith(`-${addonTier}`) : false;
     const sparkLabel = hasAddon ? `${GREEN}${codexData.additionalLabel}${RESET}` : codexData.additionalLabel;
     const sparkLimits = codexData.spark ? formatLimits(codexData.spark) : null;
     const sparkStr = sparkLimits ? `${sparkLabel} ${sparkLimits}` : null;


### PR DESCRIPTION
## Summary
- **Session state**: statusline writes ctx%, activity, agents, user prompt to `~/.claude/hud/.coral-sessions.json` keyed by session_id; ralph hook reads ctx% on Stop events to inject actual context usage; transcript parse cached by file size to skip redundant 512KB re-parse
- **cli-resolve hook**: replace `CLAUDE_PLUGIN_ROOT` env dependency with `import.meta.url`, add `hookEventName`, fix `updatedInput` to flat tool_input shape (was causing `H.includes` runtime error)
- **Ralph skill**: add no-confirm constraint and Step 3 hard gate — no time estimates or feasibility warnings
- **Plan skill**: clarify max-rounds exit uses workflow with next phase's provider
- **KB**: update `hooks-pretooluse-bash-updatedinput` with correct pattern, add `hooks-statusline-data-asymmetry`

## Test plan
- [x] `coral-cli -h` resolves correctly via hook rewrite
- [x] rtk hook coexists without conflict
- [x] Session state file written on statusline render
- [x] Ralph hook reads ctx% from session state on Stop events

🤖 Generated with [Claude Code](https://claude.com/claude-code)