### PR TITLE
fix: move migrate-coral-dir hook to Stop with decision:block

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -77,11 +77,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/migrate-coral-dir.mjs\"",
-            "timeout": 3
-          },
-          {
-            "type": "command",
             "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/kb-promote-gate.mjs\"",
             "timeout": 5
           },
@@ -128,6 +123,11 @@
     "Stop": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/migrate-coral-dir.mjs\"",
+            "timeout": 3
+          },
           {
             "type": "command",
             "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/ralph-loop.mjs\"",

--- a/hooks/migrate-coral-dir.mjs
+++ b/hooks/migrate-coral-dir.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * UserPromptSubmit hook — migrates .claude/coral/ to .coral/ (one-time).
+ * Stop hook — migrates .claude/coral/ to .coral/ (one-time).
  * If .coral/ already exists, skips (migration already done).
- * If .claude/coral/ exists without .coral/, moves and notifies Claude.
+ * If .claude/coral/ exists without .coral/, moves and blocks stop to notify Claude.
  * Fail-open: any error exits silently.
  */
 
@@ -23,10 +23,9 @@ try {
   renameSync(oldDir, newDir);
 
   console.log(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'UserPromptSubmit',
-      additionalContext: 'Coral data migrated from .claude/coral/ to .coral/. Update .gitignore (.claude/coral/* → .coral/*) then commit both changes.',
-    },
+    decision: 'block',
+    reason: 'Coral data migrated from .claude/coral/ to .coral/. Update .gitignore (.claude/coral/* → .coral/*) then commit both changes.',
+    systemMessage: '📦 Coral: migrated .claude/coral/ → .coral/',
   }));
 } catch {
   process.exit(0);


### PR DESCRIPTION
## Summary
- Migration hook moved from UserPromptSubmit to Stop event
- Uses `decision: 'block'` pattern instead of `additionalContext` — Claude is forced to actively process the migration notification before exiting
- SessionStart and UserPromptSubmit both proved unreliable for ensuring Claude acts on migration context

## Test plan
- [x] Fresh project with `.claude/coral/` but no `.coral/` — on first Stop, migration runs and Claude updates .gitignore
- [x] Project with `.coral/` already present — hook exits silently, no block

🤖 Generated with [Claude Code](https://claude.com/claude-code)