### PR TITLE
fix: update migration hook to mention .claude/coral symlink in gitignore

### DIFF
--- a/hooks/migrate-coral-dir.mjs
+++ b/hooks/migrate-coral-dir.mjs
@@ -48,7 +48,7 @@ try {
 
   console.log(JSON.stringify({
     decision: 'block',
-    reason: 'Coral data migrated: .claude/coral/kb/ → .kb/ (git-tracked). Other data moved to plugin storage. Add .kb/ to version control and remove .claude/coral/ from .gitignore if present.',
+    reason: 'Coral data migrated: .claude/coral/kb/ → .kb/ (git-tracked). Other data moved to plugin storage. Add .claude/coral (symlink) to .gitignore.',
     systemMessage: '📦 Coral: migrated .claude/coral/ → .kb/ + plugin data',
   }));
 } catch {


### PR DESCRIPTION
## Summary
- Migration hook reason text now instructs to add `.claude/coral` (symlink) to `.gitignore` instead of the old message about removing `.claude/coral/` from `.gitignore`

## Test plan
- [x] Migration hook fires → reason text mentions adding `.claude/coral` symlink to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)