### PR TITLE
Auto-add .claude/coral symlink to .gitignore

### DIFF
--- a/hooks/session-start.mjs
+++ b/hooks/session-start.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from 'node:child_process';
-import { existsSync, lstatSync, mkdirSync, readFileSync, symlinkSync } from 'node:fs';
+import { appendFileSync, existsSync, lstatSync, mkdirSync, readFileSync, symlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -63,9 +63,19 @@ function ensureProjectSymlink(projectDir) {
     const target = coralProjectDir(projectDir);
     mkdirSync(target, { recursive: true });
     symlinkSync(target, link);
+    ensureGitignore(projectDir, '.claude/coral');
   } catch {
     // fail-open
   }
+}
+
+function ensureGitignore(projectDir, entry) {
+  const gitignore = join(projectDir, '.gitignore');
+  if (existsSync(gitignore)) {
+    const content = readFileSync(gitignore, 'utf-8');
+    if (content.includes(entry)) return;
+  }
+  appendFileSync(gitignore, `\n${entry}\n`);
 }
 
 function readStdin() {


### PR DESCRIPTION
## Summary
- session-start hook now appends `.claude/coral` to the project's `.gitignore` after creating the symlink
- Prevents accidental commits of machine-specific symlink paths
- Skips if entry already exists in `.gitignore`

## Test plan
- [x] Symlink creation still works (defensive lstat check)
- [x] `.gitignore` append skips when entry already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)