### PR TITLE
.claude/coral symlink moved to init-project

### DIFF
--- a/hooks/session-start.mjs
+++ b/hooks/session-start.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from 'node:child_process';
-import { existsSync, lstatSync, mkdirSync, readFileSync, symlinkSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -22,8 +22,6 @@ try {
   const additionalContext = sessionId
     ? `SessionStart:session_id=${sessionId}\n\n${injectContent}`
     : injectContent;
-
-  if (projectDir) ensureProjectSymlink(projectDir);
 
   console.log(JSON.stringify({
     hookSpecificOutput: {
@@ -54,18 +52,6 @@ function resolveProjectSource(projectDir) {
 
 function coralProjectDir(projectDir) {
   return join(homedir(), '.coral', 'projects', resolveProjectSource(projectDir).replace(/\//g, '-'));
-}
-
-function ensureProjectSymlink(projectDir) {
-  try {
-    const link = join(projectDir, '.claude', 'coral');
-    try { if (lstatSync(link)) return; } catch { /* path doesn't exist, proceed */ }
-    const target = coralProjectDir(projectDir);
-    mkdirSync(target, { recursive: true });
-    symlinkSync(target, link);
-  } catch {
-    // fail-open
-  }
 }
 
 function readStdin() {

--- a/skills/init-project/SKILL.md
+++ b/skills/init-project/SKILL.md
@@ -188,6 +188,18 @@ argument-hint: "[existing|new]"
   cp -r "$STAGING/.claude/"* .claude/ && rm -rf "$STAGING"
   ```
 
+  Then create the coral project data symlink and add it to `.gitignore`:
+
+  ```bash
+  # Symlink .claude/coral → ~/.coral/projects/{slug}/
+  if [ ! -e .claude/coral ] && [ ! -L .claude/coral ]; then
+    mkdir -p "CORAL_PROJECT"
+    ln -s "CORAL_PROJECT" .claude/coral
+  fi
+  # Add to .gitignore if not already present
+  grep -qxF '.claude/coral' .gitignore 2>/dev/null || echo '.claude/coral' >> .gitignore
+  ```
+
   **Evidence gate**: Phase 3 is complete ONLY when generated files exist in their final locations.
   If no files were created, Phase 3 did not execute correctly.
 


### PR DESCRIPTION
## Summary
- Remove automatic `.claude/coral` symlink creation from session-start hook
- Move symlink + `.gitignore` entry to init-project skill (Phase 3c)
- Session-start hook no longer modifies project files — read-only only

## Why
Automatic symlink creation in session-start causes two problems:
1. Creates untracked `.claude/coral` that shows in `git status`
2. Fixing that requires auto-modifying `.gitignore`, which is a team-owned file

init-project is an explicit user action, making both changes appropriate.

## Test plan
- [x] session-start hook no longer creates symlink or touches .gitignore
- [x] init-project SKILL.md includes symlink + .gitignore step in Phase 3c

🤖 Generated with [Claude Code](https://claude.com/claude-code)