### PR TITLE
docs: README update — CORAL_KB_PATH, remove AGENT_TEAMS

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -84,8 +84,6 @@ my-project/
 /coral:discuss should we use microservices or a monolith?
 ```
 
-> **필수:** `.claude/settings.json`에 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 설정
-
 다양한 AI 페르소나가 각자의 관점에서 논쟁합니다.
 할 말이 있는 쪽이 먼저 발언하는 입찰 시스템. 상호 검증을 거치며 입장이 정제됩니다.
 최종 종합으로 마무리. 트랜스크립트는 `~/.coral/projects/{slug}/discuss/` 아래에 저장됩니다.
@@ -187,13 +185,13 @@ Claude가 놓치기 쉬운 것을 발견하면 (근본 원인, 주의사항, 기
 
 | 변수 | 기본값 | 설명 |
 |------|--------|------|
+| `CORAL_KB_PATH` | `~/.coral/kb` | KB 저장 경로 지정 |
 | `CORAL_CODEX_MODEL` | `gpt-5.4` | Codex CLI 기본 모델 |
 | `CORAL_CODEX_EFFORT` | `xhigh` | Codex 추론 노력도 (`low`, `medium`, `high`, `xhigh`) |
 | `CORAL_CLAUDE_MODEL_CAP` | `opus` | Claude 최대 모델 티어 (`opus`, `sonnet`, `haiku`). 상위 티어 요청은 자동 다운그레이드. |
 | `CORAL_MAX_SESSIONS` | `10` | 최대 동시 CLI 세션 수 (1–10) |
 | `CORAL_DISCUSS_MAX_EPOCHS` | `2` | 토론 자동 종료 전 최대 에포크 (1–10) |
 | `CORAL_DISCUSS_TTL_DAYS` | `0` | 완료된 토론 세션 자동 정리 기한 (일, 0 = 비활성화) |
-| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | _(미설정)_ | `/coral:discuss` **필수**. `1`로 설정. |
 
 > **팁:** Coral의 워크플로우와 리뷰 에이전트는 기본적으로 Opus를 사용합니다. Pro 구독이거나 사용량을 절약하고 싶다면 `CORAL_CLAUDE_MODEL_CAP=sonnet`으로 설정하여 모든 Claude 서브에이전트 호출을 Sonnet 티어로 제한할 수 있습니다.
 `.claude/settings.json`에 설정 (세션 간 유지):
@@ -201,7 +199,7 @@ Claude가 놓치기 쉬운 것을 발견하면 (근본 원인, 주의사항, 기
 ```json
 {
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CORAL_KB_PATH": "/path/to/my-obsidian-vault",
     "CORAL_DISCUSS_MAX_EPOCHS": "2",
     "CORAL_DISCUSS_TTL_DAYS": "0"
   }

--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ Look familiar? Browse this repository's [`.claude/`](.claude/) folder.
 /coral:discuss should we use microservices or a monolith?
 ```
 
-> **Requires:** `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in `.claude/settings.json`
-
 Multiple AI personas argue from different angles.
 Bid-based turn-taking surfaces the most urgent responses first.
 Positions evolve through genuine cross-examination.
@@ -193,13 +191,13 @@ Mistakes aren't repeated across sessions.
 
 | Variable | Default | Description |
 |---|---|---|
+| `CORAL_KB_PATH` | `~/.coral/kb` | Custom KB storage path |
 | `CORAL_CODEX_MODEL` | `gpt-5.4` | Default Codex CLI model |
 | `CORAL_CODEX_EFFORT` | `xhigh` | Codex reasoning effort (`low`, `medium`, `high`, `xhigh`) |
 | `CORAL_CLAUDE_MODEL_CAP` | `opus` | Maximum Claude model tier (`opus`, `sonnet`, `haiku`). Requests for higher tiers are downgraded. |
 | `CORAL_MAX_SESSIONS` | `10` | Max concurrent CLI sessions (1–10) |
 | `CORAL_DISCUSS_MAX_EPOCHS` | `2` | Max epochs before discussion auto-ends (1–10) |
 | `CORAL_DISCUSS_TTL_DAYS` | `0` | Days before completed discuss sessions are auto-pruned (0 = disabled) |
-| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | _(unset)_ | **Required** for `/coral:discuss`. Set to `1`. |
 
 > **Tip:** Coral's workflow and review agents use Opus by default. If you're on a Pro plan or want to conserve usage, set `CORAL_CLAUDE_MODEL_CAP=sonnet` to cap all Claude subagent calls at Sonnet tier.
 
@@ -208,7 +206,7 @@ Set in `.claude/settings.json` (persists across sessions):
 ```json
 {
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CORAL_KB_PATH": "/path/to/my-obsidian-vault",
     "CORAL_DISCUSS_MAX_EPOCHS": "2",
     "CORAL_DISCUSS_TTL_DAYS": "0"
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ Environment variables, config files, and the plugin manifest.
 | `CORAL_DISCUSS_QUOTA_PER_EPOCH` | `3` | Speaking turns per agent per epoch (1–10). Stored per-session at creation time. |
 | `CORAL_DISCUSS_TTL_DAYS` | `0` | Days before completed discuss sessions are eligible for pruning (0 = disabled) |
 | `CORAL_BACKEND_IDLE_MS` | `21600000` | Backend daemon idle timeout in milliseconds (default 6 hours) |
-| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | _(unset)_ | Required for `/coral:discuss` and `/coral:ralph --team`. Set to `1`. |
+| `CORAL_KB_PATH` | `~/.coral/kb` | Custom KB storage path |
 
 ### Usage - Shell
 
@@ -25,7 +25,7 @@ Environment variables, config files, and the plugin manifest.
 export CORAL_CODEX_MODEL=gpt-5.4
 export CORAL_CODEX_EFFORT=high
 export CORAL_DISCUSS_BID_THRESHOLD=50
-export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+export CORAL_KB_PATH=/path/to/my-obsidian-vault
 ```
 
 ### Usage - .claude/settings.json

--- a/docs/core-modules.md
+++ b/docs/core-modules.md
@@ -89,7 +89,7 @@ Connection info at `~/.claude/coral/backend.json`. Stores `{ pid, port, token, v
 
 ### src/execution/session-manager.ts - Persisted Session Registry
 
-`SessionManager`: persisted session registry under `~/.claude/coral/execution/sessions/<project-hash>/`. Provider-aware methods: `allocate(provider, name, model, cwd)`, `get(provider, sessionId)`, `list(provider)`, `setConversationRef(sessionId, ref)`, `setNonResumable(sessionId)`, `claimForJobSync(sessionId, jobId)` / `claimForJobAtomic(sessionId, jobId)` (single-active-job invariant), `releaseJob(sessionId, jobId)`. Atomic writes (`.tmp` + rename). Includes migration from old runner session format. See `src/execution/session-manager.ts`.
+`SessionManager`: persisted session registry under `~/.claude/coral/sessions/<project-hash>/`. Provider-aware methods: `allocate(provider, name, model, cwd)`, `get(provider, sessionId)`, `list(provider)`, `setConversationRef(sessionId, ref)`, `setNonResumable(sessionId)`, `claimForJobSync(sessionId, jobId)` / `claimForJobAtomic(sessionId, jobId)` (single-active-job invariant), `releaseJob(sessionId, jobId)`. Atomic writes (`.tmp` + rename). Includes migration from old runner session format. See `src/execution/session-manager.ts`.
 
 ---
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -26,7 +26,7 @@ All hook scripts are **Node.js ESM** (`.mjs`). They read input JSON from stdin, 
 
 Injects the plugin's INJECT.md content into Claude's context at the start of every session. This ensures Claude always receives the behavioral guidelines (Clarity First, Surgical Changes, etc.) and KB system instructions.
 
-Implementation: `hooks/session-start.mjs` reads `INJECT.md` from the plugin root, resolves the active source slug from `CLAUDE_PROJECT_DIR`, replaces `{{CORAL_PROJECTS}}` with `~/.coral/projects/{slug}` and `{{PROJECT_SOURCE}}` with the project source identifier, and returns the result via `hookSpecificOutput.additionalContext`.
+Implementation: `hooks/session-start.mjs` reads `INJECT.md` from the plugin root, resolves the active source slug from `CLAUDE_PROJECT_DIR`, replaces `{{CORAL_PROJECTS}}` with `~/.coral/projects/{slug}`, `{{PROJECT_SOURCE}}` with the project source identifier, and `{{CORAL_KB}}` with the KB root path (from `CORAL_KB_PATH` env var or default `~/.coral/kb`), and returns the result via `hookSpecificOutput.additionalContext`.
 
 > **Note**: Codex sessions receive INJECT.md through a separate mechanism - the MCP server prepends it to the prompt in `executeOneShot()`. See [Core Modules](./core-modules.md) for details.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -63,7 +63,6 @@ Consecutive `/coral:codex` calls without `session` automatically continue the pr
 
 ## /coral:discuss - Moderated Discussion
 
-Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` environment variable.
 
 ```bash
 /coral:discuss "Should we adopt microservices?"


### PR DESCRIPTION
## Summary
- Add `CORAL_KB_PATH` to configuration table and settings.json example
- Remove `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` from discuss requirements and config (no longer needed)
- Both EN and KO READMEs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)