### PR TITLE
fix: plan exit condition clarity + severity reclassification

### DIFF
--- a/methods/HOW-COMPLETE.md
+++ b/methods/HOW-COMPLETE.md
@@ -1,8 +1,7 @@
 # HOW to Evaluate Completion
 
-Apply this alongside the existing exit condition (step 4f).
-The existing severity check ("both reviewers no CRITICAL/HIGH") remains necessary.
-These are additional necessary conditions — both must also be satisfied for a round to pass.
+Apply this alongside the caller's severity gate.
+These are additional necessary conditions — the caller's severity gate AND all conditions below must pass for a round to exit.
 
 ## Frame Stability Condition
 
@@ -19,7 +18,7 @@ Frame stability is achieved when the most recent round produced no FRAME-level f
 ## Counterexample Type Coverage
 
 Track which counterexample types from HOW-REVIEW's checklist have been explicitly probed across all rounds.
-This tracking lives in the round summary (step 4e) under `### Counterexample Coverage`.
+This tracking lives in the round summary under `### Counterexample Coverage`.
 
 Format:
 ```
@@ -69,8 +68,7 @@ A round that introduces new FRAME findings in a late round is a regression — t
 ## Combined Exit Rule
 
 A round passes when ALL of the following are true:
-1. Both reviewers returned no CRITICAL or HIGH findings
-   *(existing rule — MEDIUM/LOW findings may be fixed inline without re-verification)*
-2. No FRAME-level findings in this round *(Frame Stability)*
+1. Caller's severity gate passed (no CRITICAL or HIGH after synthesis — reclassification happens at synthesis time, never after fixes)
+2. No FRAME-level findings in this round, regardless of severity *(Frame Stability)*
 3. All major counterexample types have been explored across rounds *(Coverage)*
 4. Refutation effort appears genuine *(Effort Assessment)*

--- a/methods/HOW-SYNTHESIZE.md
+++ b/methods/HOW-SYNTHESIZE.md
@@ -1,6 +1,6 @@
 # HOW to Synthesize Review Feedback
 
-Apply this methodology when synthesizing reviewer feedback (step 4c). You are operating as **Vada** (truth-seeker).
+Apply this methodology when synthesizing reviewer feedback. You are operating as **Vada** (truth-seeker).
 Your job is to reconstruct from adversarial destruction —
 not to defend your draft, not to pick a side, but to find what is actually true.
 
@@ -20,6 +20,32 @@ it means the plan's problem statement needs correction. Do not downgrade it base
 
 **Rule**: A FRAME-level finding classified as Adapt requires you to explicitly re-examine
 the plan's problem statement before making any structural changes.
+
+## Severity Reclassification
+
+Reclassification happens here, at synthesis time — not after fixes are applied.
+The caller's exit condition uses the reclassified severity as the as-returned value.
+
+**Upgrade** (existing): A FRAME-level Adopt finding is always CRITICAL, regardless of reviewer's stated severity.
+
+**Downgrade**: The synthesizer may lower a finding's severity when the reviewer's assessment is unjustified.
+Required: explicit rationale citing why the stated severity does not hold.
+
+| Downgrade allowed | Downgrade blocked |
+|-------------------|-------------------|
+| Finding contradicts the codebase's actual state | FRAME-level Adopt (always CRITICAL) |
+| Finding is stylistic preference stated as HIGH | Finding confirmed by both reviewers independently |
+| Finding duplicates another at different severity | Finding traces to a concrete failure mode |
+| Severity disproportionate to impact — trivial fix, no downstream effect, self-evident resolution | — |
+
+Format in the Round Summary:
+```
+| # | Source | Finding | Severity | Reclassified | Rationale |
+|---|--------|---------|----------|-------------|-----------|
+| 3 | Architect | ... | HIGH | → MEDIUM | No file:line, stylistic preference |
+```
+
+If not reclassified, omit the Reclassified column for that row.
 
 **Adopt vs Adapt**: A reviewer says "the API should use streaming responses."
 **Adopt** means you agree with both the diagnosis and the solution — add streaming as specified.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -146,20 +146,24 @@ Strip `--codex`, `--deep`, and `--no-handoff` flags before passing the prompt to
 
     **4d. Exit Condition**
 
-    **If `--deep`**: Read `CORAL_METHODS/HOW-COMPLETE.md` and apply its additional completion criteria alongside the rules below.
+    **Step 1 — Classify**: Scan the Round Summary table. Record `max_severity` = highest severity after synthesis (reclassified severity if 4b applied one, otherwise reviewer's original). Never reclassify here — reclassification happens at synthesis time (4b), not at exit time.
 
-    **Step 1 — Classify**: Scan the Round Summary table. Record `max_severity` = highest severity any reviewer returned this round. Use the severity AS RETURNED — never reclassify based on whether fixes were applied.
-
-    **Step 2 — Decide**:
+    **Step 2 — Severity gate**:
 
     | `max_severity` | Round | Verdict | Action |
     |----------------|-------|---------|--------|
     | CRITICAL or HIGH | < 5 | **Continue** | → 4a (same phase, next round) |
     | CRITICAL or HIGH | = 5 | **Max rounds** | → next phase, or AskUserQuestion if last |
-    | MEDIUM or LOW | any | **Fix and pass** | → exit phase |
-    | ≤ LOW only | any | **Clean pass** | → exit phase (+ HOW-COMPLETE if `--deep`) |
+    | MEDIUM | any | **Fix and pass** | → fix inline, then Step 3 |
+    | LOW or none | any | **Clean pass** | → Step 3 |
 
-    > **Hard rule**: a resolved/fixed HIGH is still HIGH for this decision. Fixes may introduce new issues — re-verification catches them. Never downgrade `max_severity` based on post-round edits.
+    > **Hard rule**: severity reclassification happens only during synthesis (4b), never after fixes. A finding that was HIGH after synthesis stays HIGH at exit — fixing it does not lower the severity. Fixes may introduce new issues; re-verification catches them.
+
+    **Step 3 — Completion gate** (`--deep` only, otherwise exit phase):
+
+    If `--deep`: Read `CORAL_METHODS/HOW-COMPLETE.md`. Apply ALL conditions in its Combined Exit Rule.
+    If any condition fails → **Continue** (→ 4a, next round).
+    Exit phase only when both Step 2 AND Step 3 pass.
 
     ### 4e. Execution Order
 


### PR DESCRIPTION
## Summary
- Plan 4d: split into Step 2 (severity gate) + Step 3 (completion gate) — `--deep` HOW-COMPLETE is now a blocking step, not an ignorable one-liner
- Fix row 3/4 overlap in decide table (MEDIUM vs LOW now distinct)
- HOW-SYNTHESIZE: add Severity Reclassification section — synthesizer can downgrade inflated severity with explicit rationale at synthesis time (4b), never after fixes (4d)
- HOW-COMPLETE: align severity language with plan ("after synthesis")
- Remove step number references from HOW methods (caller-agnostic)

## Test plan
- [x] Run `/coral:plan --deep` — verify HOW-COMPLETE is read and applied as blocking gate at Step 3
- [x] Run `/coral:plan` (no --deep) — verify severity gate table works standalone, exits at Step 2
- [x] Verify reviewer HIGH on trivial finding gets downgraded at synthesis with rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)