### PR TITLE
fix: replace SKILL.md shell commands with hook-based path injection

### DIFF
--- a/hooks/coral-skill-vars.mjs
+++ b/hooks/coral-skill-vars.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import { execSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+
+const CORAL_SKILLS = /\/(?:coral:)?(?:plan|preplan|analyze|ralph|bid|discuss|init-project|bugfix|code-simplify)\b/;
+
+try {
+  const input = JSON.parse(await readStdin());
+  const event = input.hook_event_name;
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  const projectDir = process.env.CLAUDE_PROJECT_DIR;
+
+  if (!pluginRoot || !projectDir) process.exit(0);
+
+  let matched = false;
+
+  if (event === 'UserPromptSubmit') {
+    const message = input.user_message || input.message || input.prompt || '';
+    matched = CORAL_SKILLS.test(message);
+  } else if (event === 'PreToolUse') {
+    const skill = input.tool_input?.skill || '';
+    matched = /^coral:/.test(skill);
+  }
+
+  if (!matched) process.exit(0);
+
+  const context = [
+    `CORAL_PROJECT: ${coralProjectDir(projectDir)}`,
+    `CORAL_AGENTS: ${join(pluginRoot, 'agents')}/`,
+    `CORAL_METHODS: ${join(pluginRoot, 'methods')}/`,
+  ].join('\n');
+
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: event,
+      additionalContext: `Coral skill path variables — substitute these for the named placeholders in the skill body:\n${context}`,
+    },
+  }));
+} catch {
+  process.exit(0);
+}
+
+function resolveProjectSource(projectDir) {
+  try {
+    const remote = execSync('git remote get-url origin', {
+      cwd: projectDir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim().replace(/\.git$/, '');
+    const sshPath = remote.match(/^[^@]+@[^:]+:(.+)$/)?.[1];
+    const rawPath = sshPath ?? remote.replace(/^[^:]+:\/\//, '').replace(/^[^@/]+@/, '').replace(/^[^/]+\/+/, '');
+    const segments = rawPath.split('/').filter(Boolean);
+    if (segments.length >= 2) return `${segments.at(-2)}/${segments.at(-1)}`;
+  } catch {
+    // fall through
+  }
+  return `local/${basename(projectDir)}`;
+}
+
+function coralProjectDir(projectDir) {
+  return join(homedir(), '.coral', 'projects', resolveProjectSource(projectDir).replace(/\//g, '-'));
+}
+
+function readStdin() {
+  return new Promise(resolve => {
+    let data = '';
+    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve('{}'));
+  });
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -89,6 +89,11 @@
             "type": "command",
             "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/kb-memo-reminder.mjs\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/coral-skill-vars.mjs\"",
+            "timeout": 3
           }
         ]
       }
@@ -106,6 +111,11 @@
             "type": "command",
             "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/ralph-loop.mjs\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "test -d \"${CLAUDE_PLUGIN_ROOT}\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/hooks/coral-skill-vars.mjs\"",
+            "timeout": 3
           }
         ]
       },

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -4,10 +4,6 @@ description: "Use when deep investigation is needed — project structure, requi
 argument-hint: "[--codex] [investigation target or question]"
 ---
 
-> **CORAL_AGENTS**: !`echo ~/.claude/plugins/cache/coral/coral/*/agents/`
-> **CORAL_METHODS**: !`echo ~/.claude/plugins/cache/coral/coral/*/methods/`
-> **CORAL_PROJECT**: !`url=$(git remote get-url origin 2>/dev/null) && echo ~/.coral/projects/$(echo "$url" | sed -E 's#.*[:/]([^/]+/[^/.]+)(\.git)?$#\1#' | tr '/' '-') || echo ~/.coral/projects/local-$(basename $PWD)`
-
 # Deep Analysis & Investigation
 
 <Role>

--- a/skills/bid/SKILL.md
+++ b/skills/bid/SKILL.md
@@ -4,8 +4,6 @@ description: Submit a bid or speech in an active --user discuss session
 argument-hint: "<score>, <thought> | <speech content>"
 ---
 
-> **CORAL_PROJECT**: !`url=$(git remote get-url origin 2>/dev/null) && echo ~/.coral/projects/$(echo "$url" | sed -E 's#.*[:/]([^/]+/[^/.]+)(\.git)?$#\1#' | tr '/' '-') || echo ~/.coral/projects/local-$(basename $PWD)`
-
 # Bid / Speak in Active Discussion
 
 Submit a bid or speech as the `user` observer in a running `--user` discuss session.

--- a/skills/bugfix/SKILL.md
+++ b/skills/bugfix/SKILL.md
@@ -4,8 +4,6 @@ description: "Use when encountering a bug, error, or unexpected behavior that ne
 argument-hint: "[--codex] <bug description or error message>"
 ---
 
-> **CORAL_AGENTS**: !`echo ~/.claude/plugins/cache/coral/coral/*/agents/`
-
 # Bug Debugging
 
 Diagnose bugs, plan fixes, and execute - end-to-end.

--- a/skills/code-simplify/SKILL.md
+++ b/skills/code-simplify/SKILL.md
@@ -4,8 +4,6 @@ description: "Use when code needs simplification — recently modified code by d
 argument-hint: "[--codex] <scope or prompt>"
 ---
 
-> **CORAL_AGENTS**: !`echo ~/.claude/plugins/cache/coral/coral/*/agents/`
-
 # Code Simplification
 
 Simplify and refine code for clarity and maintainability while preserving functionality.

--- a/skills/discuss/SKILL.md
+++ b/skills/discuss/SKILL.md
@@ -4,8 +4,6 @@ description: "Use when a topic benefits from multiple perspectives debating befo
 argument-hint: "[--user] [topic] [--hints axis1:pos1,pos2 axis2:pos1,pos2]"
 ---
 
-> **CORAL_PROJECT**: !`url=$(git remote get-url origin 2>/dev/null) && echo ~/.coral/projects/$(echo "$url" | sed -E 's#.*[:/]([^/]+/[^/.]+)(\.git)?$#\1#' | tr '/' '-') || echo ~/.coral/projects/local-$(basename $PWD)`
-
 # Moderated Multi-Agent Discussion
 
 Start a backend-managed structured discussion with AI agents.

--- a/skills/init-project/SKILL.md
+++ b/skills/init-project/SKILL.md
@@ -4,8 +4,6 @@ description: "Use when setting up a new or existing project for AI-assisted deve
 argument-hint: "[existing|new]"
 ---
 
-> **CORAL_PROJECT**: !`url=$(git remote get-url origin 2>/dev/null) && echo ~/.coral/projects/$(echo "$url" | sed -E 's#.*[:/]([^/]+/[^/.]+)(\.git)?$#\1#' | tr '/' '-') || echo ~/.coral/projects/local-$(basename $PWD)`
-
 # Project Initialization
 
 <Role>

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -4,9 +4,6 @@ description: "Use when a task needs structured planning before implementation. S
 argument-hint: "[--deep] [--codex] [task description]"
 ---
 
-> **CORAL_METHODS**: !`echo ~/.claude/plugins/cache/coral/coral/*/methods/`
-> **CORAL_PROJECT**: !`url=$(git remote get-url origin 2>/dev/null) && echo ~/.coral/projects/$(echo "$url" | sed -E 's#.*[:/]([^/]+/[^/.]+)(\.git)?$#\1#' | tr '/' '-') || echo ~/.coral/projects/local-$(basename $PWD)`
-
 # Planning
 
 Execute a multi-round planning session with architect/critic review.

--- a/skills/preplan/SKILL.md
+++ b/skills/preplan/SKILL.md
@@ -4,9 +4,6 @@ description: "Use when a problem needs clarification and agreement before planni
 argument-hint: "[--codex] <issue or topic>"
 ---
 
-> **CORAL_METHODS**: !`echo ~/.claude/plugins/cache/coral/coral/*/methods/`
-> **CORAL_PROJECT**: !`url=$(git remote get-url origin 2>/dev/null) && echo ~/.coral/projects/$(echo "$url" | sed -E 's#.*[:/]([^/]+/[^/.]+)(\.git)?$#\1#' | tr '/' '-') || echo ~/.coral/projects/local-$(basename $PWD)`
-
 # Pre-plan
 
 Structured problem-definition conversation with the user before planning begins.

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -4,9 +4,6 @@ description: "Use when implementing a plan or executing a prompt that requires v
 argument-hint: "[--red] [--codex] [--team] [task description]"
 ---
 
-> **CORAL_AGENTS**: !`echo ~/.claude/plugins/cache/coral/coral/*/agents/`
-> **CORAL_PROJECT**: !`url=$(git remote get-url origin 2>/dev/null) && echo ~/.coral/projects/$(echo "$url" | sed -E 's#.*[:/]([^/]+/[^/.]+)(\.git)?$#\1#' | tr '/' '-') || echo ~/.coral/projects/local-$(basename $PWD)`
-
 # Persistent Execution with Verification
 
 Announce at start: "Using ralph to execute this task with verification loop."


### PR DESCRIPTION
## Summary
- SKILL.md `!` backtick shell commands (`$()`, `node`, `.claude` paths) were blocked by Claude Code's security policy in non-dangerous permission mode, breaking all 9 coral slash commands (`/plan`, `/analyze`, `/ralph`, etc.)
- New `coral-skill-vars.mjs` hook injects CORAL_PROJECT, CORAL_AGENTS, CORAL_METHODS via UserPromptSubmit and PreToolUse(Skill) events — computed in Node.js with no security restrictions
- Removed all `> **CORAL_***: !`...`` lines from 9 SKILL.md files — no shell evaluation needed

## Test plan
- [x] `/coral:plan` (Skill tool path) — UserPromptSubmit hook injects vars
- [x] `Skill("coral:plan")` (Claude tool call) — PreToolUse hook injects vars
- [x] CORAL_PROJECT resolves correctly: `/home/kang/.coral/projects/kangig94-coral`
- [x] Verify on a clean install without `--dangerously-skip-permissions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)