### PR TITLE
fix: replace agent CORAL_METHODS backtick with Bash tool notation

### DIFF
--- a/.claude/rules/plugin-extension.md
+++ b/.claude/rules/plugin-extension.md
@@ -30,11 +30,13 @@ plugin files from project files. Three read patterns and one spawn pattern exist
 | `CORAL_METHODS/xxx.md` | **Read** the file (Read/Glob tool) | `CORAL_METHODS/HOW-REVIEW.md` |
 | `coral:xxx` | **Spawn** subagent (Task tool) | `coral:scanner` |
 
-- Every file using these aliases must define them at the top (after frontmatter):
+- **Skills**: `coral-skill-vars.mjs` hook injects CORAL_PROJECT, CORAL_AGENTS, CORAL_METHODS
+  as additionalContext on UserPromptSubmit and PreToolUse(Skill). No `!` backtick needed in SKILL.md.
+- **Agents**: Define path aliases at the top (after frontmatter) using Bash tool notation:
   ```
-  > **CORAL_AGENTS**: !`echo ~/.claude/plugins/cache/coral/coral/*/agents/`
-  > **CORAL_SKILLS**: !`echo ~/.claude/plugins/cache/coral/coral/*/skills/`
-  > **CORAL_METHODS**: !`echo ~/.claude/plugins/cache/coral/coral/*/methods/`
+  > **CORAL_AGENTS**: Bash(echo ~/.claude/plugins/cache/coral/coral/*/agents/)
+  > **CORAL_SKILLS**: Bash(echo ~/.claude/plugins/cache/coral/coral/*/skills/)
+  > **CORAL_METHODS**: Bash(echo ~/.claude/plugins/cache/coral/coral/*/methods/)
   ```
 - Never use bare `agents/xxx.md`, `skills/xxx/`, or `methods/xxx.md` — these resolve relative
   to the user's project directory, which breaks when the plugin is used outside its own repo.

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -7,7 +7,7 @@ deep: bool
 disallowedTools: Write, Edit
 ---
 
-> **CORAL_METHODS**: !`echo ~/.claude/plugins/cache/coral/coral/*/methods/`
+> **CORAL_METHODS**: Bash(echo ~/.claude/plugins/cache/coral/coral/*/methods/)
 
 <Agent_Prompt>
   <Role>

--- a/agents/critic.md
+++ b/agents/critic.md
@@ -7,7 +7,7 @@ deep: bool
 disallowedTools: Write, Edit
 ---
 
-> **CORAL_METHODS**: !`echo ~/.claude/plugins/cache/coral/coral/*/methods/`
+> **CORAL_METHODS**: Bash(echo ~/.claude/plugins/cache/coral/coral/*/methods/)
 
 <Agent_Prompt>
   <Role>

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -7,7 +7,7 @@ deep: bool
 disallowedTools: Write, Edit
 ---
 
-> **CORAL_METHODS**: !`echo ~/.claude/plugins/cache/coral/coral/*/methods/`
+> **CORAL_METHODS**: Bash(echo ~/.claude/plugins/cache/coral/coral/*/methods/)
 
 <Agent_Prompt>
   <Role>

--- a/agents/gap-finder.md
+++ b/agents/gap-finder.md
@@ -6,7 +6,7 @@ methods: [HOW-ELICIT, HOW-PROVENANCE]
 disallowedTools: Write, Edit
 ---
 
-> **CORAL_METHODS**: !`echo ~/.claude/plugins/cache/coral/coral/*/methods/`
+> **CORAL_METHODS**: Bash(echo ~/.claude/plugins/cache/coral/coral/*/methods/)
 
 <Agent_Prompt>
   <Role>

--- a/agents/resolver.md
+++ b/agents/resolver.md
@@ -5,7 +5,7 @@ model: opus
 methods: [HOW-SYNTHESIZE, HOW-RESOLVE]
 ---
 
-> **CORAL_METHODS**: !`echo ~/.claude/plugins/cache/coral/coral/*/methods/`
+> **CORAL_METHODS**: Bash(echo ~/.claude/plugins/cache/coral/coral/*/methods/)
 
 <Agent_Prompt>
   <Role>

--- a/agents/scanner.md
+++ b/agents/scanner.md
@@ -7,7 +7,7 @@ deep: bool
 disallowedTools: Write, Edit
 ---
 
-> **CORAL_METHODS**: !`echo ~/.claude/plugins/cache/coral/coral/*/methods/`
+> **CORAL_METHODS**: Bash(echo ~/.claude/plugins/cache/coral/coral/*/methods/)
 
 <Agent_Prompt>
   <Role>


### PR DESCRIPTION
## Summary
- Replace `!` backtick shell notation in 6 agent files (debugger, resolver, architect, critic, gap-finder, scanner) with `Bash(echo ...)` tool notation
- Update `.claude/rules/plugin-extension.md` cross-reference convention to document the new skill (hook injection) and agent (Bash notation) patterns
- Follow-up to #127 — agents don't go through SKILL.md loader so the backtick was never evaluated, but this makes intent explicit

## Test plan
- [x] Agent files still contain correct CORAL_METHODS path reference
- [x] plugin-extension.md documents both skill and agent patterns
- [x] Verify agent subagents resolve CORAL_METHODS correctly when spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)