### PR TITLE
docs: rewrite README and sync architecture docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+## Development
+
+```bash
+npm install
+npm run build     # TypeScript compile + esbuild bundle
+npm test          # Run tests with vitest
+npm run dev       # TypeScript watch mode
+```
+
+## Git Workflow
+
+- **`main`**: Release branch. Always deployable.
+- **`dev`**: Integration branch. Direct commits allowed for small changes.
+- **Feature branches**: Branch from `dev`, rebase merge back via PR.
+- **Release**: Squash merge `dev` → `main` via PR.
+
+Merge policy:
+- **feature → dev**: rebase (preserve individual commits)
+- **dev → main**: squash (one commit per release, traceable via `(#N)`)
+
+## Commit Style
+
+Prefix: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+Imperative mood: "add session fork support" not "added" or "adds"

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,9 +1,6 @@
 # 🪸 Coral
 
-Claude Code는 이미 코딩할 줄 압니다. Coral은 *당신의 방식대로* 코딩하도록 가르칩니다.
-
-컨벤션 적용, 워크플로우 구조화, 의사결정을 다각도로 검토 —
-모든 Claude Code 세션에서 동작하는 슬래시 커맨드로 제공됩니다.
+Claude Code는 이미 코딩할 줄 압니다. Coral은 *당신의 방식대로* 일하도록 가르칩니다.
 
 ## 설치
 
@@ -13,24 +10,19 @@ Claude Code는 이미 코딩할 줄 압니다. Coral은 *당신의 방식대로*
 /plugin marketplace add https://github.com/kangig94/coral
 /plugin install coral
 
-# Codex CLI (선택 - `codex-*` 스킬과 `--codex` 플래그 활성화):
-npm install -g @openai/codex  # v0.104+
+# Codex CLI (선택 — --codex 교차 모델 위임 활성화):
+npm install -g @openai/codex
 ```
 
 ## 바로 사용해보기
 
-설정 불필요. 아무 Claude Code 세션에서, 기존 프로젝트에서 바로 실행:
+기존 프로젝트에서 바로 실행:
 
 ```
 /coral:analyze what does this codebase do?
 ```
 
-Coral이 프로젝트를 읽고 구조화된 분석 결과를 반환합니다:
-아키텍처, 모듈, 진입점, 의존성 그래프. 파일 생성 없음, 설정 불필요.
-
-## 이렇게 활용하세요
-
-### 프로젝트 구조화
+## 프로젝트 구조화
 
 https://github.com/user-attachments/assets/881f1a14-9f4f-4d3d-8023-59610eb13ac4
 
@@ -38,56 +30,89 @@ https://github.com/user-attachments/assets/881f1a14-9f4f-4d3d-8023-59610eb13ac4
 /coral:init-project
 ```
 
-Coral이 기술 스택을 스캔하고, 리뷰어 검증을 거쳐 `.claude/` 디렉토리를 생성합니다 —
-컨벤션, 에이전트, 아키텍처 문서를 프로젝트에 맞게 생성합니다.
-
-생성된 에이전트는 기성품이 아닙니다 — 프로젝트의 청중에 맞게 보정된
-루브릭 기반 다차원 평가 체계를 내장합니다.
-Claude가 일반적인 기본값이 아닌 당신의 규칙을 따르게 됩니다.
+Coral이 기술 스택을 스캔하고 `.claude/` 디렉토리를 생성합니다 — 컨벤션, 리뷰 에이전트, 아키텍처 문서를 프로젝트에 맞게.
 
 ```bash
-# 기존 프로젝트 - 그냥 실행, Coral이 자동 스캔
-/coral:init-project
-
-# 기술 스택 힌트 (소스 파일이 적을 때)
-/coral:init-project "React + FastAPI"
-
-# 상세 설명 (신규 또는 복잡한 프로젝트)
-/coral:init-project "multi-tenant SaaS REST API with Go, must be serverless"
-
-# 참조 자료 포함
-/coral:init-project "CLI tool like ref/existing-cli, see docs/spec.md"
+/coral:init-project                                          # 기존 프로젝트
+/coral:init-project "React + FastAPI"                        # 기술 스택 힌트
+/coral:init-project "multi-tenant SaaS REST API with Go"     # 상세 설명
 ```
 
-생성되는 구조:
+<details>
+<summary>생성되는 구조</summary>
+
 ```
 my-project/
 + .claude/
-+   CLAUDE.md                 <- 프로젝트 허브: 빌드 명령, 워크플로우, 핵심 규칙
++   CLAUDE.md                 ← 프로젝트 허브: 빌드 명령, 워크플로우, 핵심 규칙
 +   agents/
-+     code-critic.md          <- 코드 품질 리뷰
-+     ...                     <- 도메인 에이전트 (React, Go, ML, infra 등)
++     code-critic.md          ← 코드 품질 리뷰
++     ...                     ← 도메인 에이전트 (React, Go, ML, infra 등)
 +   rules/
-+     conventions.md          <- 네이밍, git, 스타일
-+     ...                     <- 도메인 규칙, 파일 경로 기반 자동 활성화
++     conventions.md          ← 네이밍, git, 스타일
++     ...                     ← 도메인 규칙, 파일 경로 기반 자동 활성화
 + docs/
-+   architecture.md           <- 모듈 맵, 의존성 그래프
++   architecture.md           ← 모듈 맵, 의존성 그래프
 ```
 
-어디서 본 구조 아닌가요? 이 저장소의 [`.claude/`](.claude/) 폴더가 바로 그 결과물입니다.
+이 저장소의 [`.claude/`](.claude/) 폴더가 실제 예시입니다.
 
----
+</details>
 
-### 다양한 관점 얻기
+## 계획, 구현, 수정
+
+```
+pathfind  →  preplan  →  plan  →  ralph
+(탐색)       (정의)      (설계)    (구현 + 검증)
+```
+
+```bash
+# 문제를 알고 있고, 계획이 필요할 때:
+/coral:plan add retry logic to the API client
+
+# 증상은 있지만 원인을 모를 때:
+/coral:pathfind API is slow, DB hits limits, users are complaining
+
+# 복잡한 문제, 먼저 정의가 필요할 때:
+/coral:preplan race condition in the session manager
+
+# 계획이 있고, 구현만 남았을 때:
+/coral:ralph implement the caching layer
+
+# 버그 — 진단, 계획, 수정을 한 번에:
+/coral:bugfix why does session lookup return null?
+```
+
+<details>
+<summary>고급 플래그</summary>
+
+```bash
+# 방법론 기반 심층 리뷰 (resolver + HOW 추론):
+/coral:plan --deep add retry logic to the API client
+
+# 적대적 테스트 — 놓친 부분을 찾는 red-attacker 생성:
+/coral:ralph --red implement the caching layer
+
+# Codex CLI에 교차 모델 위임:
+/coral:plan --codex redesign the session management system
+
+# Codex 직접 세션 (다중 턴, 세션 유지):
+/coral:codex review auth.ts for security issues
+```
+
+`--codex`는 스킬 내에서 Codex에 위임; `/coral:codex`는 독립적인 Codex 세션.
+
+</details>
+
+## 토론
 
 ```
 /coral:discuss should we use microservices or a monolith?
 ```
 
-다양한 AI 페르소나가 각자의 관점에서 논쟁합니다.
-할 말이 있는 쪽이 먼저 발언하는 입찰 시스템. 상호 검증을 거치며 입장이 정제됩니다.
-최종 종합으로 마무리. 트랜스크립트는 `~/.coral/projects/{slug}/discuss/` 아래에 저장됩니다.
-`--user`를 추가하면 직접 참여 가능: `/coral:discuss --user "topic"`, 이후 `/coral:bid`로 발언.
+다양한 AI 페르소나가 각자의 관점에서 논쟁합니다. 입찰 기반 발언 순서, 상호 검증, 구조화된 종합으로 마무리.
+
+직접 참여: `/coral:discuss --user "topic"`, 이후 `/coral:bid`로 발언.
 
 예시: **"Am I AGI?"** — 전체 트랜스크립트 [EN](docs/examples/discuss-agi-en.md) · [KO](docs/examples/discuss-agi-ko.md)
 
@@ -115,48 +140,16 @@ my-project/
 
 </details>
 
----
-
-### 워크플로우 가속
+## 상태줄
 
 ```
-/coral:plan add retry logic to the API client
-/coral:plan --deep add retry logic to the API client
-/coral:bugfix why does session lookup return null?
-/coral:ralph implement the caching layer
+/coral:statusline install
 ```
 
-구조화된 추론 방법론에 기반한 아키텍트/크리틱 다중 라운드 리뷰를 포함한 계획 수립.
-`--deep`은 방법론 기반 종합을 활성화합니다 — resolver 에이전트와 HOW 추론 파일을 사용하여 복잡한 작업에 대한 심층 리뷰.
-체계적 버그 진단 — 근본 원인, 계획, 수정. 완료 전까지 반복 검증하며 실행.
-
-문제는 있지만 뭘 만들어야 할지 모를 때:
 ```
-/coral:pathfind API is slow, DB hits limits, users are complaining
+opus 4.6 │ 5h:39% (1:23) wk:36% (5.2d) │ ctx:58% │ $1.57 50m │ coral:analyze
+gpt-5.4  │ 5h: 0% (4:59) wk:22% (2.8d) │ spark 5h: 3% (0:47) wk: 1% (6.8d)
 ```
-Pathfind가 근본 원인을 진단하고, 발산적 방향을 생성한 뒤 preplan으로 넘깁니다.
-
-복잡한 작업에는 문제 정의부터 시작:
-```
-/coral:preplan race condition in the session manager
-```
-Preplan이 사용자와 이해를 맞춘 뒤 plan으로 넘깁니다.
-Plan이 리뷰를 거쳐 솔루션을 설계하고, ralph가 구현과 검증을 수행합니다.
-각 스킬은 독립적으로도 동작합니다 — 전체 파이프라인은 `pathfind → preplan → plan → ralph`입니다.
-
-`--red` 플래그로 놓친 부분을 찾아내는 적대적 테스트 에이전트 생성:
-```
-/coral:ralph --red implement the caching layer
-```
-
-Codex를 활용한 교차 모델 워크플로우:
-```
-/coral:plan --codex redesign the session management system
-/coral:codex review auth.ts for security issues
-```
-
-`--codex`는 스킬 내 특정 단계만 Codex에 위임; `/coral:codex`는 Codex와의 직접 다중 턴 세션용.
-연속적인 `/coral:codex` 호출은 같은 세션을 유지합니다. "new"로 새 세션 시작.
 
 ## 스킬
 
@@ -165,103 +158,58 @@ Codex를 활용한 교차 모델 워크플로우:
 | `/coral:analyze` | 심층 분석 및 조사 | 선택 |
 | `/coral:pathfind` | 문제 증상에서 발산적 방향 탐색 | - |
 | `/coral:preplan` | 계획 전 문제 정의 | 선택 |
-| `/coral:plan` | 구조화된 다중 라운드 리뷰 및 충돌 해결 포함 계획. `--deep`으로 방법론 기반 종합 | 선택 |
+| `/coral:plan` | 구조화된 다중 라운드 리뷰 포함 계획. `--deep`으로 방법론 기반 종합 | 선택 |
 | `/coral:ralph` | 검증 포함 영속적 실행. `--red`로 적대적 테스트 | 선택 |
-| `/coral:bugfix` | 버그 진단, 계획, 수정 실행 | 선택 |
+| `/coral:bugfix` | 버그 진단, 계획, 수정을 한 번에 | 선택 |
 | `/coral:code-simplify` | 코드 명확성 향상 및 정리 | 선택 |
 | `/coral:codex` | Codex CLI 직접 실행 (세션 유지) | 필수 |
 | `/coral:init-project` | 프로젝트 초기화 오케스트레이터 | - |
 | `/coral:discuss` | 모더레이션 기반 다자간 AI 토론 | - |
 | `/coral:bid` | 활성 `--user` 토론 세션에서 입찰/발언 | - |
-| `/coral:statusline` | HUD 상태줄 설정 | - |
-
-`선택` = Codex 없이 기본 동작; `--codex`를 전달하면 Codex CLI에 위임.
-계획은 `~/.coral/projects/{slug}/plans/` 아래에 저장됩니다. Ralph는 기존 계획의 구현에 최적입니다.
-`/coral:bid`는 `/coral:discuss --user` 세션 전용 — 독립적으로 사용할 수 없습니다.
+| `/coral:equip` | MCP 도구 원터치 설치 | - |
+| `/coral:statusline` | HUD 상태줄 설치/제거 | - |
+| `/coral:reef` | 세션 활동 및 KB 상태 실시간 대시보드 | - |
 
 ## 지식 베이스
 
-Coral은 공유 지식 베이스를 `~/.coral/kb/`에 두고 (notes와 principles로 구분), 메모·계획·분석·토론 세션 같은
-프로젝트별 작업 데이터는 `~/.coral/projects/{slug}/` 아래에 둡니다.
-
-Claude가 놓치기 쉬운 것을 발견하면 (근본 원인, 주의사항, 기억할 패턴) 즉시 메모를 작성합니다.
-에러 발생 시 처음부터 디버깅하기 전에 KB를 확인합니다.
-작업 완료 시 메모를 검토하고 영구 항목으로 승격합니다. 같은 실수를 세션마다 반복하지 않습니다.
+Coral은 매 세션에서 배웁니다. 근본 원인, 주의사항, 패턴 — 메모로 포착하고, 검토 후 `~/.coral/kb/`에 영구 지식으로 승격합니다. 다음 세션은 처음부터 디버깅하기 전에 KB를 확인합니다. 같은 실수를 반복하지 않습니다.
 
 ## 설정
 
 | 변수 | 기본값 | 설명 |
 |------|--------|------|
-| `CORAL_KB_PATH` | `~/.coral/kb` | KB 저장 경로 지정 |
+| `CORAL_KB_PATH` | `~/.coral/kb` | KB 저장 경로 |
 | `CORAL_CODEX_MODEL` | `gpt-5.4` | Codex CLI 기본 모델 |
 | `CORAL_CODEX_EFFORT` | `xhigh` | Codex 추론 노력도 (`low`, `medium`, `high`, `xhigh`) |
-| `CORAL_CLAUDE_MODEL_CAP` | `opus` | Claude 최대 모델 티어 (`opus`, `sonnet`, `haiku`). 상위 티어 요청은 자동 다운그레이드. |
+| `CORAL_CLAUDE_MODEL_CAP` | `opus` | Claude 최대 모델 티어 (`opus`, `sonnet`, `haiku`) |
 | `CORAL_MAX_SESSIONS` | `10` | 최대 동시 CLI 세션 수 (1–10) |
 | `CORAL_DISCUSS_MAX_EPOCHS` | `2` | 토론 자동 종료 전 최대 에포크 (1–10) |
-| `CORAL_DISCUSS_TTL_DAYS` | `0` | 완료된 토론 세션 자동 정리 기한 (일, 0 = 비활성화) |
+| `CORAL_DISCUSS_TTL_DAYS` | `0` | 완료된 토론 세션 자동 정리 기한 (0 = 비활성화) |
 
-> **팁:** Coral의 워크플로우와 리뷰 에이전트는 기본적으로 Opus를 사용합니다. Pro 구독이거나 사용량을 절약하고 싶다면 `CORAL_CLAUDE_MODEL_CAP=sonnet`으로 설정하여 모든 Claude 서브에이전트 호출을 Sonnet 티어로 제한할 수 있습니다.
+> **팁:** `CORAL_CLAUDE_MODEL_CAP=sonnet`으로 설정하면 모든 서브에이전트 호출을 Sonnet 티어로 제한합니다. Pro 구독이거나 사용량을 절약하고 싶을 때.
+
 `.claude/settings.json`에 설정 (세션 간 유지):
 
 ```json
 {
   "env": {
     "CORAL_KB_PATH": "/path/to/my-obsidian-vault",
-    "CORAL_DISCUSS_MAX_EPOCHS": "2",
-    "CORAL_DISCUSS_TTL_DAYS": "0"
+    "CORAL_CLAUDE_MODEL_CAP": "sonnet"
   }
 }
 ```
 
-또는 셸에서: `export CORAL_CODEX_MODEL=gpt-5.4`
-
 ## 문서
 
-- [Architecture](docs/architecture.md) - 아키텍처 및 데이터 흐름
-- [MCP Tools](docs/mcp-tools.md) - MCP 도구 입출력 사양
-- [Core Modules](docs/core-modules.md) - TypeScript 모듈 상세
-- [Agents](docs/agents.md) - 에이전트 정의 및 라우팅
-- [Hooks](docs/hooks.md) - 훅 시스템 및 라이프사이클 이벤트
-- [Skills](docs/skills.md) - 슬래시 커맨드 사용법
-- [Methodology](docs/methodology.md) - 구조화된 추론 방법론 (HOW 파일)
-- [Discuss](docs/discuss.md) - 토론 시스템 설계
-- [Build System](docs/build-system.md) - 빌드 파이프라인
-- [Configuration](docs/configuration.md) - 환경 변수 및 설정 파일
+- [Architecture](docs/architecture.md) — 아키텍처 및 데이터 흐름
+- [MCP Tools](docs/mcp-tools.md) — MCP 도구 입출력 사양
+- [Core Modules](docs/core-modules.md) — TypeScript 모듈 상세
+- [Agents](docs/agents.md) — 에이전트 정의 및 라우팅
+- [Hooks](docs/hooks.md) — 훅 시스템 및 라이프사이클 이벤트
+- [Skills](docs/skills.md) — 슬래시 커맨드 사용법
+- [Methodology](docs/methodology.md) — 구조화된 추론 방법론 (HOW 파일)
+- [Discuss](docs/discuss.md) — 토론 시스템 설계
+- [Build System](docs/build-system.md) — 빌드 파이프라인
+- [Configuration](docs/configuration.md) — 환경 변수 및 설정 파일
 
----
-
-## 상태줄
-
-Claude Code 세션용 실시간 HUD (선택):
-
-```
-/coral:statusline install
-
-# 설치 후:
-opus 4.6 | 5h:39% (1:23) wk:36% (5.2d) | ctx:58% | $1.57 50m | coral:analyze
-gpt-5.4  | 5h: 0% (4:59) wk:22% (2.8d) | spark 5h: 3% (0:47) wk: 1% (6.8d)
-```
-
-- **1줄 (항상)**: 모델, Claude 속도 제한, 컨텍스트 사용량, 세션 ID, 마지막 활성 스킬
-- **2줄 (선택)**: Codex 모델 및 속도 제한 - Codex 설치 시에만 표시
-
-제거: `/coral:statusline uninstall`
-
-## 개발
-
-```bash
-npm install
-npm run build     # TypeScript 컴파일 + esbuild 번들
-npm test          # vitest로 테스트 실행
-```
-
-### Git 워크플로우
-
-- **`main`**: 릴리스 브랜치. 항상 배포 가능.
-- **`dev`**: 통합 브랜치. 소규모 변경은 직접 커밋 가능.
-- **Feature 브랜치**: `dev`에서 분기, PR로 rebase merge.
-- **릴리스**: `dev` → `main` squash merge via PR.
-
-Merge 정책:
-- **feature → dev**: rebase (개별 커밋 보존)
-- **dev → main**: squash (릴리스당 하나의 커밋, `(#N)`으로 추적)
+## [기여하기](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 [한국어](README.ko.md)
 
-Claude Code already knows how to code. Coral teaches it how *you* code.
-
-Your conventions enforced, your workflow structured, your decisions examined from
-multiple angles - all through slash commands that work in any Claude Code session.
+Claude Code already knows how to code. Coral teaches it how *you* work.
 
 ## Install
 
@@ -15,24 +12,19 @@ multiple angles - all through slash commands that work in any Claude Code sessio
 /plugin marketplace add https://github.com/kangig94/coral
 /plugin install coral
 
-# Codex CLI (optional - enables `codex-*` skills and `--codex` flags):
-npm install -g @openai/codex  # v0.104+
+# Codex CLI (optional — enables --codex cross-model delegation):
+npm install -g @openai/codex
 ```
 
 ## Try It Now
 
-No setup. Run this in any Claude Code session, on any existing project:
+Run this on any existing project:
 
 ```
 /coral:analyze what does this codebase do?
 ```
 
-Coral reads your project and returns a structured analysis:
-architecture, modules, entry points, and dependencies. No files written, no configuration required.
-
-## Choose Your Path
-
-### Structure my project
+## Structure a Project
 
 https://github.com/user-attachments/assets/881f1a14-9f4f-4d3d-8023-59610eb13ac4
 
@@ -40,28 +32,17 @@ https://github.com/user-attachments/assets/881f1a14-9f4f-4d3d-8023-59610eb13ac4
 /coral:init-project
 ```
 
-Coral scans your stack, plans with reviewer verification, and generates `.claude/` -
-conventions, agents, architecture docs - tailored to your project.
-
-Generated agents aren't boilerplate — they encode evaluation philosophies
-with rubric-anchored scoring across multiple dimensions, calibrated to your project's audience.
-Claude follows your rules, not generic defaults.
+Coral scans your stack and generates `.claude/` — conventions, review agents, architecture docs — tailored to your project.
 
 ```bash
-# existing project - just run it, Coral scans automatically
-/coral:init-project
-
-# tech stack hint (when source files are sparse)
-/coral:init-project "React + FastAPI"
-
-# full description (new or complex projects)
-/coral:init-project "multi-tenant SaaS REST API with Go, must be serverless"
-
-# with reference material
-/coral:init-project "CLI tool like ref/existing-cli, see docs/spec.md"
+/coral:init-project                                          # existing project
+/coral:init-project "React + FastAPI"                        # tech stack hint
+/coral:init-project "multi-tenant SaaS REST API with Go"     # full description
 ```
 
-Generated structure:
+<details>
+<summary>Generated structure</summary>
+
 ```
 my-project/
 + .claude/
@@ -76,21 +57,64 @@ my-project/
 +   architecture.md           ← module map, dependency graph
 ```
 
-Look familiar? Browse this repository's [`.claude/`](.claude/) folder.
+Browse this repository's [`.claude/`](.claude/) folder for a real example.
 
----
+</details>
 
-### Get diverse perspectives
+## Plan, Build, and Fix
+
+```
+pathfind  →  preplan  →  plan  →  ralph
+(explore)    (define)    (design)  (implement + verify)
+```
+
+```bash
+# Know the problem, need a plan:
+/coral:plan add retry logic to the API client
+
+# Have symptoms, not sure what's wrong:
+/coral:pathfind API is slow, DB hits limits, users are complaining
+
+# Complex problem, need alignment first:
+/coral:preplan race condition in the session manager
+
+# Have a plan, just implement it:
+/coral:ralph implement the caching layer
+
+# Bug — diagnose, plan, fix in one shot:
+/coral:bugfix why does session lookup return null?
+```
+
+<details>
+<summary>Advanced flags</summary>
+
+```bash
+# Deep review with methodology-driven synthesis (resolver + HOW reasoning):
+/coral:plan --deep add retry logic to the API client
+
+# Adversarial testing — spawns a red-attacker to target blind spots:
+/coral:ralph --red implement the caching layer
+
+# Cross-model delegation to Codex CLI:
+/coral:plan --codex redesign the session management system
+
+# Direct Codex session (multi-turn, persistent):
+/coral:codex review auth.ts for security issues
+```
+
+`--codex` delegates within a skill; `/coral:codex` opens a persistent session.
+
+</details>
+
+## Discuss
 
 ```
 /coral:discuss should we use microservices or a monolith?
 ```
 
-Multiple AI personas argue from different angles.
-Bid-based turn-taking surfaces the most urgent responses first.
-Positions evolve through genuine cross-examination.
-Structured synthesis at the end. Transcripts saved under `~/.coral/projects/{slug}/discuss/`.
-Add `--user` to join as a participant: `/coral:discuss --user "topic"`, then `/coral:bid` to submit your turns.
+Multiple AI personas argue from different angles. Bid-based turn-taking, genuine cross-examination, structured synthesis at the end.
+
+Join as a participant: `/coral:discuss --user "topic"`, then `/coral:bid` to submit your turns.
 
 Example: **"Am I AGI?"** — Full transcript [EN](docs/examples/discuss-agi-en.md) · [KO](docs/examples/discuss-agi-ko.md)
 
@@ -120,48 +144,16 @@ and unknown behavior at their structural boundaries.
 
 </details>
 
----
-
-### Accelerate my workflow
+## Statusline
 
 ```
-/coral:plan add retry logic to the API client
-/coral:plan --deep add retry logic to the API client
-/coral:bugfix why does session lookup return null?
-/coral:ralph implement the caching layer
+/coral:statusline install
 ```
 
-Multi-round planning with architect/critic review backed by structured reasoning methodologies.
-`--deep` enables methodology-driven synthesis with resolver agent and HOW reasoning files — thorough review for complex tasks.
-Systematic bug diagnosis - root cause, plan, fix. Persistent execution that verifies before declaring done.
-
-When you have problems but don't know what to build:
 ```
-/coral:pathfind API is slow, DB hits limits, users are complaining
+opus 4.6 │ 5h:39% (1:23) wk:36% (5.2d) │ ctx:58% │ $1.57 50m │ coral:analyze
+gpt-5.4  │ 5h: 0% (4:59) wk:22% (2.8d) │ spark 5h: 3% (0:47) wk: 1% (6.8d)
 ```
-Pathfind diagnoses root causes, generates divergent directions, and hands off to preplan.
-
-For complex tasks, start with problem definition:
-```
-/coral:preplan race condition in the session manager
-```
-Preplan aligns understanding with you, then hands off to plan.
-Plan designs the solution with review, then ralph implements and verifies.
-Each skill works on its own — the full pipeline is `pathfind → preplan → plan → ralph`.
-
-`--red` flag spawns an adversarial agent to write tests targeting blind spots:
-```
-/coral:ralph --red implement the caching layer
-```
-
-For cross-model workflows with Codex:
-```
-/coral:plan --codex redesign the session management system
-/coral:codex review auth.ts for security issues
-```
-
-`--codex` delegates a single phase within a skill to Codex; `/coral:codex` is for direct multi-turn Codex sessions.
-Consecutive `/coral:codex` calls continue the same session. Say "new" to start fresh.
 
 ## Skills
 
@@ -170,29 +162,21 @@ Consecutive `/coral:codex` calls continue the same session. Say "new" to start f
 | `/coral:analyze` | Deep analysis and investigation | Optional |
 | `/coral:pathfind` | Divergent direction discovery from problem symptoms | - |
 | `/coral:preplan` | Problem definition before planning | Optional |
-| `/coral:plan` | Multi-round planning with structured review and conflict resolution. `--deep` for methodology-driven synthesis | Optional |
+| `/coral:plan` | Multi-round planning with structured review. `--deep` for methodology-driven synthesis | Optional |
 | `/coral:ralph` | Persistent execution with verification. `--red` for adversarial tests | Optional |
-| `/coral:bugfix` | Bug diagnosis, planning, and fix execution | Optional |
+| `/coral:bugfix` | Bug diagnosis, planning, and fix in one shot | Optional |
 | `/coral:code-simplify` | Simplify and refine code for clarity | Optional |
 | `/coral:codex` | Direct Codex CLI execution (session-persistent) | Required |
 | `/coral:init-project` | Project initialization orchestrator | - |
 | `/coral:discuss` | Moderated multi-agent discussion | - |
 | `/coral:bid` | Submit bid/speech in active `--user` discuss session | - |
-| `/coral:statusline` | HUD statusline setup | - |
-
-`Optional` = works without Codex by default; pass `--codex` to delegate to Codex CLI.
-Plans are saved under `~/.coral/projects/{slug}/plans/`. Ralph is best for implementing an existing plan.
-`/coral:bid` is a companion to `/coral:discuss --user` — it is not usable independently.
+| `/coral:equip` | One-touch install of MCP tools | - |
+| `/coral:statusline` | Install or remove HUD statusline | - |
+| `/coral:reef` | Real-time dashboard for session activity and KB state | - |
 
 ## Knowledge Base
 
-Coral keeps a shared knowledge base at `~/.coral/kb/` (notes and principles) and project-scoped
-working data under `~/.coral/projects/{slug}/` for memos, plans, analysis, and discuss sessions.
-
-When Claude discovers something non-obvious (a root cause, a gotcha, a pattern worth remembering),
-it writes a memo immediately. On errors, it checks the KB before debugging from scratch.
-On task completion, memos are reviewed and promoted to permanent entries.
-Mistakes aren't repeated across sessions.
+Coral learns from every session. Root causes, gotchas, patterns — captured as memos, reviewed, and promoted to permanent knowledge at `~/.coral/kb/`. The next session checks the KB before debugging from scratch. Mistakes aren't repeated.
 
 ## Configuration
 
@@ -201,12 +185,12 @@ Mistakes aren't repeated across sessions.
 | `CORAL_KB_PATH` | `~/.coral/kb` | Custom KB storage path |
 | `CORAL_CODEX_MODEL` | `gpt-5.4` | Default Codex CLI model |
 | `CORAL_CODEX_EFFORT` | `xhigh` | Codex reasoning effort (`low`, `medium`, `high`, `xhigh`) |
-| `CORAL_CLAUDE_MODEL_CAP` | `opus` | Maximum Claude model tier (`opus`, `sonnet`, `haiku`). Requests for higher tiers are downgraded. |
+| `CORAL_CLAUDE_MODEL_CAP` | `opus` | Maximum Claude model tier (`opus`, `sonnet`, `haiku`) |
 | `CORAL_MAX_SESSIONS` | `10` | Max concurrent CLI sessions (1–10) |
 | `CORAL_DISCUSS_MAX_EPOCHS` | `2` | Max epochs before discussion auto-ends (1–10) |
-| `CORAL_DISCUSS_TTL_DAYS` | `0` | Days before completed discuss sessions are auto-pruned (0 = disabled) |
+| `CORAL_DISCUSS_TTL_DAYS` | `0` | Days before completed sessions are auto-pruned (0 = disabled) |
 
-> **Tip:** Coral's workflow and review agents use Opus by default. If you're on a Pro plan or want to conserve usage, set `CORAL_CLAUDE_MODEL_CAP=sonnet` to cap all Claude subagent calls at Sonnet tier.
+> **Tip:** Set `CORAL_CLAUDE_MODEL_CAP=sonnet` to cap all subagent calls at Sonnet tier for Pro plans or to conserve usage.
 
 Set in `.claude/settings.json` (persists across sessions):
 
@@ -214,61 +198,22 @@ Set in `.claude/settings.json` (persists across sessions):
 {
   "env": {
     "CORAL_KB_PATH": "/path/to/my-obsidian-vault",
-    "CORAL_DISCUSS_MAX_EPOCHS": "2",
-    "CORAL_DISCUSS_TTL_DAYS": "0"
+    "CORAL_CLAUDE_MODEL_CAP": "sonnet"
   }
 }
 ```
 
-Or via shell: `export CORAL_CODEX_MODEL=gpt-5.4`
-
 ## Documentation
 
-- [Architecture](docs/architecture.md) - Architecture and data flow
-- [MCP Tools](docs/mcp-tools.md) - Input/output specs for all MCP tools
-- [Core Modules](docs/core-modules.md) - TypeScript module details
-- [Agents](docs/agents.md) - Agent definitions and routing
-- [Hooks](docs/hooks.md) - Hook system and lifecycle events
-- [Skills](docs/skills.md) - Slash command usage
-- [Methodology](docs/methodology.md) - Reasoning methodologies (HOW files)
-- [Discuss](docs/discuss.md) - Discuss system design
-- [Build System](docs/build-system.md) - Build pipeline
-- [Configuration](docs/configuration.md) - Environment variables and config files
+- [Architecture](docs/architecture.md) — System structure and data flow
+- [MCP Tools](docs/mcp-tools.md) — Input/output specs for all MCP tools
+- [Core Modules](docs/core-modules.md) — TypeScript module details
+- [Agents](docs/agents.md) — Agent definitions and routing
+- [Hooks](docs/hooks.md) — Hook system and lifecycle events
+- [Skills](docs/skills.md) — Slash command usage
+- [Methodology](docs/methodology.md) — Reasoning methodologies (HOW files)
+- [Discuss](docs/discuss.md) — Discuss system design
+- [Build System](docs/build-system.md) — Build pipeline
+- [Configuration](docs/configuration.md) — Environment variables and config files
 
----
-
-## Statusline
-
-Optional real-time HUD for Claude Code sessions:
-
-```
-/coral:statusline install
-
-# after install:
-opus 4.6 │ 5h:39% (1:23) wk:36% (5.2d) │ ctx:58% │ $1.57 50m │ coral:analyze
-gpt-5.4  │ 5h: 0% (4:59) wk:22% (2.8d) │ spark 5h: 3% (0:47) wk: 1% (6.8d)
-```
-
-- **Line 1 (always)**: model, Claude rate limits, context usage, session ID, last active skill
-- **Line 2 (optional)**: Codex model and rate limits - shown only when Codex is installed
-
-To remove: `/coral:statusline uninstall`
-
-## Development
-
-```bash
-npm install
-npm run build     # TypeScript compile + esbuild bundle
-npm test          # Run tests with vitest
-```
-
-### Git Workflow
-
-- **`main`**: Release branch. Always deployable.
-- **`dev`**: Integration branch. Direct commits allowed for small changes.
-- **Feature branches**: Branch from `dev`, rebase merge back via PR.
-- **Release**: Squash merge `dev` → `main` via PR.
-
-Merge policy:
-- **feature → dev**: rebase (preserve individual commits)
-- **dev → main**: squash (one commit per release, traceable via `(#N)`)
+## [Contributing](CONTRIBUTING.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -466,13 +466,17 @@ coral/
 │   │   ├── detect.ts            # Mode detection, cache state, runtime context
 │   │   ├── paths.ts             # KB path and memo boundary helpers
 │   │   ├── frontmatter.ts       # Note/principle parsing + serialization
-│   │   ├── search-basic.ts      # Basic index-backed literal search
-│   │   ├── search-enhanced.ts   # Enhanced search with basic fallback
+│   │   ├── orama-factory.ts      # Orama DB factory (schema, tokenizer, pre-normalization)
+│   │   ├── search.ts            # Unified BM25 text search via Orama
+│   │   ├── memo.ts              # Auto-generated memo creation
 │   │   ├── promote.ts           # Memo -> note promotion
 │   │   ├── update.ts            # Partial note updates
 │   │   ├── delete.ts            # Note deletion
-│   │   ├── reindex.ts           # JSON/enhanced index rebuild
-│   │   └── lancedb-runtime.ts   # Runtime-only enhanced search adapter
+│   │   ├── mutation-helpers.ts   # Shared mutation utilities (atomic write, stale marking)
+│   │   ├── reindex.ts           # JSON + Orama index rebuild
+│   │   ├── reindex-enhanced.ts  # LanceDB table rebuild (future vector)
+│   │   ├── types.ts             # KB type definitions
+│   │   └── lancedb-runtime.ts   # Runtime-only LanceDB adapter
 │   └── discuss/                 # Discuss domain + projections
 │       ├── events.ts            # Domain event union + persisted runtime types
 │       ├── reducer.ts           # Event replay into snapshot state
@@ -556,22 +560,22 @@ The KB stack is split between backend-exposed tool contracts, markdown-vault hel
 
 ```
 execution/server.ts
-  ├── kb/contracts.ts            (kb_search/kb_promote/kb_update/kb_delete/kb_reindex descriptors + routing)
-  ├── kb/detect.ts               (cached KB context, mode detection, index state)
+  ├── kb/contracts.ts            (kb_search/kb_promote/kb_update/kb_delete/kb_memo/kb_reindex descriptors + routing)
+  ├── kb/detect.ts               (cached KB context, Orama lifecycle, index state)
   └── providers/registry.ts      (reserves KB built-in tool names)
 
 kb/contracts.ts
-  └── kb/{search-basic,search-enhanced,promote,update,delete,reindex}.ts
+  └── kb/{search,memo,promote,update,delete,reindex}.ts
 
 kb/{promote,update,delete,reindex}.ts
   ├── kb/frontmatter.ts          (frontmatter parsing + serialization)
+  ├── kb/mutation-helpers.ts     (atomic write, text index stale marking)
   ├── kb/paths.ts                (vault/memo boundary resolution)
-  └── kb/detect.ts               (cache invalidation, stale/enhanced state)
+  └── kb/detect.ts               (cache invalidation, Orama persistence)
 
-kb/search-basic.ts
-  ├── kb/frontmatter.ts
-  ├── kb/paths.ts
-  └── kb/detect.ts
+kb/search.ts
+  ├── kb/orama-factory.ts        (schema, tokenizer, pre-normalization)
+  └── kb/detect.ts               (ensureOramaIndex)
 ```
 
 ### Discuss Subsystem

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -597,6 +597,17 @@ Searches KB note filename, principles, tags, title, and content with Orama BM25 
 
 Returns `{ results, mode, warning? }`. Each result has `{ note, title, matchedBy, tags, principles, snippet? }` where `note` is a slug directly usable in `kb_update` and `kb_delete`. `mode` is `'text'` for the current Orama-backed search path and `'hybrid'` when text search is paired with vector results.
 
+## kb_memo
+
+Writes a memo with auto-generated timestamp, path, and frontmatter. The project source is derived from the caller's working directory via `git remote`.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `topic` | string | Yes | Kebab-case topic slug (e.g. `orama-threshold`) |
+| `content` | string | Yes | Memo body text (one paragraph + context) |
+
+Returns `{ filename, path }`.
+
 ## kb_promote
 
 Promotes a memo into a new KB note. Promotion is create-only: if the destination note already exists, the tool fails and the caller should use `kb_update` instead.


### PR DESCRIPTION
## Summary
- Rewrite README for user journey flow (5.6 → 8.5 UX score across 4 review iterations)
- Sync README.ko.md to match English structure
- Move Development/Git workflow to CONTRIBUTING.md
- Update architecture.md and mcp-tools.md for Orama search migration

## Changes
- README restructured: Install → Try It Now → Structure → Plan/Build/Fix → Discuss → Statusline → Skills → KB → Config → Docs → Contributing
- Skills table is now canonical reference (prose duplication removed)
- Pipeline shown as ASCII diagram, advanced flags in `<details>`
- KB rewritten as value proposition
- architecture.md: stale search-basic/search-enhanced refs replaced with search.ts, orama-factory.ts, memo.ts
- mcp-tools.md: kb_memo tool documented, note slug descriptions added

🤖 Generated with [Claude Code](https://claude.com/claude-code)