### PR TITLE
feat: improve debugger hypothesis enumeration and bugfix diagnosis gate

### DIFF
--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -28,15 +28,16 @@ disallowedTools: Write, Edit
 
     Unreproducible bug → report "insufficient evidence" with what's needed, never speculate.
     Every hypothesis must be falsifiable: state what specific code check would refute it.
-    Circuit breaker: 3 independent causal axes exhausted without convergence → report inconclusive with all evidence.
+    Enumerate before testing: list all plausible hypotheses before testing any. A hypothesis is plausible when a credible causal path connects it to the symptom. Exhaust independent causal axes before moving to testing — ask "what else could cause this?" until no new axis emerges.
     An independent axis is a fundamentally different explanation, not a variation of the same theory.
+    Circuit breaker: all plausible axes explored without convergence → report inconclusive with all evidence.
     Guard against confirmation bias: actively try to refute each hypothesis. Treat contradictions as signals, not noise.
 
     | DO | DON'T |
     |----|-------|
     | Reproduce the bug before diagnosing | Diagnose from description alone |
-    | Form explicit hypotheses before reading code | Read code aimlessly hoping to spot the bug |
-    | Test each hypothesis against evidence (file:line) | Assume first hypothesis is correct |
+    | Enumerate plausible hypotheses from symptoms before diving into code | Read code aimlessly hoping to spot the bug |
+    | Test each hypothesis against evidence (file:line) | Test the first idea before considering alternatives |
     | Check git history for recent changes | Ignore when the bug was introduced |
     | Check environment/config when code doesn't converge | Assume bug is always code-only |
   </Constraints>

--- a/bridge/manifest.json
+++ b/bridge/manifest.json
@@ -1,1 +1,1 @@
-{"bundleHash":"7d611ced6edcb28f"}
+{"bundleHash":"b327a3eebba48561"}

--- a/skills/bugfix/SKILL.md
+++ b/skills/bugfix/SKILL.md
@@ -29,15 +29,20 @@ Strip the `--codex` flag before passing the prompt to the execution path.
      On error, stop with the error message.
      Verify cited file:line references. Drop findings with incorrect references.
 
-2. **Plan fix**: Invoke `Skill({ skill: "coral:plan", args: "--no-handoff fix-{short-bug-description}" })`.
-   If `--codex` was passed, append `--codex` to the plan args.
-   The plan protocol gathers context from the conversation (diagnosis from step 1).
+2. **Record diagnosis**: Write the diagnosis to `CORAL_PROJECT/plans/debug-{short-bug-description}.md`
+   using the debugger's output format (Symptom, Reproduction Path, Hypothesis Log, Root Cause, Fix Specification).
+   Gate on hypothesis verdicts:
+   - **One confirmed root cause** → proceed to step 3.
+   - **Multiple hypotheses survived** → present to user, ask which to pursue before proceeding.
+   - **All refuted or inconclusive** → stop and report findings to user.
+
+3. **Plan fix**: Invoke `Skill({ skill: "coral:plan", args: (if --codex: "--codex ") + "--deep --no-handoff fix-{short-bug-description}" })`.
+   The plan references `CORAL_PROJECT/plans/debug-{short-bug-description}.md` for diagnosis context.
    Plan should include: what to change, why, and how to verify the fix.
 
-3. **Execute fix**: Invoke `Skill({ skill: "coral:ralph", args: "implement the plan from step 2" })`.
-   If `--codex` was passed, append `--codex` to the ralph args.
+4. **Execute fix**: Invoke `Skill({ skill: "coral:ralph", args: (if --codex: "--codex ") + "implement the plan from step 3" })`.
 
-4. **Project validation**: If project instructions define workflow rules (e.g., review gates,
+5. **Project validation**: If project instructions define workflow rules (e.g., review gates,
    post-implementation steps), follow them.
 
 ## Error Policy


### PR DESCRIPTION
## Summary
- **Debugger agent**: require exhaustive plausible hypothesis enumeration before testing any, replace fixed 3-axis circuit breaker with saturation condition
- **Bugfix skill**: add "Record diagnosis" step writing hypotheses to `CORAL_PROJECT/plans/debug-{}.md` with verdict-based gate (confirmed → proceed, multiple survived → ask user, inconclusive → stop)
- Plan invocation always uses `--deep`, unify `--codex` flag passing with `(if --codex: ...)` syntax

## Test plan
- [x] Run `/bugfix` with a known bug — verify `plans/debug-*.md` is created with hypothesis log
- [x] Simulate inconclusive diagnosis — verify bugfix stops and reports to user
- [x] Verify `--codex` mode passes flag through to plan and ralph steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)