### PR TITLE
fix: raise memo promote gate threshold from 1 to 10

### DIFF
--- a/hooks/kb-promote-gate.mjs
+++ b/hooks/kb-promote-gate.mjs
@@ -74,7 +74,7 @@ try {
       try { unlinkSync(flag); } catch { /* ignore */ }
     }
     sweepStale(flagDir, FLAG_PREFIX, 24 * 60 * 60_000);
-    if (visibleMemos.length > 0) {
+    if (visibleMemos.length >= 10) {
       const list = visibleMemos.join(', ');
       process.stdout.write(JSON.stringify({
         decision: 'block',


### PR DESCRIPTION
## Summary
Stop hook blocked session exit when even 1 memo existed. With backend down, this created an infinite block loop. Threshold raised to 10.

## Test plan
- [x] Hook file updated
- [x] Manual: session exits cleanly with < 10 memos

🤖 Generated with [Claude Code](https://claude.com/claude-code)