### PR TITLE
fix: statusline backend flicker — dynamic resolve, unified TTL, wider timeout

### DIFF
--- a/hooks/hud-auto-update.mjs
+++ b/hooks/hud-auto-update.mjs
@@ -15,7 +15,7 @@ try {
 
   const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   if (!pluginRoot) process.exit(0);
-  if (!pluginRoot.includes('/.claude/plugins/cache/')) process.exit(0);
+  if (!pluginRoot.includes('/.claude/plugins/marketplaces/')) process.exit(0);
 
   const installed = join(homedir(), '.claude', 'hud', 'coral-hud.mjs');
   const source = join(pluginRoot, 'skills', 'statusline', 'coral-hud.mjs');


### PR DESCRIPTION
## Summary
- Statusline: resolve backend.json on each cache-miss (not module load), unify TTL to 5s, timeout 200ms→800ms
- HUD auto-update hook: trigger for marketplaces/ path (was cache/ only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)