### PR TITLE
fix: use fetch() for Codex API and preserve codex-enabled flag

### DIFF
--- a/hooks/hud-auto-update.mjs
+++ b/hooks/hud-auto-update.mjs
@@ -10,11 +10,13 @@ function fileHash(path) {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
+const PRESERVE = new Set(['.coral-codex-enabled']);
+
 function cleanRuntimeFiles(hudDir) {
   let entries;
   try { entries = readdirSync(hudDir); } catch { return; }
   for (const name of entries) {
-    if (name.startsWith('.coral-')) {
+    if (name.startsWith('.coral-') && !PRESERVE.has(name)) {
       try { unlinkSync(join(hudDir, name)); } catch {}
     }
   }

--- a/skills/statusline/coral-hud.mjs
+++ b/skills/statusline/coral-hud.mjs
@@ -8,7 +8,6 @@ import { readFileSync, readdirSync, existsSync, writeFileSync, mkdirSync, openSy
 import { join } from "path";
 import { homedir } from "os";
 import { execSync } from "child_process";
-import https from "node:https";
 const SEP = " \u2502 ";
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
@@ -17,31 +16,8 @@ const DIM = "\x1b[2m";
 const RESET = "\x1b[0m";
 const CYAN = "\x1b[36m";
 const MAGENTA = "\x1b[35m";
-const CODEX_USER_AGENT = "codex_cli_rs";
+const CODEX_USER_AGENT = "codex_cli_rs/0.117.0";
 
-const SYSTEM_CA_PATH = "/etc/ssl/certs/ca-certificates.crt";
-let _systemCa;
-function getSystemCa() {
-  if (_systemCa !== undefined) return _systemCa;
-  try { _systemCa = readFileSync(SYSTEM_CA_PATH, "utf-8"); } catch { _systemCa = null; }
-  return _systemCa;
-}
-
-function httpsRequest(url, options = {}) {
-  return new Promise((resolve, reject) => {
-    const u = new URL(url);
-    const ca = getSystemCa();
-    const req = https.request(u, { ...options, ...(ca ? { ca } : {}) }, (res) => {
-      let body = "";
-      res.on("data", (c) => { body += c; });
-      res.on("end", () => resolve({ status: res.statusCode, body }));
-    });
-    req.on("error", reject);
-    if (options.signal) options.signal.addEventListener("abort", () => req.destroy(), { once: true });
-    if (options.body) req.write(options.body);
-    req.end();
-  });
-}
 
 function getCodexClientId(idToken) {
   try {
@@ -694,20 +670,19 @@ function writeBackCodexCredentials(creds, refreshed) {
 
 async function refreshCodexToken(refreshTok, clientId, signal) {
   try {
-    const body = new URLSearchParams({
-      grant_type: "refresh_token",
-      client_id: clientId,
-      refresh_token: refreshTok,
-      scope: "openid profile email",
-    }).toString();
-    const resp = await httpsRequest("https://auth.openai.com/oauth/token", {
+    const resp = await fetch("https://auth.openai.com/oauth/token", {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body,
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: clientId,
+        refresh_token: refreshTok,
+        scope: "openid profile email",
+      }).toString(),
       signal,
     });
-    if (resp.status !== 200) return null;
-    const data = JSON.parse(resp.body);
+    if (!resp.ok) return null;
+    const data = await resp.json();
     const accessToken = data.access_token;
     if (!accessToken) return null;
     return { accessToken, refreshToken: data.refresh_token || null };
@@ -735,19 +710,19 @@ function parseLimitsFromRl(rl) {
 
 async function fetchCodexUsage(accessToken, accountId, signal) {
   try {
-    const resp = await httpsRequest("https://chatgpt.com/backend-api/wham/usage", {
+    const resp = await fetch("https://chatgpt.com/backend-api/wham/usage", {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         "chatgpt-account-id": accountId,
         "User-Agent": CODEX_USER_AGENT,
-        originator: CODEX_USER_AGENT,
+        originator: "codex_cli_rs",
       },
       signal,
     });
     if (resp.status === 401) return { unauthorized: true };
     if (resp.status === 429) return { rateLimited: true };
-    if (resp.status !== 200) return null;
-    const body = JSON.parse(resp.body);
+    if (!resp.ok) return null;
+    const body = await resp.json();
 
     const codex = parseLimitsFromRl(body.rate_limit);
 


### PR DESCRIPTION
## Summary
- Replace `httpsRequest()` (Node.js `https` module) with native `fetch()` for chatgpt.com API calls — fixes Cloudflare TLS fingerprinting block that broke Codex usage monitoring after CLI update
- Add version to User-Agent header (`codex_cli_rs/0.117.0`) per KB guidance
- Remove dead code: `https` import, `httpsRequest()`, `getSystemCa()`, `SYSTEM_CA_PATH`
- Preserve `.coral-codex-enabled` flag in `hud-auto-update.mjs` `cleanRuntimeFiles()` — was being deleted on every HUD update, disabling Codex line

## Test plan
- [x] Verify statusline Line 2 (Codex usage) appears after session restart
- [x] Verify `.coral-codex-enabled` survives HUD auto-update
- [x] Verify Codex token refresh works via `fetch()` to `auth.openai.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)