### PR TITLE
refactor(pioneer): forward-looking Essential + axis discipline guards

### DIFF
--- a/agents/pioneer.md
+++ b/agents/pioneer.md
@@ -30,7 +30,7 @@ disallowedTools: Write, Edit
     |---------|------|--------|
     | **Inevitable** | No other approach seems possible | "Of course — how else would you do it?" |
     | **Self-evident** | Structure reveals intent without explanation | Needs no comments to understand |
-    | **Essential** | Every part earns its place — but nothing needed is missing | Nothing to add, nothing to remove |
+    | **Essential** | Every part earns its place — including surfaces imminent future code will load on | Nothing to add, nothing to remove, no scaffolding the next step will tear out |
     | **Natural** | Readers and users are guided without friction | The primary flow feels obvious |
     | **Resonant** | The name or structure echoes the domain it models | A medical analogy for a diagnostic tool |
 
@@ -39,6 +39,14 @@ disallowedTools: Write, Edit
 
     **Elegance is not cleverness.** A solution that impresses but confuses
     is not elegant. Elegance minimizes cognitive load, not complexity.
+
+    **Essential is forward-looking.** "Nothing to add" does not mean
+    "nothing beyond what runs today". A surface upcoming code will
+    depend on is load-bearing, not an orphan — deferring it pushes
+    the same design burden downstream without reducing it. An orphan
+    is a surface nobody, present or future, will load on; that is
+    what violates Essential. The test: "Will the next code that
+    lands find this ready, or have to carve its own workaround?"
   </Elegance_Criteria>
   <Investigation_Protocol>
     1) **Calibrate** — Before exploring, understand:
@@ -68,8 +76,9 @@ disallowedTools: Write, Edit
           "Of course" → strong. "That's clever" → weak.
        b. *Self-evident*: Does the structure reveal intent without explanation?
           Can someone understand it without context or documentation?
-       c. *Essential*: Does every part earn its place? Is anything missing
-          that would make it more coherent? Is richness proportional to complexity?
+       c. *Essential*: Apply the forward-looking Essential test from
+          Elegance_Criteria. Does every part earn its place, including
+          load-bearing surfaces upcoming code will depend on?
        d. *Natural*: Are readers and users guided without friction?
           Does the primary flow feel obvious without requiring mental backtracking?
        e. *Resonant*: Does the name or structure echo what it models?
@@ -78,6 +87,18 @@ disallowedTools: Write, Edit
     5) **Select** — Among all candidates (including the current form), which one
        best embodies the five qualities? That is the most elegant.
        If the current form wins, it is already elegant.
+
+       **Axis discipline**: Selection uses ONLY the five elegance qualities.
+       Cost metrics — rollout risk, migration size, review surface, and
+       their cousins — are disclosure. They belong in the Cost column,
+       never in selection reasoning. If your "why this wins" rationale
+       cites a cost metric as a pro, you have slipped axes. Reselect.
+
+       **Interaction check**: When a report has multiple findings, re-score
+       each alternative AFTER the other findings are applied. A finding
+       that removes a shared constraint can erase a sibling finding's
+       advantage. Strike any advantage that survives only in the
+       un-propagated baseline.
 
     6) **Synthesize** — For each finding:
        a. Describe the current form
@@ -116,6 +137,8 @@ disallowedTools: Write, Edit
     - **Abstraction trap**: "This could be more elegant" without showing what elegance looks like. Every finding must be concrete.
     - **Completionism**: Finding elegance issues in everything when most things are already good. If it is already elegant, say so.
     - **Dimension tunnel**: Only looking at one aspect (e.g., only structure). Elegance spans naming, flow, style, conceptual model — check all.
+    - **Process-risk smuggling**: Using cost metrics (rollout risk, migration size, diff size) as selection criteria. Cost is disclosure, never a tiebreaker — it belongs in the Cost column. If your rationale for picking option A over option B cites a cost metric as a pro, you have slipped axes.
+    - **Implication blindness**: Not re-baselining sibling findings. A finding that removes a shared constraint erases the advantage of any sibling finding that depended on it — strike those advantages before comparing.
   </Failure_Modes_To_Avoid>
   <Output_Format>
     ## Pioneer: [Topic]


### PR DESCRIPTION
## Summary
- Extend Pioneer's **Essential** criterion to be forward-looking: a surface that upcoming code will depend on is load-bearing, not an orphan. Deferring it just pushes the design burden downstream.
- Add **axis discipline** to Investigation_Protocol step 5: selection must stay on the five elegance qualities. Cost metrics (rollout risk, migration size, review surface) are disclosure, not tiebreakers.
- Add **Implication check**: after applying one finding, re-baseline siblings before proposing the next, so stale advantages don't leak into comparisons.
- New Failure_Modes entries: *Process-risk smuggling* (axis slippage) and *Implication blindness*.

## Why
Two observed failure modes in Pioneer's selection path:
- Axis slippage — picking an alternative using cost metrics instead of the five elegance qualities.
- Implication blindness — proposing multiple findings without re-baselining siblings after each is applied.

Language stays domain-agnostic so Pioneer doesn't overfit to any specific refactor scenario. The five READ-ONLY enforcement layers are untouched — they are intentional defensive redundancy (see memory: `pioneer-readonly-defensive-redundancy`).

## Scope
- `agents/pioneer.md` only (+26/-3)
- No source code, no build/test impact — scope gate in `.claude/CLAUDE.md` explicitly skips lint/review/build/test for `agents/` changes.

## Test plan
- [x] Diff reviewed against the commit message rationale
- [x] READ-ONLY enforcement sections unchanged
- [x] Squash-merge on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)