### PR TITLE
fix: guard tier-review reviewers against shared-worktree git mutations

### DIFF
--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -61,3 +61,11 @@ When verifying work output, spawn a dedicated subagent instead of self-verifying
 - One goal, clean context, higher accuracy
 
 **Anti-pattern**: Agent generates artifacts → same agent "spot-checks" its own work → confirmation bias → defects pass through.
+
+### Shared-Worktree Safety
+
+Parallel review/guardian agents share one working tree but not commit isolation. A default Bash-capable agent that sees unfamiliar changes will try to "tidy up" with `git checkout` / `git stash` / `git reset` — silently reverting every sibling's in-progress work.
+
+**Rule**: every prompt that spawns an agent into a shared worktree MUST forbid state-changing git. Reviewers are read-only — no `git checkout` / `switch` / `stash` / `reset` / `restore` / `clean`, no staging, no committing. To inspect another revision, use read-only git (`git diff <ref>`, `git show <ref>:<path>`, `git log <ref>`) instead of checking it out.
+
+**Enforcement**: the `tier-review` skill embeds this guard in every Phase 3 spawn prompt. Any new parallel-spawn site (skills, orchestrators) MUST carry the same guard. A single `git checkout` in a shared tree reverts all concurrent agents' work — treat the omission as a defect, not a style choice.

--- a/.claude/skills/tier-review/SKILL.md
+++ b/.claude/skills/tier-review/SKILL.md
@@ -43,6 +43,9 @@ Run project review agents by tier taxonomy, consolidate findings, issue a verdic
     Spawn only agents marked INVOKE in the table.
     For each agent, pass: "Review [scope files] focusing on [focus from plan]."
 
+    **Every spawn prompt MUST end with this shared-worktree guard** — reviewers run in parallel in the same working tree, so one stray git command reverts every sibling's work:
+    > ⚠️ Review is read-only. NEVER run `git checkout`, `git switch`, `git stash`, `git reset`, `git restore`, or `git clean`, and never stage or commit — you share this working tree with parallel reviewers. To inspect another revision, use `git diff <ref>`, `git show <ref>:<path>`, or `git log <ref>` — never check it out.
+
     **Default**: spawn ALL INVOKE agents in parallel, wait for all.
 
     **With `--gated`** (cost-saving short-circuit — use when API budget is tight):

--- a/skills/init-project/templates/agents/AGENT.md.template
+++ b/skills/init-project/templates/agents/AGENT.md.template
@@ -47,7 +47,7 @@ model: <opus|sonnet>
 |---------|-------------|
 | `Role` | WHO — core responsibility + explicit NOT-responsible boundaries + When to Invoke table |
 | `Success_Criteria` | WHAT — measurable completion criteria |
-| `Constraints` | GUARD — iron law + DO/DON'T table. Compress failure modes here as one-liners. |
+| `Constraints` | GUARD — iron law + DO/DON'T table. Compress failure modes here as one-liners. Read-only/review agents MUST include a DON'T forbidding state-changing git (`checkout`/`switch`/`stash`/`reset`/`restore`/`clean`) and staging/committing — parallel reviewers share one worktree, so any such command reverts every sibling's work. |
 | `Output_Format` | FORMAT — structured output template with tables |
 
 ### Optional Sections

--- a/skills/init-project/templates/rules/agents.md.template
+++ b/skills/init-project/templates/rules/agents.md.template
@@ -28,3 +28,11 @@ When verifying work output, spawn a dedicated subagent instead of self-verifying
 - One goal, clean context, higher accuracy
 
 **Anti-pattern**: Agent generates artifacts → same agent "spot-checks" its own work → confirmation bias → defects pass through.
+
+### Shared-Worktree Safety
+
+Parallel review/guardian agents share one working tree but not commit isolation. A default Bash-capable agent that sees unfamiliar changes will try to "tidy up" with `git checkout` / `git stash` / `git reset` — silently reverting every sibling's in-progress work.
+
+**Rule**: every prompt that spawns an agent into a shared worktree MUST forbid state-changing git. Reviewers are read-only — no `git checkout` / `switch` / `stash` / `reset` / `restore` / `clean`, no staging, no committing. To inspect another revision, use read-only git (`git diff <ref>`, `git show <ref>:<path>`, `git log <ref>`) instead of checking it out.
+
+**Enforcement**: the `tier-review` skill embeds this guard in every Phase 3 spawn prompt. Any new parallel-spawn site (skills, orchestrators) MUST carry the same guard. A single `git checkout` in a shared tree reverts all concurrent agents' work — treat the omission as a defect, not a style choice.

--- a/skills/init-project/templates/skills/tier-review/SKILL.md
+++ b/skills/init-project/templates/skills/tier-review/SKILL.md
@@ -43,6 +43,9 @@ Run project review agents by tier taxonomy, consolidate findings, issue a verdic
     Spawn only agents marked INVOKE in the table.
     For each agent, pass: "Review [scope files] focusing on [focus from plan]."
 
+    **Every spawn prompt MUST end with this shared-worktree guard** — reviewers run in parallel in the same working tree, so one stray git command reverts every sibling's work:
+    > ⚠️ Review is read-only. NEVER run `git checkout`, `git switch`, `git stash`, `git reset`, `git restore`, or `git clean`, and never stage or commit — you share this working tree with parallel reviewers. To inspect another revision, use `git diff <ref>`, `git show <ref>:<path>`, or `git log <ref>` — never check it out.
+
     **Default**: spawn ALL INVOKE agents in parallel, wait for all.
 
     **With `--gated`** (cost-saving short-circuit — use when API budget is tight):


### PR DESCRIPTION
## Summary
`tier-review` spawns review agents in parallel into the **same working tree** with no worktree isolation. A default Bash-capable reviewer that wants to "compare against main" or "tidy up" reaches for `git checkout` / `switch` / `stash` / `reset` — which moves HEAD and silently reverts every sibling agent's in-progress work. This already caused one incident (a guardian ran `git checkout main`, wiping the feature branch's tree).

Fix at the **choke point + rule** (no per-agent duplication):
- Inject a mandatory read-only shared-worktree guard into every `tier-review` Phase 3 spawn prompt — both the active skill (`.claude/skills/tier-review`) and the init-project template.
- Document the invariant as a **Shared-Worktree Safety** principle in `agents.md` (+ template): reviewers are read-only; inspect other refs with `git diff`/`show`/`log`, never `checkout`. Any new parallel-spawn site must carry the same guard.
- Add a one-line rule to `AGENT.md.template` so generated read-only/review agents declare the same DON'T.

Version unchanged (0.7.4). Docs/rules/skills only — `npm run build:release` produces no `bridge/` diff.

## Test plan
- `npm run build:release` — clean, no `bridge/` changes
- `npm test` — 301 files / 2484 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)