### PR TITLE
statusline: Codex flag under CONFIG_DIR + enterprise dollar cap (0.7.7 patch)

### DIFF
--- a/skills/statusline/SKILL.md
+++ b/skills/statusline/SKILL.md
@@ -11,7 +11,7 @@ Manage the coral HUD statusline for Claude Code.
 
 ## Commands
 
-> **Config directory**: `CONFIG_DIR` = the **Claude config dir** reported in the SessionStart context (already resolved, absolute — it honors `CLAUDE_CONFIG_DIR`). Use it for every `CONFIG_DIR/...` path below. `~/.codex/auth.json` is Codex's own directory and is NOT affected.
+> **Config directory**: `CONFIG_DIR` = the **Claude config dir** reported in the SessionStart context (already resolved, absolute — it honors `CLAUDE_CONFIG_DIR`). Use it for every `CONFIG_DIR/...` path below, consistently across all steps. `~/.codex/auth.json` is Codex's own directory and is NOT affected.
 
 ### install
 
@@ -32,9 +32,9 @@ Manage the coral HUD statusline for Claude Code.
    }
    ```
    Expand `CONFIG_DIR` to its absolute path (and `~` to the real home directory).
-6. Check if `~/.codex/auth.json` exists:
+6. Check if `~/.codex/auth.json` exists (Codex's own dir — the literal `~/.codex`, NOT under `CONFIG_DIR`):
    - If yes, ask the user: "Codex login detected. Display Codex usage in statusline?"
-     - **yes** → create `CONFIG_DIR/hud/.coral-codex-enabled` (empty file)
+     - **yes** → create `CONFIG_DIR/hud/.coral-codex-enabled` (empty file — the **same** `CONFIG_DIR/hud` as step 2; do not write this to `~/.claude` when `CONFIG_DIR` differs)
      - **no** → delete `CONFIG_DIR/hud/.coral-codex-enabled` if it exists
    - If no `auth.json`, skip silently (do not create or delete any Codex files)
 7. Confirm installation to the user
@@ -58,7 +58,7 @@ The install command reads this file and writes it to `CONFIG_DIR/hud/coral-hud.m
 
 ## Notes
 
-- `CONFIG_DIR` is the Claude config dir from the SessionStart context (see Config directory above); expand `~` to the real home in any remaining paths
+- `CONFIG_DIR` is the Claude config dir from the SessionStart context (see Config directory above); each config dir keeps its own HUD install and its own Codex opt-in flag
 - If re-running install, overwrite the existing script (this updates the HUD to the latest version)
 - Claude rate limits are fetched from `api.anthropic.com/api/oauth/usage` using OAuth credentials
 - Codex rate limits and spark limits are fetched from `chatgpt.com/backend-api/wham/usage` (GET, no token cost); requires Codex login (`~/.codex/auth.json`)

--- a/skills/statusline/SKILL.md
+++ b/skills/statusline/SKILL.md
@@ -61,6 +61,7 @@ The install command reads this file and writes it to `CONFIG_DIR/hud/coral-hud.m
 - `CONFIG_DIR` is the Claude config dir from the SessionStart context (see Config directory above); each config dir keeps its own HUD install and its own Codex opt-in flag
 - If re-running install, overwrite the existing script (this updates the HUD to the latest version)
 - Claude rate limits are fetched from `api.anthropic.com/api/oauth/usage` using OAuth credentials
+- Enterprise/extra-usage plans have no 5h/weekly windows; instead the usage API returns `extra_usage` (a monthly dollar cap), shown in the limits slot as `mo$ <pct> ($used/$limit)`
 - Codex rate limits and spark limits are fetched from `chatgpt.com/backend-api/wham/usage` (GET, no token cost); requires Codex login (`~/.codex/auth.json`)
 - Two-line layout: Line 1 (Claude) shows model, limits, ctx, session, and last active skill; Line 2 (Codex) shows codex model, codex limits, and spark limits
 - Skill detection reads last 500KB of `transcript_path` JSONL (tail-read for performance), finds last `Skill` or `proxy_Skill` tool_use block

--- a/skills/statusline/coral-hud.mjs
+++ b/skills/statusline/coral-hud.mjs
@@ -576,11 +576,36 @@ function formatWindow(label, val, resetsAt, mode, dimLabel = false) {
   return `${prefix}${colorPct(pct)}${resetStr}`;
 }
 
+function fmtUsd(n) {
+  if (n >= 100 || Number.isInteger(n)) return `$${Math.round(n)}`;
+  if (n >= 1) return `$${n.toFixed(1)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+// Enterprise/extra-usage plans replace the 5h/weekly windows with a monthly
+// dollar cap (`extra_usage`). Amounts are integer minor units scaled by
+// `decimal_places`; utilization is derived from used/limit (the API leaves the
+// `utilization` field null at zero usage).
+function parseExtraUsage(eu) {
+  if (!eu || !eu.is_enabled || eu.disabled_reason) return null;
+  if (typeof eu.monthly_limit !== "number" || eu.monthly_limit <= 0) return null;
+  const div = Math.pow(10, typeof eu.decimal_places === "number" ? eu.decimal_places : 2);
+  const limit = eu.monthly_limit / div;
+  const used = (typeof eu.used_credits === "number" ? eu.used_credits : 0) / div;
+  return { used, limit, pct: (used / limit) * 100 };
+}
+
+function formatExtraUsage(eu) {
+  if (!eu) return null;
+  return `${DIM}mo$${RESET}${colorPct(clampPct(eu.pct))} ${DIM}(${fmtUsd(eu.used)}/${fmtUsd(eu.limit)})${RESET}`;
+}
+
 function formatLimits(data) {
   if (!data) return null;
   const parts = [
     formatWindow("5h", data.fiveHour, data.fiveHourResetsAt, "5h"),
     formatWindow("wk", data.weekly, data.weeklyResetsAt, "wk", true),
+    formatExtraUsage(data.extraUsage),
   ].filter(Boolean);
   return parts.length > 0 ? parts.join(" ") : null;
 }
@@ -636,6 +661,7 @@ async function renderLimits() {
       weekly: resp.seven_day?.utilization,
       fiveHourResetsAt: resp.five_hour?.resets_at || null,
       weeklyResetsAt: resp.seven_day?.resets_at || null,
+      extraUsage: parseExtraUsage(resp.extra_usage),
     };
     writeCacheSlot("claude", data);
     return formatLimits(data);


### PR DESCRIPTION
## statusline patch — re-tagged onto v0.7.7 (no version bump)

Two skills-only statusline fixes. Ships under the existing **0.7.7** release by re-tagging `v0.7.7` onto the squash-merge commit — no version bump (version files and `bridge/` are untouched; skills ship directly from `skills/`).

### Changes
- **fix**: statusline install keeps the Codex opt-in flag under `CONFIG_DIR/hud`, not `~/.claude`, when `CLAUDE_CONFIG_DIR` is non-default. A targeted step-6 reminder stops the model from slipping to the default dir for that one path (it used the right dir for steps 1–5 but defaulted at step 6).
- **feat**: enterprise / extra-usage plans (no 5h/weekly windows) now show the monthly dollar cap from the usage API's `extra_usage` as `mo$ <pct%> ($used/$limit)`. Verified against a live enterprise account: `mo$ 0% ($0/$466)`.

Scope: `skills/statusline/` only (`SKILL.md` + `coral-hud.mjs`). No `src/`, `bridge/`, or version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)