### PR TITLE
fix(inject): always inject the CLI/Tools section, not only in KB mode

### DIFF
--- a/INJECT.md
+++ b/INJECT.md
@@ -83,10 +83,12 @@ Emotional discipline matters. Frustration, fatigue, and the urge to finish are r
 Recognize them as inputs that degrade judgment, not reasons to cut corners.
 The correct response to "I'm almost done and something broke" is not speed — it is stillness.
 
-<!-- KB_ONLY:BEGIN -->
-# Knowledge Base
+# Tools
 
 CLI: `{{CORAL_CLI}}`
+
+<!-- KB_ONLY:BEGIN -->
+# Knowledge Base
 
 ## Search
 Source code and official docs (via WebFetch) are the source of truth — always start there.


### PR DESCRIPTION
Moves the `# Tools` heading + `CLI: {{CORAL_CLI}}` line out of the `KB_ONLY` block in `INJECT.md`, so the CLI surface reaches the provider even when KB guidance is stripped (KB-off mode). The `KB_ONLY` block now scopes only the Knowledge Base section.

Docs/template-only change. `INJECT.md` is read from the plugin root at runtime (`src/providers/inject.ts:33`), not bundled into `bridge/`, so no build artifact change is needed.

Verified: `inject` / `request-prep` / `hooks` suites green (57 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)