### PR TITLE
ci: manual release workflow + statusline live CORAL_CODEX_MODEL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+# Manual release: enter a version, run the test suite, build, then commit + tag
+# + push to main. Triggered from the Actions tab ("Run workflow").
+#
+# Requires the "protect main" repo ruleset to list GitHub Actions in its bypass
+# actors so the default GITHUB_TOKEN can push the release commit to the protected
+# branch. Without that bypass the "Commit, tag, and push" step fails with a
+# "Changes must be made through a pull request" error.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version — semver, no leading v (e.g. 0.9.13)'
+        required: true
+        type: string
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          version="$INPUT_VERSION"
+          if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "::error::Invalid version '$version' (expected semver like 0.9.13, no leading v)"
+            exit 1
+          fi
+          {
+            echo "VERSION=$version"
+            echo "TAG=v$version"
+          } >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Ensure tag does not already exist
+        run: |
+          git fetch --tags --force --quiet
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag $TAG already exists — bump the version"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 26
+
+      - run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Bump version and release build
+        run: |
+          npm version "$VERSION" --no-git-tag-version
+          npm run build:release
+
+      - name: Commit, tag, and push to main
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m "Release v$VERSION"
+          git tag -a "$TAG" -m "Release v$VERSION"
+          git push origin HEAD:main
+          git push origin "$TAG"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$TAG" --title "Release v$VERSION" --generate-notes

--- a/skills/statusline/coral-hud.mjs
+++ b/skills/statusline/coral-hud.mjs
@@ -1094,6 +1094,42 @@ function alignColumns(a, b) {
   return [padVisual(a, w), padVisual(b, w)];
 }
 
+const CODEX_MODEL_DEFAULT = 'gpt-5.6-sol';
+
+// Read one key from a settings.json `env` block; undefined on any miss (no file,
+// bad JSON, absent/empty value).
+function readSettingsEnvValue(path, key) {
+  try {
+    const value = JSON.parse(readFileSync(path, 'utf-8'))?.env?.[key];
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Codex model shown on line 2. Read the effective CORAL_CODEX_MODEL fresh from
+// settings.json on every render so an edit (including unset) reflects without a
+// session restart — this statusLine subprocess inherits the parent session's
+// env, frozen at session start, so `process.env` would go stale. Precedence
+// mirrors Claude Code's settings merge: project-local > project > user; no
+// settings value means the built-in default. A shell-exported CORAL_CODEX_MODEL
+// is deliberately not consulted — it is a frozen session-start snapshot, so
+// honoring it would defeat "unset -> default".
+function resolveCodexModelDisplay(input) {
+  const projectDir = input.cwd || input.workspace?.current_dir || input.workspace?.project_dir;
+  const paths = [];
+  if (projectDir) {
+    paths.push(join(projectDir, '.claude', 'settings.local.json'));
+    paths.push(join(projectDir, '.claude', 'settings.json'));
+  }
+  paths.push(join(CLAUDE_DIR, 'settings.json'));
+  for (const path of paths) {
+    const value = readSettingsEnvValue(path, 'CORAL_CODEX_MODEL');
+    if (value) return value;
+  }
+  return CODEX_MODEL_DEFAULT;
+}
+
 async function main() {
   const input = await readStdin();
   if (!input) {
@@ -1111,7 +1147,7 @@ async function main() {
 
   // Column alignment: model name + limits (up to second |)
   const claudeModel = renderModel(input);
-  const envModel = process.env.CORAL_CODEX_MODEL || 'gpt-5.6-sol';
+  const envModel = resolveCodexModelDisplay(input);
   let col1Claude, col1Codex, col2Claude, col2Codex;
   let codexCreditStr = null;
 


### PR DESCRIPTION
Two changes.

## 1. Manual release workflow (`.github/workflows/release.yml`)

A `workflow_dispatch` ("Run workflow" button) release.

**Usage:** Actions tab → **Release** → *Run workflow* → enter `version` (semver, no leading `v`, e.g. `0.9.13`).

**Flow:** validate semver → guard against an existing `v<version>` tag → `npm ci` → `npm test` → `npm version --no-git-tag-version` → `npm run build:release` → commit `Release v<version>` → annotated tag `v<version>` → push `main` + tag → GitHub release (`--generate-notes`). Uses default `GITHUB_TOKEN` + `contents: write`. Guards: semver validation, no tag overwrite, `concurrency`, input passed via env (no shell injection).

### ⚠️ One-time setup before the button works
`main` is protected by the **"protect main" ruleset**; the default `GITHUB_TOKEN` (`github-actions[bot]`) is not in its bypass list, so the push step fails until:

**Settings → Rules → Rulesets → "protect main" → Bypass list → add "Repository admin" or GitHub Actions**, then save.

## 2. Statusline reflects current `CORAL_CODEX_MODEL` (`skills/statusline/coral-hud.mjs`)

The HUD read the codex model from `process.env`, which the statusLine subprocess inherits frozen at session start — so editing/unsetting `CORAL_CODEX_MODEL` in `settings.json` only showed after a restart. Now resolved fresh from `settings.json` on every render (project-local > project > user, else the `gpt-5.6-sol` default), so `unset → gpt-5.6-sol` reflects with no restart. Verified: 8 cases (set / unset→default / precedence / empty / malformed-JSON / none→default), `node --check` clean, fail-open. Trade-off: a shell-exported `CORAL_CODEX_MODEL` is no longer shown in the HUD (settings.json is the source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)