### PR TITLE
ci: speed up CI tests (worker oversubscription + npm cache)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
 
       - run: npm ci
 

--- a/vitest/default.ts
+++ b/vitest/default.ts
@@ -17,5 +17,11 @@ export default defineConfig({
     exclude: ['ref/**', 'node_modules/**'],
     setupFiles: ['vitest/setup.ts'],
     globalSetup: ['vitest/no-real-coral-leak.ts'],
+    // This suite is I/O-bound (IPC sockets, subprocess spawns, timers), so on a
+    // 2-core CI runner it is worker-bound rather than core-bound: oversubscribing
+    // workers overlaps the I/O waits (measured ~1m11s @2 → ~38s @4). Applied only
+    // under CI; local dev keeps vitest's default (all cores) so a many-core box
+    // stays fast. GitHub Actions sets CI=true.
+    ...(process.env.CI ? { maxWorkers: 4, minWorkers: 4 } : {}),
   },
 });


### PR DESCRIPTION
## Faster CI tests

The `npm test` default vitest suite is **I/O-bound** (IPC sockets, subprocess spawns, timers), so on a 2-core CI runner it is worker-bound, not core-bound. Measured (worker count vs `vitest default` wall-clock):

| maxWorkers | time |
|---|---|
| 2 (≈ current CI) | ~1m11s |
| 4 | ~38s |
| 8 | ~24s |

**Changes**
- `vitest/default.ts`: gate `maxWorkers/minWorkers = 4` on `process.env.CI` so CI oversubscribes its cores to overlap I/O waits. Local dev is untouched (keeps vitest's default = all cores), so a many-core box stays fast (~15s).
- `.github/workflows/release.yml`: `actions/setup-node` `cache: npm` to cut `npm ci` time.

`CI=1 npm test` verified green — 405 files / 3587 tests pass at `maxWorkers=4`. Value kept conservative at 4 (safe for a 2-core runner's memory/CPU); can be raised later if the real CI run has headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)