### PR TITLE
ci: release workflow pushes to main via GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,14 @@
 name: Release
 
 # Manual release: enter a version, run the test suite, build, then commit + tag
-# + push to main. Triggered from the Actions tab ("Run workflow").
+# + push directly to main. Triggered from the Actions tab ("Run workflow").
 #
-# Requires the "protect main" repo ruleset to list GitHub Actions in its bypass
-# actors so the default GITHUB_TOKEN can push the release commit to the protected
-# branch. Without that bypass the "Commit, tag, and push" step fails with a
-# "Changes must be made through a pull request" error.
+# The push to protected main is authenticated as a GitHub App (secrets
+# RELEASE_APP_ID + RELEASE_APP_PRIVATE_KEY). That App is listed in the
+# "protect main" ruleset Bypass list with "Always" mode, so the release commit
+# reaches the protected branch without a PR/approval. The App only needs
+# repository Contents: read & write. Tags are unprotected, so the tag push
+# itself needs no bypass.
 
 on:
   workflow_dispatch:
@@ -21,7 +23,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
@@ -41,10 +43,18 @@ jobs:
             echo "TAG=v$version"
           } >> "$GITHUB_ENV"
 
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Ensure tag does not already exist
         run: |
@@ -69,10 +79,23 @@ jobs:
           npm version "$VERSION" --no-git-tag-version
           npm run build:release
 
-      - name: Commit, tag, and push to main
+      - name: Resolve App committer identity
+        id: committer
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          uid=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          echo "name=${APP_SLUG}[bot]" >> "$GITHUB_OUTPUT"
+          echo "email=${uid}+${APP_SLUG}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
+      - name: Commit, tag, and push to main
+        env:
+          COMMITTER_NAME: ${{ steps.committer.outputs.name }}
+          COMMITTER_EMAIL: ${{ steps.committer.outputs.email }}
+        run: |
+          git config user.name "$COMMITTER_NAME"
+          git config user.email "$COMMITTER_EMAIL"
           git add -A
           git commit -m "Release v$VERSION"
           git tag -a "$TAG" -m "Release v$VERSION"
@@ -81,5 +104,5 @@ jobs:
 
       - name: Create GitHub release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh release create "$TAG" --title "Release v$VERSION" --generate-notes


### PR DESCRIPTION
Switches the manual release workflow to push the version-bump commit to protected `main` as a **GitHub App** (rather than the default `GITHUB_TOKEN`, which can't be added to this repo's "protect main" ruleset bypass).

## How it works
- `actions/create-github-app-token@v1` mints an installation token from `secrets.RELEASE_APP_ID` + `secrets.RELEASE_APP_PRIVATE_KEY`.
- `checkout` + `git push` use that token, so the release commit + tag are pushed as the App.
- The App is in the **"protect main" ruleset Bypass list (Always)**, so the direct push to main skips the PR/approval requirement.
- Commit is authored under the App's bot identity (`<app-slug>[bot]`, canonical noreply email).
- Tags are unprotected, so the tag push needs no bypass regardless.

Result: **one-click, fully automated release (build → commit main → tag → GitHub release)** with **no personal PAT**.

## Required repo setup (already done by maintainer)
- GitHub App with repo **Contents: read & write**, installed on this repo.
- App added to the **"protect main"** ruleset bypass, **Always** mode.
- Secrets `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`.

Workflow-only change; YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)