### PR TITLE
ci: use GitHub default release labels

### DIFF
--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -10,17 +10,17 @@ Feature PRs carry **source only**. Do **not** bump the version or rebuild `clien
 
 ## PR Labels
 
-Every PR carries **exactly one type label** matching its title prefix. The label is what drives the changelog: the Release workflow groups merged PRs by label (see [`.github/release.yml`](../../.github/release.yml)), so an unlabeled PR falls under "Other Changes".
+Every PR carries **exactly one type label** mapped from its title prefix. The label is what drives the changelog: the Release workflow groups merged PRs by label (see [`.github/release.yml`](../../.github/release.yml)), so an unlabeled PR falls under "Other Changes". Reuse GitHub's default labels where they express the same type.
 
-| PR title prefix | Label       |
-| --------------- | ----------- |
-| `feat:`         | `feat`      |
-| `fix:`          | `fix`       |
-| `refactor:`     | `refactor`  |
-| `docs:`         | `docs`      |
-| `test:`         | `test`      |
-| `ci:`           | `ci`        |
-| `chore:`        | `chore`     |
+| PR title prefix | Label           |
+| --------------- | --------------- |
+| `feat:`         | `enhancement`   |
+| `fix:`          | `bug`           |
+| `refactor:`     | `refactor`      |
+| `docs:`         | `documentation` |
+| `test:`         | `test`          |
+| `ci:`           | `ci`            |
+| `chore:`        | `chore`         |
 
 Attach the label in the same step that opens the PR — `gh pr create --label <type> …` — never leave a PR unlabeled. Use the `ignore-for-release` label to omit a PR (e.g. a revert or pure no-op) from the release notes.
 
@@ -38,7 +38,7 @@ The GitHub release body is generated automatically (`gh release create --generat
 
 ## Commit Style
 
-- Prefix: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:` (a PR's prefix determines its label — see [PR Labels](#pr-labels))
+- Prefix: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:` (a PR's prefix maps to its label — see [PR Labels](#pr-labels))
 - Imperative mood: "add session fork support" not "added" or "adds"
 - Body explains WHY, not WHAT (the diff shows what)
 - Reference issue numbers when applicable

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,6 @@
 # Configures GitHub's automatic release-notes generation, used by the Release
 # workflow (`gh release create --generate-notes` in .github/workflows/release.yml).
-# Merged PRs are grouped by their single type label; label names match the
+# Merged PRs are grouped by their single type label; labels are mapped from the
 # commit / PR-title prefix convention (see .claude/rules/conventions.md § PR Labels).
 # A PR with no matching label lands in "Other Changes"; `ignore-for-release` omits it.
 changelog:
@@ -9,13 +9,13 @@ changelog:
       - ignore-for-release
   categories:
     - title: 🚀 Features
-      labels: [feat]
+      labels: [enhancement]
     - title: 🐛 Fixes
-      labels: [fix]
+      labels: [bug]
     - title: ♻️ Refactoring
       labels: [refactor]
     - title: 📝 Documentation
-      labels: [docs]
+      labels: [documentation]
     - title: 🧪 Tests
       labels: [test]
     - title: 🔧 CI & Build


### PR DESCRIPTION
## Summary

- map `feat:` PRs to GitHub's default `enhancement` label
- map `fix:` PRs to GitHub's default `bug` label
- map `docs:` PRs to GitHub's default `documentation` label
- keep the custom labels that do not have default equivalents

## Why

The release-note setup introduced custom `feat`, `fix`, and `docs` labels that duplicate GitHub's default labels. Reusing the defaults removes redundant repository metadata while preserving the existing PR-title convention.

## Impact

Generated release notes will group feature, fix, and documentation PRs by the default GitHub labels. Contributors keep using the same title prefixes; only the label mapping changes.

## Validation

- parsed `.github/release.yml` with the project's installed YAML parser
- ran `git diff --check`
- verified `feat`, `fix`, and `docs` each have zero current uses