### PR TITLE
fix: retry recoverable Codex turn failures

### DIFF
--- a/src/providers/codex/request-mapping.ts
+++ b/src/providers/codex/request-mapping.ts
@@ -14,6 +14,7 @@ import { errorMessage } from '../../infra/error-format.js';
 import { isRecord, readString } from '../../infra/json.js';
 import type { ProviderTransportClose } from '../protocol.js';
 import type { ThreadResumeParams, ThreadStartParams, TurnStartParams, UserInput } from './protocol.js';
+import type { RecoverableTurnFailure } from './turn-recovery.js';
 
 type CodexServerSpecRequest = Pick<ProviderRequest, 'cwd' | 'coralEnv' | 'secretEnv'>;
 
@@ -550,9 +551,20 @@ export const CODEX_CAPACITY_CONTINUATION_PROMPT = `Continue the unanswered or pa
 Do not repeat prior work or restate the original prompt.
 Continue from where you stopped.`;
 
-export function mapCapacityContinuationTurnStartParams(original: TurnStartParams): TurnStartParams {
+export const CODEX_CYBER_POLICY_CONTINUATION_PROMPT = `Continue the unanswered or partial repository implementation from the current thread.
+Keep the work strictly within defensive software quality: code correctness, robust input handling, bounded resource use, and regression tests in the user's own codebase.
+Do not broaden the task beyond that scope.
+Do not repeat prior work or restate the original prompt.
+Continue from where you stopped.`;
+
+export function mapRecoveryContinuationTurnStartParams(
+  original: TurnStartParams,
+  failure: RecoverableTurnFailure,
+): TurnStartParams {
+  const prompt =
+    failure === 'cyberPolicy' ? CODEX_CYBER_POLICY_CONTINUATION_PROMPT : CODEX_CAPACITY_CONTINUATION_PROMPT;
   return {
     ...original,
-    input: buildCodexTurnInput(CODEX_CAPACITY_CONTINUATION_PROMPT),
+    input: buildCodexTurnInput(prompt),
   };
 }

--- a/src/providers/codex/thread-kernel.ts
+++ b/src/providers/codex/thread-kernel.ts
@@ -17,7 +17,7 @@ import { normalizeCodexUsage, type CodexTokenUsage } from './usage.js';
 import {
   buildCodexContinuity,
   isCodexSessionUnavailable,
-  mapCapacityContinuationTurnStartParams,
+  mapRecoveryContinuationTurnStartParams,
   mapThreadResumeParams,
   mapThreadStartParams,
   mapTurnStartParams,
@@ -28,11 +28,13 @@ import {
 import type { AppServerMethod, AppServerRequestParams, AppServerResponse, Turn, TurnStartParams } from './protocol.js';
 import { locateCodexRolloutArtifactFromRuntime } from './artifacts.js';
 import {
-  isRecoverableServerOverload,
+  recoverableTurnFailure,
+  recoverableTurnFailureFromInfo,
   readErrorNotificationEvidence,
   turnFailureMessage,
   type ErrorNotificationEvidence,
-} from './capacity-recovery.js';
+  type RecoverableTurnFailure,
+} from './turn-recovery.js';
 
 const INFERRED_COMPLETION_DELAY_MS = 250;
 export const PRE_TURN_MAILBOX_CAP = 64;
@@ -636,8 +638,7 @@ function applyNotificationCore(
       if (!evidence.willRetry) {
         attempt.terminalErrors.push(evidence);
       }
-      const isOverload = evidence.info.kind === 'known' && evidence.info.value === 'serverOverloaded';
-      if (!isOverload) {
+      if (recoverableTurnFailureFromInfo(evidence.info) === null) {
         emitProgress(emit, `Codex error: ${evidence.message ?? 'unknown error'}`);
       }
       return;
@@ -1230,7 +1231,7 @@ function emitFinalTurnProgress(result: CodexKernelResult, emit: (event: Provider
   if (result.kind !== 'completed') {
     return;
   }
-  if (isRecoverableServerOverload(result.turn, result.attempt.terminalErrors)) {
+  if (recoverableTurnFailure(result.turn, result.attempt.terminalErrors) !== null) {
     return;
   }
   emitProgress(emit, `Turn ${result.turn.status ?? 'finished'}.`);
@@ -1260,29 +1261,38 @@ export const codexTurnKernel: Provider = (request, runtime) =>
       }
       const originalParams = mapTurnStartParams(request, state.threadId, state.serviceTier);
       let params = originalParams;
-      let recoveries = 0;
+      let continuationCount = 0;
+      const recoveredFailures = new Set<RecoverableTurnFailure>();
 
       for (;;) {
         const attempt = state.activeAttempt;
         const started = await startTurn(runtime, lease, state, attempt, params, emit);
         const result = started ?? (await waitForTurnResult(lease, runtime, state));
 
+        const recoveryReason =
+          result.kind === 'completed' ? recoverableTurnFailure(result.turn, result.attempt.terminalErrors) : null;
         if (
           result.kind === 'completed' &&
-          recoveries < 1 &&
           result.attempt.turnId !== null &&
-          isRecoverableServerOverload(result.turn, result.attempt.terminalErrors)
+          recoveryReason !== null &&
+          !recoveredFailures.has(recoveryReason)
         ) {
           retireAttempt(state, attempt);
-          emitProgress(emit, 'Codex capacity reached; retrying the same thread (1/1).');
+          emitProgress(
+            emit,
+            recoveryReason === 'serverOverloaded'
+              ? 'Codex capacity reached; retrying the same thread (1/1).'
+              : 'Codex policy check stopped the turn; retrying the same thread (1/1).',
+          );
           if (runtime.signal.aborted) {
             const terminal = finishInvocation(state, { kind: 'aborted', reason: 'signal_abort', attempt }, emit);
             if (terminal) emit(terminal);
             return;
           }
-          recoveries += 1;
-          state.activeAttempt = createAttempt(recoveries);
-          params = mapCapacityContinuationTurnStartParams(originalParams);
+          recoveredFailures.add(recoveryReason);
+          continuationCount += 1;
+          state.activeAttempt = createAttempt(continuationCount);
+          params = mapRecoveryContinuationTurnStartParams(originalParams, recoveryReason);
           continue;
         }
 

--- a/src/providers/codex/turn-recovery.ts
+++ b/src/providers/codex/turn-recovery.ts
@@ -143,26 +143,34 @@ export function readErrorNotificationEvidence(message: AppServerNotificationMess
   };
 }
 
-function isServerOverloaded(info: DecodedCodexErrorInfo): boolean {
-  return info.kind === 'known' && info.value === 'serverOverloaded';
+export type RecoverableTurnFailure = 'serverOverloaded' | 'cyberPolicy';
+
+export function recoverableTurnFailureFromInfo(info: DecodedCodexErrorInfo): RecoverableTurnFailure | null {
+  if (info.kind !== 'known') {
+    return null;
+  }
+  return info.value === 'serverOverloaded' || info.value === 'cyberPolicy' ? info.value : null;
 }
 
-export function isRecoverableServerOverload(
+export function recoverableTurnFailure(
   turn: Turn,
   terminalEvidence: readonly ErrorNotificationEvidence[],
-): boolean {
+): RecoverableTurnFailure | null {
   if (turn.status !== 'failed') {
-    return false;
+    return null;
   }
   const completedError = decodeTurnError(turn);
   if (completedError.kind === 'known') {
-    return isServerOverloaded(completedError.info);
+    return recoverableTurnFailureFromInfo(completedError.info);
   }
   if (completedError.kind !== 'absent') {
-    return false;
+    return null;
   }
   const lastTerminalError = terminalEvidence.at(-1);
-  return lastTerminalError !== undefined && !lastTerminalError.willRetry && isServerOverloaded(lastTerminalError.info);
+  if (lastTerminalError === undefined || lastTerminalError.willRetry) {
+    return null;
+  }
+  return recoverableTurnFailureFromInfo(lastTerminalError.info);
 }
 
 export function turnFailureMessage(

--- a/tests/unit/providers/codex-request-mapping.test.ts
+++ b/tests/unit/providers/codex-request-mapping.test.ts
@@ -4,13 +4,14 @@ import { join } from 'node:path';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
   CODEX_CAPACITY_CONTINUATION_PROMPT,
+  CODEX_CYBER_POLICY_CONTINUATION_PROMPT,
   applyCodexContinuityUpdate,
   buildCodexContinuity,
   buildCodexPrompt,
   buildCodexProviderServerSpec,
   mapThreadResumeParams,
   mapThreadStartParams,
-  mapCapacityContinuationTurnStartParams,
+  mapRecoveryContinuationTurnStartParams,
   mapTurnStartParams,
   readCodexPersistedContinuity,
   resolveCodexServiceTier,
@@ -25,8 +26,11 @@ type TierStatSync = NonNullable<NonNullable<ProviderRuntime['storage']>['statSyn
 const defaultReadFileSync: TierReadFileSync = (path, encoding) => readFileSync(path, encoding);
 const defaultStatSync: TierStatSync = statSync as TierStatSync;
 
-describe('mapCapacityContinuationTurnStartParams', () => {
-  it('preserves resolved wire settings and replaces only the input', () => {
+describe('mapRecoveryContinuationTurnStartParams', () => {
+  it.each([
+    ['serverOverloaded', CODEX_CAPACITY_CONTINUATION_PROMPT],
+    ['cyberPolicy', CODEX_CYBER_POLICY_CONTINUATION_PROMPT],
+  ] as const)('preserves resolved wire settings and replaces only the input for %s', (failure, expectedPrompt) => {
     const original = mapTurnStartParams(
       makeRequest({
         prompt: 'original task',
@@ -38,14 +42,20 @@ describe('mapCapacityContinuationTurnStartParams', () => {
       'fast',
     );
 
-    const continuation = mapCapacityContinuationTurnStartParams(original);
+    const continuation = mapRecoveryContinuationTurnStartParams(original, failure);
 
     expect(continuation).toEqual({
       ...original,
-      input: [{ type: 'text', text: CODEX_CAPACITY_CONTINUATION_PROMPT, text_elements: [] }],
+      input: [{ type: 'text', text: expectedPrompt, text_elements: [] }],
     });
     expect(continuation.input[0]?.text).not.toContain('original task');
     expect(continuation.input[0]?.text).not.toContain('system rules');
+  });
+
+  it('keeps the cyber-policy continuation narrowly scoped to defensive repository quality', () => {
+    expect(CODEX_CYBER_POLICY_CONTINUATION_PROMPT).toContain('defensive software quality');
+    expect(CODEX_CYBER_POLICY_CONTINUATION_PROMPT).toContain("user's own codebase");
+    expect(CODEX_CYBER_POLICY_CONTINUATION_PROMPT).not.toContain('cyber');
   });
 });
 

--- a/tests/unit/providers/codex/thread-provider.test.ts
+++ b/tests/unit/providers/codex/thread-provider.test.ts
@@ -509,6 +509,84 @@ describe('codexThreadProvider', () => {
     expect(lease.releaseMock).toHaveBeenCalledTimes(1);
   });
 
+  it('continues one structured cyber-policy failure in the same thread', async () => {
+    let starts = 0;
+    const lease = makeLease(async (method) => {
+      if (method === 'thread/resume') return { thread: { id: 'thread-1' } };
+      if (method === 'turn/start') {
+        starts += 1;
+        return { turn: { id: `turn-${starts}`, status: 'inProgress' } };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const eventsPromise = collect(
+      codexThreadProvider(makeRequest({ prompt: 'ordinary implementation task' }), makeRuntime(lease)),
+    );
+
+    await vi.waitFor(() => expect(starts).toBe(1));
+    lease.emit({
+      method: 'error',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        willRetry: false,
+        error: { message: 'This content was flagged for possible cybersecurity risk.', codexErrorInfo: 'cyberPolicy' },
+      },
+    });
+    lease.emit({
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: {
+          id: 'turn-1',
+          status: 'failed',
+          error: {
+            message: 'This content was flagged for possible cybersecurity risk.',
+            codexErrorInfo: 'cyberPolicy',
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() => expect(starts).toBe(2));
+    const startsParams = lease.rpcMock.mock.calls
+      .filter(([method]) => method === 'turn/start')
+      .map(([, params]) => params as Record<string, unknown>);
+    expect(startsParams[1]).toMatchObject({
+      threadId: 'thread-1',
+      input: [
+        {
+          type: 'text',
+          text: expect.stringContaining('Keep the work strictly within defensive software quality'),
+        },
+      ],
+    });
+    expect(JSON.stringify(startsParams[1])).not.toContain('ordinary implementation task');
+
+    lease.emit({
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-2',
+        item: { type: 'agentMessage', text: 'Recovered from a policy false positive', phase: 'final_answer' },
+      },
+    });
+    lease.emit({
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: { id: 'turn-2', status: 'completed' } },
+    });
+
+    const events = await eventsPromise;
+    expect(events.filter((event) => event.kind === 'terminal')).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({
+      kind: 'terminal',
+      terminal: { content: 'Recovered from a policy false positive', outcome: { kind: 'completed' } },
+    });
+    const progress = events.flatMap((event) => (event.kind === 'progress' ? [event.message] : []));
+    expect(progress).toContain('Codex policy check stopped the turn; retrying the same thread (1/1).');
+    expect(progress.some((message) => message.startsWith('Codex error: This content was flagged'))).toBe(false);
+  });
+
   it('uses exact terminal error evidence only when the completed turn omits Turn.error', async () => {
     let starts = 0;
     const lease = makeLease(async (method) => {
@@ -634,7 +712,50 @@ describe('codexThreadProvider', () => {
     }
   });
 
-  it('spends the continuation budget once when the continuation also overloads', async () => {
+  it.each([
+    ['serverOverloaded', 'capacity'],
+    ['cyberPolicy', 'policy false positive'],
+  ] as const)(
+    'spends the continuation budget once when repeated %s failures occur',
+    async (codexErrorInfo, message) => {
+      let starts = 0;
+      const lease = makeLease(async (method) => {
+        if (method === 'thread/resume') return { thread: { id: 'thread-1' } };
+        if (method === 'turn/start') {
+          starts += 1;
+          return { turn: { id: `turn-${starts}`, status: 'inProgress' } };
+        }
+        throw new Error(`Unexpected method: ${method}`);
+      });
+      const runtime = makeRuntime(lease);
+      const eventsPromise = collect(codexThreadProvider(makeRequest(), runtime));
+
+      for (const turnId of ['turn-1', 'turn-2']) {
+        await vi.waitFor(() => expect(starts).toBe(Number(turnId.at(-1))));
+        lease.emit({
+          method: 'turn/completed',
+          params: {
+            threadId: 'thread-1',
+            turn: {
+              id: turnId,
+              status: 'failed',
+              error: { message, codexErrorInfo },
+            },
+          },
+        });
+      }
+
+      const events = await eventsPromise;
+      expect(starts).toBe(2);
+      expect(events.filter((event) => event.kind === 'terminal')).toHaveLength(1);
+      expect(events.at(-1)).toMatchObject({
+        kind: 'terminal',
+        terminal: { outcome: { kind: 'provider_exit', note: expect.stringContaining(message) } },
+      });
+    },
+  );
+
+  it('grants one continuation to each recoverable error kind in the same thread', async () => {
     let starts = 0;
     const lease = makeLease(async (method) => {
       if (method === 'thread/resume') return { thread: { id: 'thread-1' } };
@@ -644,31 +765,37 @@ describe('codexThreadProvider', () => {
       }
       throw new Error(`Unexpected method: ${method}`);
     });
-    const runtime = makeRuntime(lease);
-    const eventsPromise = collect(codexThreadProvider(makeRequest(), runtime));
+    const eventsPromise = collect(codexThreadProvider(makeRequest(), makeRuntime(lease)));
+    const failures = [
+      { codexErrorInfo: 'serverOverloaded', message: 'capacity' },
+      { codexErrorInfo: 'cyberPolicy', message: 'policy false positive' },
+      { codexErrorInfo: 'serverOverloaded', message: 'capacity again' },
+    ] as const;
 
-    for (const turnId of ['turn-1', 'turn-2']) {
-      await vi.waitFor(() => expect(starts).toBe(Number(turnId.at(-1))));
+    for (const [index, failure] of failures.entries()) {
+      const turnNumber = index + 1;
+      await vi.waitFor(() => expect(starts).toBe(turnNumber));
       lease.emit({
         method: 'turn/completed',
         params: {
           threadId: 'thread-1',
-          turn: {
-            id: turnId,
-            status: 'failed',
-            error: { message: 'capacity', codexErrorInfo: 'serverOverloaded' },
-          },
+          turn: { id: `turn-${turnNumber}`, status: 'failed', error: failure },
         },
       });
     }
 
     const events = await eventsPromise;
-    expect(starts).toBe(2);
+    expect(starts).toBe(3);
     expect(events.filter((event) => event.kind === 'terminal')).toHaveLength(1);
     expect(events.at(-1)).toMatchObject({
       kind: 'terminal',
-      terminal: { outcome: { kind: 'provider_exit', note: expect.stringContaining('capacity') } },
+      terminal: { outcome: { kind: 'provider_exit', note: expect.stringContaining('capacity again') } },
     });
+    const progress = events.flatMap((event) => (event.kind === 'progress' ? [event.message] : []));
+    expect(progress.filter((message) => message.includes('retrying the same thread (1/1)'))).toEqual([
+      'Codex capacity reached; retrying the same thread (1/1).',
+      'Codex policy check stopped the turn; retrying the same thread (1/1).',
+    ]);
   });
 
   it('does not continue non-capacity failures', async () => {

--- a/tests/unit/providers/codex/turn-recovery.test.ts
+++ b/tests/unit/providers/codex/turn-recovery.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest';
 import {
   decodeCodexErrorInfo,
   decodeTurnError,
-  isRecoverableServerOverload,
+  recoverableTurnFailure,
   readErrorNotificationEvidence,
-} from '#src/providers/codex/capacity-recovery.js';
+} from '#src/providers/codex/turn-recovery.js';
 import type { CodexErrorInfo, Turn } from '#src/providers/codex/protocol.js';
 
 const stringVariants = [
@@ -90,7 +90,7 @@ describe('Codex structured error decoding', () => {
   });
 });
 
-describe('capacity recovery classification', () => {
+describe('turn recovery classification', () => {
   const overloadEvidence = readErrorNotificationEvidence({
     method: 'error',
     params: {
@@ -107,56 +107,67 @@ describe('capacity recovery classification', () => {
       status: 'failed',
       error: { message: 'capacity', codexErrorInfo: 'serverOverloaded' },
     } satisfies Turn;
-    expect(isRecoverableServerOverload(turn, [])).toBe(true);
+    expect(recoverableTurnFailure(turn, [])).toBe('serverOverloaded');
+
+    const cyberPolicy = {
+      ...turn,
+      error: { message: 'policy false positive', codexErrorInfo: 'cyberPolicy' },
+    } satisfies Turn;
+    expect(recoverableTurnFailure(cyberPolicy, [])).toBe('cyberPolicy');
 
     const badRequest = {
       ...turn,
       error: { message: 'bad', codexErrorInfo: 'badRequest' },
     } satisfies Turn;
-    expect(isRecoverableServerOverload(badRequest, overloadEvidence ? [overloadEvidence] : [])).toBe(false);
+    expect(recoverableTurnFailure(badRequest, overloadEvidence ? [overloadEvidence] : [])).toBeNull();
 
     const conflictingEvidence = overloadEvidence
       ? [{ ...overloadEvidence, info: decodeCodexErrorInfo('badRequest'), message: 'later bad request' }]
       : [];
-    expect(isRecoverableServerOverload(turn, conflictingEvidence)).toBe(true);
+    expect(recoverableTurnFailure(turn, conflictingEvidence)).toBe('serverOverloaded');
   });
 
-  it('keeps every non-capacity structured cause outside the recovery allowlist', () => {
-    const nonCapacity: unknown[] = [
-      ...stringVariants.filter((variant) => variant !== 'serverOverloaded'),
+  it('keeps every non-recoverable structured cause outside the recovery allowlist', () => {
+    const nonRecoverable: unknown[] = [
+      ...stringVariants.filter((variant) => variant !== 'serverOverloaded' && variant !== 'cyberPolicy'),
       { httpConnectionFailed: { httpStatusCode: 503 } },
       { responseStreamConnectionFailed: { httpStatusCode: 502 } },
       { responseStreamDisconnected: { httpStatusCode: null } },
       { responseTooManyFailedAttempts: { httpStatusCode: 429 } },
       { activeTurnNotSteerable: { turnKind: 'review' } },
     ];
-    for (const codexErrorInfo of nonCapacity) {
+    for (const codexErrorInfo of nonRecoverable) {
       const turn = {
         id: 'turn-1',
         status: 'failed',
         error: { message: 'not capacity', codexErrorInfo },
       } as unknown as Turn;
-      expect(isRecoverableServerOverload(turn, [])).toBe(false);
+      expect(recoverableTurnFailure(turn, [])).toBeNull();
     }
   });
 
   it('uses only terminal matching notification evidence when Turn.error is physically absent', () => {
     const turn = { id: 'turn-1', status: 'failed' } satisfies Turn;
     expect(overloadEvidence).not.toBeNull();
-    expect(isRecoverableServerOverload(turn, overloadEvidence ? [overloadEvidence] : [])).toBe(true);
+    expect(recoverableTurnFailure(turn, overloadEvidence ? [overloadEvidence] : [])).toBe('serverOverloaded');
+
+    const cyberEvidence = overloadEvidence
+      ? { ...overloadEvidence, info: decodeCodexErrorInfo('cyberPolicy'), message: 'policy false positive' }
+      : null;
+    expect(recoverableTurnFailure(turn, cyberEvidence ? [cyberEvidence] : [])).toBe('cyberPolicy');
 
     const retrying = overloadEvidence ? { ...overloadEvidence, willRetry: true } : null;
-    expect(isRecoverableServerOverload(turn, retrying ? [retrying] : [])).toBe(false);
+    expect(recoverableTurnFailure(turn, retrying ? [retrying] : [])).toBeNull();
 
     const badRequest = overloadEvidence
       ? { ...overloadEvidence, info: decodeCodexErrorInfo('badRequest'), message: 'later bad request' }
       : null;
     expect(
-      isRecoverableServerOverload(turn, overloadEvidence && badRequest ? [overloadEvidence, badRequest] : []),
-    ).toBe(false);
-    expect(
-      isRecoverableServerOverload(turn, overloadEvidence && badRequest ? [badRequest, overloadEvidence] : []),
-    ).toBe(true);
+      recoverableTurnFailure(turn, overloadEvidence && badRequest ? [overloadEvidence, badRequest] : []),
+    ).toBeNull();
+    expect(recoverableTurnFailure(turn, overloadEvidence && badRequest ? [badRequest, overloadEvidence] : [])).toBe(
+      'serverOverloaded',
+    );
   });
 
   it('blocks fallback when Turn.error is present but unknown, invalid, or has null info', () => {
@@ -170,7 +181,7 @@ describe('capacity recovery classification', () => {
     ]) {
       const turn = { id: 'turn-1', status: 'failed', error } as unknown as Turn;
       expect(decodeTurnError(turn).kind).not.toBe('absent');
-      expect(isRecoverableServerOverload(turn, evidence)).toBe(false);
+      expect(recoverableTurnFailure(turn, evidence)).toBeNull();
     }
   });
 


### PR DESCRIPTION
## Summary

- recover structured cyberPolicy failures in addition to serverOverloaded
- grant one same-thread continuation per recoverable error kind in each execution chain
- use a dedicated defensive repository-quality continuation prompt after cyberPolicy
- keep repeated and non-allowlisted failures fail-closed

## Behavior

- serverOverloaded may continue once on the same Codex thread
- cyberPolicy may continue once on the same Codex thread
- one failure of each kind may recover in sequence
- a repeated failure kind terminates without an automatic loop
- explicit later user requests start a fresh recovery chain

## Validation

- focused Codex provider tests: 139 passed
- full default suite: 407 files, 3661 tests passed
- full simulation suite passed
- TypeScript typecheck passed
- ESLint for changed files passed
- production build passed
- changed-file Prettier and git diff checks passed