### PR TITLE
fix(kiwi): download WASM as a verified runtime artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,13 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
 
 jobs:
   build-and-test:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -30,3 +34,21 @@ jobs:
       - run: npm run test:store-reset:integration
       - run: npm run verify:store-reset-build
       - run: npm run test:e2e:store-reset:build
+
+  network-test:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [24, 26]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run test:network

--- a/README.ko.md
+++ b/README.ko.md
@@ -242,7 +242,7 @@ Coral은 매 세션에서 배웁니다. 근본 원인, 주의사항, 패턴 — 
 
 Coral은 항상 `Intl.Segmenter`를 기본값으로 사용해 KB 텍스트를 인덱싱합니다. **다국어 검색에는 별도 설정이 필요 없습니다** — 한국어·중국어·일본어 같은 비라틴 문자도 기본값으로 단어/어절 단위 검색이 동작합니다. `CORAL_KB_EXTRA_LANGS`는 그 상시 활성 기본값 위에 특정 언어용 형태소 분석기를 추가로 켭니다. 값은 `ko`처럼 소문자 쉼표 구분 언어 코드로 씁니다. 현재 엔진이 있는 코드는 `ko`뿐입니다.
 
-한국어 엔진은 Kiwi `cong`입니다. 선택하면 로드된 동안 resident memory가 약 1 GB 늘 수 있습니다. 엔진은 lazy-loaded 및 idle-evicted 방식으로 동작하며, 필요할 때 Coral이 약 88 MB 모델을 자동으로 가져옵니다.
+한국어 엔진은 Kiwi `cong`입니다. 선택하면 로드된 동안 resident memory가 약 1 GB 늘 수 있습니다. 엔진은 lazy-loaded 및 idle-evicted 방식으로 동작합니다. Coral은 누락되었거나 유효하지 않은 런타임 아티팩트만 내려받습니다. clean install 기준 GitHub Releases의 약 88 MB CoNg 모델과 npm의 고정된 약 0.9 MB `kiwi-nlp` 아카이브이며, 기존의 유효한 모델은 보존합니다. Kiwi 로드가 최종 실패 상태에 이르면 Coral은 `Intl.Segmenter` 기본 검색을 제공하고, 아티팩트가 복구되면 재시작 없이 Kiwi를 다시 로드해 한국어를 재색인합니다.
 
 `.claude/settings.json`에 설정 (세션 간 유지):
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Coral learns from every session. Root causes, gotchas, and patterns stay searcha
 
 Coral always indexes KB text with `Intl.Segmenter` as the baseline. **No configuration is required for multilingual search** — non-Latin scripts such as Korean, Chinese, and Japanese are searchable at word-like units out of the box. `CORAL_KB_EXTRA_LANGS` opts extra languages into a dedicated morphological analyzer on top of that always-on baseline. Use lowercase, comma-separated language codes, for example `ko`; today only `ko` has an engine.
 
-The Korean engine is Kiwi `cong`. Opting into it can add about 1 GB of resident memory while loaded; it is lazy-loaded and idle-evicted, and Coral auto-fetches an approximately 88 MB model when needed.
+The Korean engine is Kiwi `cong`. Opting into it can add about 1 GB of resident memory while loaded; it is lazy-loaded and idle-evicted. Coral downloads only missing or invalid runtime artifacts: an approximately 88 MB CoNg model from GitHub Releases and a pinned approximately 0.9 MB `kiwi-nlp` archive from npm on a clean install. A valid existing model is preserved. After a terminal Kiwi load failure, Coral serves the `Intl.Segmenter` baseline; once the artifacts are repaired, it reloads Kiwi and reindexes Korean without a restart.
 
 Set in `.claude/settings.json` (persists across sessions):
 

--- a/clients/skills/equip/SKILL.md
+++ b/clients/skills/equip/SKILL.md
@@ -47,7 +47,7 @@ Bundled engines auto-equip at coordinator boot via the bundled fallback pass. Th
 
 | status    | Action |
 |-----------|--------|
-| `catalog` | Present the catalog as a table with `id`, `name`, `tier`, package `description`, `provides` when present, translated `activation`, `status`, `statusDescription` when present, and `cleanupCommand` when present. Render `provides` as sibling collections: `provides.capabilities` as a comma-separated capability label/name list and `provides.retrievalRoles` as a comma-separated role label list, for example `provides: capabilities=[Text (FTS), Vector (Semantic)]; retrievalRoles=[Text, Vector, Graph]`. Do not group capabilities by `typeTag`; it is opaque metadata |
+| `catalog` | Present the catalog as a table with `id`, `name`, `tier`, package `description`, `provides` when present, translated `activation`, `status`, `statusDescription` when present, `confirmDownload` when present, and `cleanupCommand` when present. Render `provides` as sibling collections: `provides.capabilities` as a comma-separated capability label/name list and `provides.retrievalRoles` as a comma-separated role label list, for example `provides: capabilities=[Text (FTS), Vector (Semantic)]; retrievalRoles=[Text, Vector, Graph]`. Do not group capabilities by `typeTag`; it is opaque metadata |
 | `info`    | Show the single package entry using the same package-status routing table below, including `tier`, `fills`/`slot` when present, `provides` when present using the same sibling collection rendering as catalog rows, and the translated `activation` label |
 | `error`   | Show `userMessage` and `remediation`. Show `suggestions` when present, then stop. For debugging, show `code` and any `context` fields |
 
@@ -84,26 +84,21 @@ Bundled engines auto-equip at coordinator boot via the bundled fallback pass. Th
 
 | status               | Action                                                                                                                                                                                                                                                                     |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `already_installed`  | Inform user; `expansion equip` continues activation when applicable. If `method` is present, apply the no-change install-only routing below                                                                                                                                |
-| `already_up_to_date` | Inform user with version; `expansion equip` continues activation when applicable. If `method` is present, apply the no-change install-only routing below                                                                                                                   |
-| `installed`          | Show method used. For `method: 'runtime-download'`, apply the conditional live-recovery routing below. For other install-only methods, show `command` when present and mention restart only when the installer registered agent tooling   |
-| `updated`            | Show method and version. For `method: 'runtime-download'`, apply the conditional live-recovery routing below. For other install-only methods, show `command` when present and mention restart only when updated agent tooling requires it |
+| `already_installed`  | Inform user; `expansion equip` continues activation when applicable. For install-only results, apply the no-change case in the shared install-only result routing in the `--update <package>` section below                                                                   |
+| `already_up_to_date` | Inform user with version; `expansion equip` continues activation when applicable. For install-only results, apply the no-change case in the shared install-only result routing in the `--update <package>` section below                                                      |
+| `installed`          | Show method used. For install-only results, apply the changed case in the shared install-only result routing in the `--update <package>` section below                                                        |
+| `updated`            | Show method and version. For install-only results, apply the changed case in the shared install-only result routing in the `--update <package>` section below                                                 |
 | `equipped`           | Expansion is installed and active in the coordinator (equipment-backed packages only)                                                                                                                                                                                      |
 | `catching_up`        | Expansion is activating; tell the user to poll `/equip --list` until it reaches `equipped`                                                                                                                                                                                 |
 | `already_equipped`   | Inform the user the expansion is already active                                                                                                                                                                                                                            |
 | `error`              | Show `userMessage` and `remediation`. Show `suggestions` when present, then stop. For debugging, show `code` and any `context` fields                                                                                                                                      |
 
-6. For `installed` or `updated` install-only results that carry `method`:
-   - `method: 'runtime-download'`: show `targetDir` when present and say no coding-agent restart is required. When `ko` is enabled and the backend is active, Kiwi recovery and Korean reindex proceed live; otherwise the artifacts are ready for the next backend start or for when `ko` is enabled.
-   - Other methods: show the executable `command` when present. Mention an agent restart only when that installer registered or updated agent tooling.
-7. For the no-change statuses `already_installed` and `already_up_to_date` that carry `method`:
-   - `method: 'runtime-download'`: show `targetDir` when present and explain that the artifacts were already valid, so this command started neither a download nor a reindex. Do not promise an analyzer upgrade. If Kiwi remains degraded, run `coral-cli backend shutdown` so the next command restarts the backend and retries initialization; if that retry also fails, check artifact filesystem permissions and report the repeated error.
-   - Other methods: show the existing `command` when present without claiming that the installer ran or that a restart is required.
-8. Onboarding runs inside `coral-cli expansion equip <package>` before install/activate:
+6. Apply the shared install-only result routing in the `--update <package>` section below when the mutation result is install-only.
+7. Onboarding runs inside `coral-cli expansion equip <package>` before install/activate:
    - `engine_env_var_missing`: show the missing `envVar` and remediation exactly. Do not suggest restart/retry loops.
    - `binding_required`: show `suggestions` when present; otherwise show candidate ids from `context.candidates` when present. The user should equip one engine that fills the missing binding, then retry the original package.
    - `user_cancelled`: stop without retrying automatically.
-9. Do not run `coral-cli expansion equip <package>` a second time unless the user has changed the missing setup state or equipped a required peer engine.
+8. Do not run `coral-cli expansion equip <package>` a second time unless the user has changed the missing setup state or equipped a required peer engine.
 
 ### `--update <package>`
 
@@ -115,17 +110,24 @@ Bundled engines auto-equip at coordinator boot via the bundled fallback pass. Th
 
 | status               | Action                                                                                                                                |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `already_installed`  | Inform user. If `method` is present, apply the no-change install-only routing below                                                    |
-| `already_up_to_date` | Inform user with version. If `method` is present, apply the no-change install-only routing below                                       |
-| `installed`          | Show method and version, then apply the changed install-only routing below                                                             |
-| `updated`            | Show method and version, then apply the changed install-only routing below                                                             |
+| `already_up_to_date` | Inform user with version. For install-only results, apply the no-change case in the shared install-only result routing below            |
+| `updated`            | Show method and version. For install-only results, apply the changed case in the shared install-only result routing below               |
 | `equipped`           | Expansion is updated and active in the coordinator                                                                                    |
 | `catching_up`        | Expansion is updated and activating; tell the user to poll `/equip --list` until it reaches `equipped`                                |
 | `already_equipped`   | Inform the user the updated expansion is already active                                                                               |
 | `error`              | Show `userMessage` and `remediation`. Show `suggestions` when present, then stop. For debugging, show `code` and any `context` fields |
 
-5. Apply the same changed versus no-change install-only routing as ordinary equip. For `installed` and `updated` with `method: 'runtime-download'`, show `targetDir` when present and use the same conditional live-recovery guidance: no coding-agent restart is required; recovery and reindex are live only when `ko` is enabled and the backend is active, otherwise the artifacts are ready for the next backend start or for when `ko` is enabled. For `already_installed` and `already_up_to_date`, say the artifacts were already valid and this command started neither a download nor a reindex; do not promise an analyzer upgrade. Show `targetDir` or `command` according to the method as above.
+5. Apply the shared install-only result routing below: use the changed case for `updated` and the no-change case for `already_up_to_date`.
 6. `update` is equivalent to `equip` when the local version differs from the catalog version; `/equip <package>` also updates implicitly. Use `/equip --update <package>` when the user is explicitly asking to bump or refresh the installed version.
+
+#### Shared install-only result routing
+
+- Changed results:
+  - `method: 'runtime-download'`: show `targetDir` when present and say no coding-agent restart is required. When `ko` is enabled and the backend is active, Kiwi recovery and Korean reindex proceed live; otherwise the artifacts are ready for the next backend start or for when `ko` is enabled.
+  - Other methods: show the executable `command` when present. Mention an agent restart only when that installer registered or updated agent tooling.
+- No-change results:
+  - `method: 'runtime-download'`: show `targetDir` when present and explain that the artifacts were already valid, so this command started neither a download nor a reindex. Do not promise an analyzer upgrade. Unconditionally offer this next step: if Korean search is still not using Kiwi, the user can run `coral-cli backend shutdown` so the next command restarts the backend and retries initialization; if that retry also fails, check artifact filesystem permissions and report the repeated error.
+  - Other methods: show the existing `command` when present without claiming that the installer ran or that a restart is required.
 
 ### `info <package>`
 

--- a/clients/skills/equip/SKILL.md
+++ b/clients/skills/equip/SKILL.md
@@ -75,52 +75,63 @@ Bundled engines auto-equip at coordinator boot via the bundled fallback pass. Th
 
 ### `<package>`
 
-0. Unless you already know the package's `activation` from a prior `--list`/`info` in this session, run `coral-cli expansion info <package>` first.
+0. Unless this session already has a complete current `--list`/`info` entry for the package — including `activation` and whether `confirmDownload` is present — run `coral-cli expansion info <package>` first. Remembering only the activation is not sufficient.
 1. **Retired residue gate.** If `activation` is `'remove-catalog'`, do not run `expansion equip`. When `cleanupCommand` is present, show that exact command, ask the user to confirm cleanup, and on confirmation run only Bash(`<exact cleanupCommand>`), parse its single-line JSON result, and stop. Never interpolate or reconstruct this command. When `cleanupCommand` is absent, show `lastError` and stop without running any command.
-2. **Consent gate for install-only packages.** If `activation` is `'none'`, equipping runs the package's own install script through your shell (typically `curl … | bash`) — code Coral fetches from a remote host and executes. Tell the user the package id and that equipping will download and run a remote install script, then ask them to confirm. If they decline, stop without running equip. (Engine packages — `activation: 'equip'` — need no extra prompt; proceed directly.) The install runs synchronously and its script output is not streamed back — only the final status returns — so tell the user it may take up to a minute before reporting.
+2. **Consent gate for install-only packages.** If `activation` is `'none'` and the current entry includes `confirmDownload`, show that message exactly and ask the user to confirm. It describes the package's actual download and preservation behavior; do not replace it with a generic remote-script warning. If the field is absent, explain that the package may run its own remote install script through the shell, then ask for confirmation. If the user declines, stop without running equip. (Engine packages — `activation: 'equip'` — need no extra prompt; proceed directly.) The install runs synchronously and progress is not streamed back, so explain that the final result may take time.
 3. Bash(`coral-cli expansion equip <package>`)
 4. Parse the single-line JSON result.
 5. Route by `status`:
 
-| status               | Action                                                                                                           |
-|----------------------|------------------------------------------------------------------------------------------------------------------|
-| `already_installed`  | Inform user; `expansion equip` continues activation when applicable                                              |
-| `already_up_to_date` | Inform user with version; `expansion equip` continues activation when applicable                                 |
-| `installed`          | Show method used. For install-only packages, show `command` when present, then tell the user to restart their coding agent so any tooling the install script registered (e.g. an MCP server) takes effect |
-| `updated`            | Show method and version. For install-only packages, show `command` when present, then tell the user to restart their coding agent for the updated tooling to take effect |
-| `equipped`           | Expansion is installed and active in the coordinator (equipment-backed packages only)                            |
-| `catching_up`        | Expansion is activating; tell the user to poll `/equip --list` until it reaches `equipped`                       |
-| `already_equipped`   | Inform the user the expansion is already active                                                                  |
-| `error`              | Show `userMessage` and `remediation`. Show `suggestions` when present, then stop. For debugging, show `code` and any `context` fields |
+| status               | Action                                                                                                                                                                                                                                                                     |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `already_installed`  | Inform user; `expansion equip` continues activation when applicable. If `method` is present, apply the no-change install-only routing below                                                                                                                                |
+| `already_up_to_date` | Inform user with version; `expansion equip` continues activation when applicable. If `method` is present, apply the no-change install-only routing below                                                                                                                   |
+| `installed`          | Show method used. For `method: 'runtime-download'`, apply the conditional live-recovery routing below. For other install-only methods, show `command` when present and mention restart only when the installer registered agent tooling   |
+| `updated`            | Show method and version. For `method: 'runtime-download'`, apply the conditional live-recovery routing below. For other install-only methods, show `command` when present and mention restart only when updated agent tooling requires it |
+| `equipped`           | Expansion is installed and active in the coordinator (equipment-backed packages only)                                                                                                                                                                                      |
+| `catching_up`        | Expansion is activating; tell the user to poll `/equip --list` until it reaches `equipped`                                                                                                                                                                                 |
+| `already_equipped`   | Inform the user the expansion is already active                                                                                                                                                                                                                            |
+| `error`              | Show `userMessage` and `remediation`. Show `suggestions` when present, then stop. For debugging, show `code` and any `context` fields                                                                                                                                      |
 
-6. Onboarding runs inside `coral-cli expansion equip <package>` before install/activate:
+6. For `installed` or `updated` install-only results that carry `method`:
+   - `method: 'runtime-download'`: show `targetDir` when present and say no coding-agent restart is required. When `ko` is enabled and the backend is active, Kiwi recovery and Korean reindex proceed live; otherwise the artifacts are ready for the next backend start or for when `ko` is enabled.
+   - Other methods: show the executable `command` when present. Mention an agent restart only when that installer registered or updated agent tooling.
+7. For the no-change statuses `already_installed` and `already_up_to_date` that carry `method`:
+   - `method: 'runtime-download'`: show `targetDir` when present and explain that the artifacts were already valid, so this command started neither a download nor a reindex. Do not promise an analyzer upgrade. If Kiwi remains degraded, run `coral-cli backend shutdown` so the next command restarts the backend and retries initialization; if that retry also fails, check artifact filesystem permissions and report the repeated error.
+   - Other methods: show the existing `command` when present without claiming that the installer ran or that a restart is required.
+8. Onboarding runs inside `coral-cli expansion equip <package>` before install/activate:
    - `engine_env_var_missing`: show the missing `envVar` and remediation exactly. Do not suggest restart/retry loops.
    - `binding_required`: show `suggestions` when present; otherwise show candidate ids from `context.candidates` when present. The user should equip one engine that fills the missing binding, then retry the original package.
    - `user_cancelled`: stop without retrying automatically.
-7. Do not run `coral-cli expansion equip <package>` a second time unless the user has changed the missing setup state or equipped a required peer engine.
+9. Do not run `coral-cli expansion equip <package>` a second time unless the user has changed the missing setup state or equipped a required peer engine.
 
 ### `--update <package>`
 
-1. Bash(`coral-cli expansion update <package>`)
-2. Parse the single-line JSON result.
-3. Route by `status`:
+0. Apply the same current-entry preflight as `<package>`: unless this session has a complete current entry including `activation` and whether `confirmDownload` is present, run `coral-cli expansion info <package>`.
+1. Apply the same retired-residue gate. For `activation: 'none'`, apply the same consent gate before update: when `confirmDownload` is present, show that message exactly and ask for confirmation; when absent, show the shell-installer warning and ask for confirmation. If declined, stop without running update.
+2. Bash(`coral-cli expansion update <package>`)
+3. Parse the single-line JSON result.
+4. Route by `status`:
 
-| status               | Action |
-|----------------------|--------|
-| `already_up_to_date` | Inform user with version. If `command` is present for an install-only expansion, show the installed path; no further action |
-| `updated`            | Show method and version. If `command` is present for an install-only expansion, show the installed path |
-| `equipped`           | Expansion is updated and active in the coordinator |
-| `catching_up`        | Expansion is updated and activating; tell the user to poll `/equip --list` until it reaches `equipped` |
-| `already_equipped`   | Inform the user the updated expansion is already active |
+| status               | Action                                                                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `already_installed`  | Inform user. If `method` is present, apply the no-change install-only routing below                                                    |
+| `already_up_to_date` | Inform user with version. If `method` is present, apply the no-change install-only routing below                                       |
+| `installed`          | Show method and version, then apply the changed install-only routing below                                                             |
+| `updated`            | Show method and version, then apply the changed install-only routing below                                                             |
+| `equipped`           | Expansion is updated and active in the coordinator                                                                                    |
+| `catching_up`        | Expansion is updated and activating; tell the user to poll `/equip --list` until it reaches `equipped`                                |
+| `already_equipped`   | Inform the user the updated expansion is already active                                                                               |
 | `error`              | Show `userMessage` and `remediation`. Show `suggestions` when present, then stop. For debugging, show `code` and any `context` fields |
 
-4. `update` is equivalent to `equip` when the local version differs from the catalog version; `/equip <package>` also updates implicitly. Use `/equip --update <package>` when the user is explicitly asking to bump or refresh the installed version.
+5. Apply the same changed versus no-change install-only routing as ordinary equip. For `installed` and `updated` with `method: 'runtime-download'`, show `targetDir` when present and use the same conditional live-recovery guidance: no coding-agent restart is required; recovery and reindex are live only when `ko` is enabled and the backend is active, otherwise the artifacts are ready for the next backend start or for when `ko` is enabled. For `already_installed` and `already_up_to_date`, say the artifacts were already valid and this command started neither a download nor a reindex; do not promise an analyzer upgrade. Show `targetDir` or `command` according to the method as above.
+6. `update` is equivalent to `equip` when the local version differs from the catalog version; `/equip <package>` also updates implicitly. Use `/equip --update <package>` when the user is explicitly asking to bump or refresh the installed version.
 
 ### `info <package>`
 
 1. Bash(`coral-cli expansion info <package>`)
 2. Parse the single-line JSON result.
-3. Show the status and, when returned, the package `tier`, `provides.capabilities`, `addonPath`, installed `command`, retired-residue `cleanupCommand`, `userMessage`, and `remediation`. Treat an error result as terminal.
+3. Show the status and, when returned, the package `tier`, `provides.capabilities`, `confirmDownload`, `addonPath`, installed `command`, retired-residue `cleanupCommand`, `userMessage`, and `remediation`. Show `confirmDownload` exactly so the user can inspect any source, size, and preservation disclosure before equip or update. Treat an error result as terminal.
 
 ### `uninstall <equipment-name>`
 
@@ -130,17 +141,17 @@ Bundled engines auto-equip at coordinator boot via the bundled fallback pass. Th
 
 | status         | Action                                                                                                           |
 |----------------|------------------------------------------------------------------------------------------------------------------|
-| `uninstalled`  | Confirm the installed-tier engine was removed through the coordinator-owned catalog-removal transaction           |
+| `uninstalled`  | For install-only packages, confirm the local installation or runtime artifacts were removed directly. For installed-tier engines, confirm removal through the coordinator-owned catalog-removal transaction |
 | `not_equipped` | Inform user the engine was already not equipped; treat as success                                                |
 | `error`        | Show `userMessage` and `remediation`. Show `suggestions` when present, then stop. For debugging, show `code` and any `context` fields |
 
-4. `unequip` for installed-tier engines asks the coordinator to remove the catalog entry transactionally, which disposes any live scope without running bundled fallback, unregisters manifest-scoped capability declarations when allowed, and then removes local artifacts. For install-only packages, it removes the local binary.
+4. `unequip` for installed-tier engines asks the coordinator to remove the catalog entry transactionally, which disposes any live scope without running bundled fallback, unregisters manifest-scoped capability declarations when allowed, and then removes local artifacts. For install-only packages, it removes the local installation or runtime artifacts.
 
 ## Notes
 
-- Install-only binaries and engine artifacts both land under the engine data tree (`~/.coral/data/engines/<engine>/`, or `~/.coral/data-dev/engines/<engine>/` when `CORAL_FLAVOR=dev`); the CLI reports the exact installed path as `command`
+- Install-only binaries and engine artifacts both land under the engine data tree (`~/.coral/data/engines/<engine>/`, or `~/.coral/data-dev/engines/<engine>/` when `CORAL_FLAVOR=dev`). Shell-installer results report the executable path as `command`; pinned runtime-download results report their artifact root as `targetDir`
 - Corpus indexes stay under `~/.coral/data/kb/` in prod or `~/.coral/data-dev/kb/` in dev
 - These data paths are account-neutral. `CODEX_HOME` and `CLAUDE_CONFIG_DIR` select provider credentials per invocation and never change the Coral daemon or state root
 - Some installed engines may have native artifacts or model downloads; follow the `userMessage` and `remediation` returned by the CLI for missing prerequisites.
-- An install-only package (`activation: 'none'`) installs by running the package's own install script (which Coral executes via the shell, e.g. `curl … | bash`). That external script — not Coral — may register the tool with the coding agent (for example as an MCP server); when it does, the agent must be restarted before the newly installed tooling is available.
+- An install-only package (`activation: 'none'`) may use a shell installer or Coral's pinned `runtime-download` path. Read `confirmDownload` and the returned `method` instead of assuming a remote script. Only shell installers that register coding-agent tooling require a coding-agent restart. With Kiwi runtime downloads, recovery and reindex are live only when `ko` is enabled and the backend is active.
 - On Windows, `unequip` after activation may require a Coral restart when a loaded native addon remains mapped for the coordinator process lifetime.

--- a/clients/skills/equip/SKILL.md
+++ b/clients/skills/equip/SKILL.md
@@ -47,7 +47,7 @@ Bundled engines auto-equip at coordinator boot via the bundled fallback pass. Th
 
 | status    | Action |
 |-----------|--------|
-| `catalog` | Present the catalog as a table with `id`, `name`, `tier`, package `description`, `provides` when present, translated `activation`, `status`, `statusDescription` when present, `confirmDownload` when present, and `cleanupCommand` when present. Render `provides` as sibling collections: `provides.capabilities` as a comma-separated capability label/name list and `provides.retrievalRoles` as a comma-separated role label list, for example `provides: capabilities=[Text (FTS), Vector (Semantic)]; retrievalRoles=[Text, Vector, Graph]`. Do not group capabilities by `typeTag`; it is opaque metadata |
+| `catalog` | Present the catalog as a table with `id`, `name`, `tier`, package `description`, `provides` when present, translated `activation`, `status`, `statusDescription` when present, `confirmDownload` when present, `targetDir` when present, and `cleanupCommand` when present. Render `provides` as sibling collections: `provides.capabilities` as a comma-separated capability label/name list and `provides.retrievalRoles` as a comma-separated role label list, for example `provides: capabilities=[Text (FTS), Vector (Semantic)]; retrievalRoles=[Text, Vector, Graph]`. Do not group capabilities by `typeTag`; it is opaque metadata |
 | `info`    | Show the single package entry using the same package-status routing table below, including `tier`, `fills`/`slot` when present, `provides` when present using the same sibling collection rendering as catalog rows, and the translated `activation` label |
 | `error`   | Show `userMessage` and `remediation`. Show `suggestions` when present, then stop. For debugging, show `code` and any `context` fields |
 
@@ -133,7 +133,7 @@ Bundled engines auto-equip at coordinator boot via the bundled fallback pass. Th
 
 1. Bash(`coral-cli expansion info <package>`)
 2. Parse the single-line JSON result.
-3. Show the status and, when returned, the package `tier`, `provides.capabilities`, `confirmDownload`, `addonPath`, installed `command`, retired-residue `cleanupCommand`, `userMessage`, and `remediation`. Show `confirmDownload` exactly so the user can inspect any source, size, and preservation disclosure before equip or update. Treat an error result as terminal.
+3. Show the status and, when returned, the package `tier`, `provides.capabilities`, `confirmDownload`, `targetDir`, `addonPath`, installed `command`, retired-residue `cleanupCommand`, `userMessage`, and `remediation`. Show `confirmDownload` exactly so the user can inspect any source, size, and preservation disclosure before equip or update. Treat an error result as terminal.
 
 ### `uninstall <equipment-name>`
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -71,15 +71,26 @@ does not delete outputs for source files that were removed or moved, so cleaning
 `dist/` before compile is required for `package.json`'s `dist/` export to match
 the current `src/` tree.
 
-`scripts/build-server.mjs` does five things:
+`scripts/build-server.mjs` does six things:
 
 1. Runs simulation compatibility verification (`check-simulation.mjs`), which typechecks `tools/simulation` against `src` and verifies sealing.
 2. Reads `package.json` as the single source of truth for the version.
 3. Syncs that version into `clients/.claude-plugin/plugin.json`, `clients/.codex-plugin/plugin.json`, and the root `.claude-plugin/marketplace.json`.
-4. Bundles the backend, CLI, and Claude broker helper to `clients/build/`.
+4. Bundles the backend, CLI, and Claude broker helper to `clients/build/` using
+   the shared production options in `scripts/server-esbuild-options.mjs`.
 5. Builds a probe backend to obtain the canonical store-format fingerprint, rebuilds with that fingerprint embedded, and atomically writes `clients/build/manifest.json` with the shared identity plus hashes for the backend, CLI, and Claude helper.
+6. Runs `scripts/verify-kiwi-runtime-build-contract.mjs` against `clients/build`, checking the exact staging inventory and executing an isolated Kiwi initializer built from source with the same production esbuild options and an empty `NODE_PATH`.
 
 When `--release` is passed, it additionally copies all artifacts from `clients/build/` to `clients/bridge/`.
+
+Every `npm run build` performs the Kiwi runtime-build verification in step 6.
+`npm run verify:kiwi-runtime-build` also exposes that verifier as a standalone
+check: it checks the selected bundle directory's four-file inventory, then
+builds and executes an isolated Kiwi initializer from source with those same
+production esbuild options and an empty `NODE_PATH`.
+This feature-build check does not regenerate `clients/bridge`; the Release
+workflow performs that copy and separately verifies byte equality and package
+allowlisting.
 
 `bundleHash`, `cliBundleHash`, and `claudeAppserverBundleHash` bind the complete executable set. `version`, `buildSetId`, `flavor`, and `storeFormatFingerprint` are embedded and compared separately, so a mixed or stale artifact set fails closed even when one file happens to have unchanged bytes.
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -89,8 +89,15 @@ check: it checks the selected bundle directory's four-file inventory, then
 builds and executes an isolated Kiwi initializer from source with those same
 production esbuild options and an empty `NODE_PATH`.
 This feature-build check does not regenerate `clients/bridge`; the Release
-workflow performs that copy and separately verifies byte equality and package
-allowlisting.
+workflow performs that copy, and `npm run verify:store-reset-release`
+separately verifies byte equality and package allowlisting.
+
+The standalone Kiwi runtime-build contract can be reproduced locally with:
+
+```bash
+npm run build
+npm run verify:kiwi-runtime-build
+```
 
 `bundleHash`, `cliBundleHash`, and `claudeAppserverBundleHash` bind the complete executable set. `version`, `buildSetId`, `flavor`, and `storeFormatFingerprint` are embedded and compared separately, so a mixed or stale artifact set fails closed even when one file happens to have unchanged bytes.
 
@@ -127,6 +134,8 @@ Unbundled hooks read the adjacent manifest; bundled runtimes compare that same m
 ## Dependencies
 
 The build and runtime no longer depend on `@modelcontextprotocol/sdk`. Current package-managed runtime concerns are ordinary Node/TypeScript concerns: `zod` for schema validation, `esbuild` for bundling, native runtime packages such as `@lydell/node-pty` (prebuilt-binary fork — ships per-platform `.node` via optional dependencies, so install needs no native toolchain or lifecycle scripts), and the Coral runtime packages declared in `package.json`.
+
+`kiwi-nlp` is exact-pinned in `package.json` (no caret). `src/engines/kiwi/constants.ts` hardcodes the matching package archive, WASM, and model digests and sizes, so a dependency bump must update the pin and constants together or artifact installation fails at runtime.
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@orama/orama": "^3.1.18",
         "graphology": "^0.26.0",
         "graphology-communities-louvain": "^2.0.2",
-        "kiwi-nlp": "^0.23.0",
+        "kiwi-nlp": "0.23.0",
         "mammoth": "^1.12.0",
         "smol-toml": "^1.7.0",
         "turndown": "^7.2.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts' 'tools/**/*.ts'",
     "test": "node scripts/test.mjs",
     "test:integration": "vitest run --config vitest/integration.ts",
+    "test:network": "CORAL_TEST_NETWORK=1 vitest run --config vitest/integration.ts tests/integration/engines/kiwi-runtime-download.integration.test.ts",
     "test:e2e": "vitest run --config vitest/e2e.ts",
     "test:e2e:lifecycle": "vitest run --config vitest/e2e-lifecycle.ts",
     "test:store-reset": "vitest run --config vitest/default.ts tests/unit/store/open-or-reset.test.ts tests/unit/store/reset-incident-parser.test.ts tests/unit/store/reset-incident-reader.test.ts tests/unit/store/reset-incident-diagnostic.test.ts tests/unit/store/reset-incident-report.test.ts tests/unit/coordinator/lifecycle-reset-authority-order.test.ts tests/unit/cli/store-reset.test.ts tests/unit/cli/store-reset-signal.test.ts tests/unit/cli/errors.test.ts tests/unit/cli/emit.test.ts tests/unit/support/store-reset-issue-template.test.ts tests/invariants/store-reset-discipline.test.ts tests/invariants/architecture-boundary.test.ts",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:e2e:release": "node scripts/run-store-reset-e2e.mjs clients/bridge --all",
     "verify:store-reset-build": "node scripts/verify-store-reset-build-contract.mjs clients/build",
     "verify:store-reset-release": "node scripts/verify-store-reset-build-contract.mjs clients/bridge clients/build",
+    "verify:kiwi-runtime-build": "node scripts/verify-kiwi-runtime-build-contract.mjs clients/build",
     "test:simulation": "vitest run --config vitest/simulation.ts",
     "simulate": "node scripts/run-simulation.mjs"
   },
@@ -54,7 +55,7 @@
     "@orama/orama": "^3.1.18",
     "graphology": "^0.26.0",
     "graphology-communities-louvain": "^2.0.2",
-    "kiwi-nlp": "^0.23.0",
+    "kiwi-nlp": "0.23.0",
     "mammoth": "^1.12.0",
     "smol-toml": "^1.7.0",
     "turndown": "^7.2.2",

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -4,6 +4,11 @@ import { createHash, randomUUID } from 'crypto';
 import { chmodSync, copyFileSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
+import {
+  createProductionServerEsbuildOptions,
+  PLACEHOLDER_STORE_FORMAT_FINGERPRINT,
+} from './server-esbuild-options.mjs';
+
 mkdirSync('clients/build', { recursive: true });
 
 function parseArgs(argv) {
@@ -32,16 +37,6 @@ const buildSetId = randomUUID();
 execFileSync('node', ['scripts/check-simulation.mjs'], { stdio: 'inherit' });
 
 const { version } = JSON.parse(readFileSync('package.json', 'utf8'));
-const placeholderStoreFormatFingerprint = `sha256:${'0'.repeat(64)}`;
-
-function bundleBanner(storeFormatFingerprint) {
-  return (
-    `var __CORAL_BUILD_IDENTITY__=${JSON.stringify({ version, buildSetId, flavor, storeFormatFingerprint })};` +
-    'var __PLUGIN_ROOT__=require("path").resolve(__dirname,"..");' +
-    'var __BUNDLE_DIR__=__dirname;' +
-    'var __importMetaUrl=require("url").pathToFileURL(__filename).href;'
-  );
-}
 
 // Sync manifest versions (single source of truth: package.json). The plugin
 // manifests live under clients/ (the plugin root); marketplace.json stays at
@@ -80,28 +75,12 @@ for (const path of [
   }
 }
 
-const sharedOpts = {
-  bundle: true,
-  platform: 'node',
-  target: 'node22',
-  format: 'cjs',
-  external: ['node:*', '@lydell/node-pty'],
-  loader: { '.sql': 'text' },
-  minify: true,
-  banner: {
-    js: bundleBanner(placeholderStoreFormatFingerprint),
-  },
-  define: {
-    __VERSION__: JSON.stringify(version),
-    __BUILD_SET_ID__: JSON.stringify(buildSetId),
-    __BUILD_FLAVOR__: JSON.stringify(flavor),
-    __STORE_FORMAT_FINGERPRINT__: JSON.stringify(placeholderStoreFormatFingerprint),
-    // esbuild empties `import.meta` in CJS output, so `import.meta.url` would be
-    // `undefined`; redirect it to a banner-injected file URL of the bundle file
-    // so `createRequire(import.meta.url)` (e.g. engines/kiwi/paths.ts) resolves.
-    'import.meta.url': '__importMetaUrl',
-  },
-};
+let sharedOpts = createProductionServerEsbuildOptions({
+  version,
+  buildSetId,
+  flavor,
+  storeFormatFingerprint: PLACEHOLDER_STORE_FORMAT_FINGERPRINT,
+});
 
 await esbuild.build({
   ...sharedOpts,
@@ -118,8 +97,12 @@ const storeFormatFingerprint = execFileSync(
 if (!/^sha256:[a-f0-9]{64}$/.test(storeFormatFingerprint)) {
   throw new Error(`Built backend reported an invalid store format fingerprint: ${storeFormatFingerprint}`);
 }
-sharedOpts.banner.js = bundleBanner(storeFormatFingerprint);
-sharedOpts.define.__STORE_FORMAT_FINGERPRINT__ = JSON.stringify(storeFormatFingerprint);
+sharedOpts = createProductionServerEsbuildOptions({
+  version,
+  buildSetId,
+  flavor,
+  storeFormatFingerprint,
+});
 await esbuild.build({
   ...sharedOpts,
   entryPoints: ['src/coordinator/bootstrap.ts'],
@@ -177,6 +160,9 @@ writeFileSync(
   }) + '\n',
 );
 renameSync(manifestTmp, manifestPath);
+execFileSync(process.execPath, ['scripts/verify-kiwi-runtime-build-contract.mjs', 'clients/build'], {
+  stdio: 'inherit',
+});
 
 if (release) {
   // The shipped bundle (clients/bridge/) and the staging dir (clients/build/)

--- a/scripts/server-esbuild-options.mjs
+++ b/scripts/server-esbuild-options.mjs
@@ -1,0 +1,35 @@
+export const PLACEHOLDER_STORE_FORMAT_FINGERPRINT = `sha256:${'0'.repeat(64)}`;
+
+function bundleBanner({ version, buildSetId, flavor, storeFormatFingerprint }) {
+  return (
+    `var __CORAL_BUILD_IDENTITY__=${JSON.stringify({ version, buildSetId, flavor, storeFormatFingerprint })};` +
+    'var __PLUGIN_ROOT__=require("path").resolve(__dirname,"..");' +
+    'var __BUNDLE_DIR__=__dirname;' +
+    'var __importMetaUrl=require("url").pathToFileURL(__filename).href;'
+  );
+}
+
+export function createProductionServerEsbuildOptions({ version, buildSetId, flavor, storeFormatFingerprint }) {
+  return {
+    bundle: true,
+    platform: 'node',
+    target: 'node22',
+    format: 'cjs',
+    external: ['node:*', '@lydell/node-pty'],
+    loader: { '.sql': 'text' },
+    minify: true,
+    banner: {
+      js: bundleBanner({ version, buildSetId, flavor, storeFormatFingerprint }),
+    },
+    define: {
+      __VERSION__: JSON.stringify(version),
+      __BUILD_SET_ID__: JSON.stringify(buildSetId),
+      __BUILD_FLAVOR__: JSON.stringify(flavor),
+      __STORE_FORMAT_FINGERPRINT__: JSON.stringify(storeFormatFingerprint),
+      // Preserve a bundle-local URL after conversion to CJS. The bundled Kiwi
+      // Emscripten glue uses `createRequire(import.meta.url)` for Node built-ins;
+      // WASM location itself is supplied separately through `locateFile`.
+      'import.meta.url': '__importMetaUrl',
+    },
+  };
+}

--- a/scripts/verify-kiwi-runtime-build-contract.mjs
+++ b/scripts/verify-kiwi-runtime-build-contract.mjs
@@ -1,0 +1,96 @@
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as esbuild from 'esbuild';
+
+import {
+  createProductionServerEsbuildOptions,
+  PLACEHOLDER_STORE_FORMAT_FINGERPRINT,
+} from './server-esbuild-options.mjs';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const buildDir = resolve(repoRoot, process.argv[2] ?? 'clients/build');
+const expectedBuildFiles = new Set([
+  'coral-backend.cjs',
+  'coral-cli.cjs',
+  'coral-claude-appserver.cjs',
+  'manifest.json',
+]);
+const buildFiles = readdirSync(buildDir);
+if (buildFiles.length !== expectedBuildFiles.size || buildFiles.some((entry) => !expectedBuildFiles.has(entry))) {
+  throw new Error(`Kiwi build contract expected only the four bundle files, got: ${buildFiles.sort().join(', ')}`);
+}
+
+const projectManifest = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8'));
+const packageManifest = JSON.parse(readFileSync(join(repoRoot, 'node_modules', 'kiwi-nlp', 'package.json'), 'utf-8'));
+const tempRoot = mkdtempSync(join(tmpdir(), 'coral-kiwi-build-smoke-'));
+const isolatedBundleDir = join(tempRoot, 'bundle');
+const runtimeRoot = join(tempRoot, 'runtime');
+const runtimeWasmPath = join(runtimeRoot, 'kiwi', 'wasm', `v${String(packageManifest.version)}`, 'kiwi-wasm.wasm');
+const smokeBundle = join(isolatedBundleDir, 'kiwi-smoke.cjs');
+
+try {
+  mkdirSync(isolatedBundleDir, { recursive: true });
+  mkdirSync(dirname(runtimeWasmPath), { recursive: true });
+  copyFileSync(join(repoRoot, 'node_modules', 'kiwi-nlp', 'dist', 'kiwi-wasm.wasm'), runtimeWasmPath);
+
+  const productionOptions = createProductionServerEsbuildOptions({
+    version: String(projectManifest.version),
+    buildSetId: 'kiwi-runtime-smoke',
+    flavor: 'prod',
+    storeFormatFingerprint: PLACEHOLDER_STORE_FORMAT_FINGERPRINT,
+  });
+  await esbuild.build({
+    ...productionOptions,
+    stdin: {
+      contents: `
+        import { join } from 'node:path';
+        import { createKiwiApi } from './src/engines/kiwi/wasm-loader.ts';
+
+        void (async () => {
+          const runtimeRoot = process.env.CORAL_KIWI_SMOKE_ROOT;
+          if (!runtimeRoot) throw new Error('CORAL_KIWI_SMOKE_ROOT is required');
+          const runtime = {
+            paths: {
+              coral: {
+                engine: {
+                  dataDir: (name) => join(runtimeRoot, name),
+                },
+              },
+            },
+          };
+          const api = await createKiwiApi(runtime);
+          if (typeof api.cmd !== 'function' || typeof api.loadModelFiles !== 'function') {
+            throw new Error('Kiwi Emscripten API did not initialize');
+          }
+          process.stdout.write('kiwi-runtime-wasm-ok\\n');
+        })().catch((error) => {
+          process.stderr.write(String(error?.stack ?? error) + '\\n');
+          process.exitCode = 1;
+        });
+      `,
+      resolveDir: repoRoot,
+      sourcefile: 'kiwi-runtime-smoke.ts',
+      loader: 'ts',
+    },
+    outfile: smokeBundle,
+  });
+
+  const output = execFileSync(process.execPath, [smokeBundle], {
+    cwd: isolatedBundleDir,
+    encoding: 'utf-8',
+    env: {
+      CORAL_KIWI_SMOKE_ROOT: runtimeRoot,
+      NODE_PATH: '',
+    },
+  }).trim();
+  if (output !== 'kiwi-runtime-wasm-ok') {
+    throw new Error(`Unexpected Kiwi runtime smoke output: ${output}`);
+  }
+  console.log('Verified runtime-downloaded Kiwi WASM against an isolated bundled initializer');
+} finally {
+  rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/scripts/verify-kiwi-runtime-build-contract.mjs
+++ b/scripts/verify-kiwi-runtime-build-contract.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,9 +19,14 @@ const expectedBuildFiles = new Set([
   'coral-claude-appserver.cjs',
   'manifest.json',
 ]);
+if (!existsSync(buildDir)) {
+  throw new Error(`Kiwi build contract is missing ${buildDir}; run \`npm run build\` before this verifier.`);
+}
 const buildFiles = readdirSync(buildDir);
 if (buildFiles.length !== expectedBuildFiles.size || buildFiles.some((entry) => !expectedBuildFiles.has(entry))) {
-  throw new Error(`Kiwi build contract expected only the four bundle files, got: ${buildFiles.sort().join(', ')}`);
+  throw new Error(
+    `Kiwi build contract expected only the four bundle files, with no WASM staged beside them; got: ${buildFiles.sort().join(', ')}`,
+  );
 }
 
 const projectManifest = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8'));
@@ -29,6 +34,9 @@ const packageManifest = JSON.parse(readFileSync(join(repoRoot, 'node_modules', '
 const tempRoot = mkdtempSync(join(tmpdir(), 'coral-kiwi-build-smoke-'));
 const isolatedBundleDir = join(tempRoot, 'bundle');
 const runtimeRoot = join(tempRoot, 'runtime');
+// Deliberately derive the kiwi/wasm/v<ver>/ layout and installed version independently of
+// src/engines/kiwi/paths.ts and KIWI_NLP_VERSION so drift makes this verifier fail instead of
+// silently passing.
 const runtimeWasmPath = join(runtimeRoot, 'kiwi', 'wasm', `v${String(packageManifest.version)}`, 'kiwi-wasm.wasm');
 const smokeBundle = join(isolatedBundleDir, 'kiwi-smoke.cjs');
 

--- a/src/cli/bootstrap.ts
+++ b/src/cli/bootstrap.ts
@@ -1,63 +1,8 @@
-import { handleExpansionCommanderFailure, isCommanderDisplayOnlyError } from './commands/expansion.js';
-import { emitError } from './emit.js';
-import { buildProgram } from './program.js';
-import { isStoreResetReportInvocation } from './store-reset-signal.js';
-import { resolveStrictBundleIdentity } from '../infra/bundle-manifest.js';
+import { runCli } from './run.js';
 
-// The bundled CLI entrypoint is CommonJS, so top-level await is unavailable.
-// Keep the process alive while async command handlers are still awaiting
-// unref'ed runtime timers such as coordinator startup polling.
-function runBootstrap(): Promise<unknown> {
-  if (process.argv.length === 3 && process.argv[2] === '--print-store-reset-build-identity') {
-    const identity = resolveStrictBundleIdentity();
-    if (!identity.ok) {
-      process.exitCode = 70;
-      return Promise.resolve();
-    }
-    process.stdout.write(`${JSON.stringify(identity.manifest)}\n`);
-    return Promise.resolve();
-  }
-
-  const ownsDiagnosticSignals = isStoreResetReportInvocation(process.argv.slice(2));
-  const shutdownController = ownsDiagnosticSignals ? new AbortController() : null;
-  const onSigint = (): void => {
-    process.exitCode = 130;
-    shutdownController?.abort();
-  };
-  const onSigterm = (): void => {
-    process.exitCode = 143;
-    shutdownController?.abort();
-  };
-  if (ownsDiagnosticSignals) {
-    process.once('SIGINT', onSigint);
-    process.once('SIGTERM', onSigterm);
-  }
-  const program = buildProgram(undefined, { shutdownSignal: shutdownController?.signal });
-  const parseKeepAlive = setInterval(() => undefined, 2 ** 31 - 1);
-  return program
-    .parseAsync(process.argv)
-    .catch((error) => {
-      if (isCommanderDisplayOnlyError(error)) {
-        process.exitCode = 0;
-        return;
-      }
-
-      if (handleExpansionCommanderFailure(error, process.argv, { exit: true })) {
-        return;
-      }
-
-      emitError(error);
-      process.exit(process.exitCode ?? 1);
-    })
-    .finally(() => {
-      clearInterval(parseKeepAlive);
-      if (ownsDiagnosticSignals) {
-        process.off('SIGINT', onSigint);
-        process.off('SIGTERM', onSigterm);
-      }
-    });
-}
-
-export const bootstrapCompletion = runBootstrap();
+// The bundled CLI entrypoint is CommonJS, so top-level await is unavailable. Export the in-flight promise
+// instead so the bundle keeps a reference to it. The invocation lives here rather than in run.ts so that
+// importing the CLI does not execute it — see the note in run.ts.
+export const bootstrapCompletion = runCli();
 
 void bootstrapCompletion;

--- a/src/cli/expansion/index.ts
+++ b/src/cli/expansion/index.ts
@@ -140,6 +140,8 @@ function toInstallOnlyCatalogEntry(manifest: InstallOnlyManifest, runtime: Runti
     status,
     version: manifest.version,
     ...(local.installed && typeof local.addonPath === 'string' ? { command: local.addonPath } : {}),
+    ...(typeof local.targetDir === 'string' ? { targetDir: local.targetDir } : {}),
+    ...(typeof local.method === 'string' ? { method: local.method } : {}),
     ...(confirmDownload === undefined ? {} : { confirmDownload }),
   });
 }

--- a/src/cli/expansion/index.ts
+++ b/src/cli/expansion/index.ts
@@ -126,6 +126,7 @@ function toCatalogEntry(
 
 function toInstallOnlyCatalogEntry(manifest: InstallOnlyManifest, runtime: Runtime): CatalogEntry {
   const local = inspectExpansionInstallState(runtime, manifest.id);
+  const confirmDownload = manifest.onboarding?.find((step) => step.kind === 'confirm-download')?.message;
   const status: CatalogEntry['status'] = local.installLocked
     ? 'installing'
     : local.installed
@@ -139,6 +140,7 @@ function toInstallOnlyCatalogEntry(manifest: InstallOnlyManifest, runtime: Runti
     status,
     version: manifest.version,
     ...(local.installed && typeof local.addonPath === 'string' ? { command: local.addonPath } : {}),
+    ...(confirmDownload === undefined ? {} : { confirmDownload }),
   });
 }
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,0 +1,67 @@
+import { handleExpansionCommanderFailure, isCommanderDisplayOnlyError } from './commands/expansion.js';
+import { emitError } from './emit.js';
+import { buildProgram } from './program.js';
+import { isStoreResetReportInvocation } from './store-reset-signal.js';
+import { resolveStrictBundleIdentity } from '../infra/bundle-manifest.js';
+
+/**
+ * Runs one CLI invocation against the current `process.argv`.
+ *
+ * Deliberately separate from `bootstrap.ts`, which is the esbuild entrypoint and invokes this at module
+ * load. Keeping the invocation out of this module is what makes the CLI testable: a self-executing entry
+ * forces tests to re-import it through `vi.resetModules()` to get a fresh run, which charges a cold
+ * transform of the whole command graph to whichever test imports first. Callers here can invoke repeatedly
+ * on one already-transformed module instead. Do not move the invocation back into this file.
+ */
+export function runCli(): Promise<unknown> {
+  if (process.argv.length === 3 && process.argv[2] === '--print-store-reset-build-identity') {
+    const identity = resolveStrictBundleIdentity();
+    if (!identity.ok) {
+      process.exitCode = 70;
+      return Promise.resolve();
+    }
+    process.stdout.write(`${JSON.stringify(identity.manifest)}\n`);
+    return Promise.resolve();
+  }
+
+  const ownsDiagnosticSignals = isStoreResetReportInvocation(process.argv.slice(2));
+  const shutdownController = ownsDiagnosticSignals ? new AbortController() : null;
+  const onSigint = (): void => {
+    process.exitCode = 130;
+    shutdownController?.abort();
+  };
+  const onSigterm = (): void => {
+    process.exitCode = 143;
+    shutdownController?.abort();
+  };
+  if (ownsDiagnosticSignals) {
+    process.once('SIGINT', onSigint);
+    process.once('SIGTERM', onSigterm);
+  }
+  const program = buildProgram(undefined, { shutdownSignal: shutdownController?.signal });
+  // Keep the process alive while async command handlers are still awaiting unref'ed runtime timers such as
+  // coordinator startup polling.
+  const parseKeepAlive = setInterval(() => undefined, 2 ** 31 - 1);
+  return program
+    .parseAsync(process.argv)
+    .catch((error) => {
+      if (isCommanderDisplayOnlyError(error)) {
+        process.exitCode = 0;
+        return;
+      }
+
+      if (handleExpansionCommanderFailure(error, process.argv, { exit: true })) {
+        return;
+      }
+
+      emitError(error);
+      process.exit(process.exitCode ?? 1);
+    })
+    .finally(() => {
+      clearInterval(parseKeepAlive);
+      if (ownsDiagnosticSignals) {
+        process.off('SIGINT', onSigint);
+        process.off('SIGTERM', onSigterm);
+      }
+    });
+}

--- a/src/engines/kiwi/analyzer-manager.ts
+++ b/src/engines/kiwi/analyzer-manager.ts
@@ -6,8 +6,13 @@ import { errorMessage } from '../../infra/error-format.js';
 import { decorateDispose } from '#src/expansion/scope.js';
 import type { KbDeclaredAnalyzer } from '../../kb/extra-langs.js';
 import type { Disposable, Runtime } from '../../runtime/ports.js';
-import { inspectKiwiArtifact, kiwiArtifactStateKey, type KiwiArtifactState } from './artifact.js';
-import { loadKiwiAnalyzer, type KiwiAnalyzer } from './loader.js';
+import {
+  inspectKiwiArtifact,
+  kiwiArtifactStateKey,
+  probeKiwiArtifactIdentity,
+  type KiwiArtifactState,
+} from './artifact.js';
+import { KiwiAnalyzerMissingArtifactError, loadKiwiAnalyzer, type KiwiAnalyzer } from './loader.js';
 
 const KIWI_ANALYZER_IDLE_TTL_MS = 5 * 60 * 1000;
 
@@ -22,6 +27,7 @@ type KiwiAnalyzerManagerOptions = {
   readonly idleTtlMs?: number;
   readonly loadAnalyzer?: (runtime: Runtime) => Promise<KiwiAnalyzer>;
   readonly inspectArtifact?: (runtime: Pick<Runtime, 'paths' | 'storage'>) => KiwiArtifactState;
+  readonly probeArtifactIdentity?: (runtime: Pick<Runtime, 'paths' | 'storage'>) => string;
   readonly logger?: (message: string) => void;
   readonly collectGarbage?: () => void;
 };
@@ -64,20 +70,18 @@ export type KiwiAnalyzerManagerStatus =
     };
 
 export type KiwiAnalyzerLeaseReadiness =
-  | {
-      readonly ready: true;
-      readonly state?: 'degraded';
-      readonly reason?: string;
-    }
+  | { readonly ready: true; readonly state: 'ok' }
+  | { readonly ready: true; readonly state: 'degraded'; readonly reason: string }
   | {
       readonly ready: false;
-      readonly state: 'unloaded' | 'loading' | 'evicting' | 'degraded';
+      readonly state: 'unloaded' | 'loading' | 'evicting';
       readonly reason?: string;
     };
 
 type DegradedState = {
   readonly reason: string;
   readonly artifactStateKey: string;
+  readonly artifactIdentity: string;
   readonly failedAt: number;
 };
 
@@ -132,6 +136,7 @@ export class KiwiAnalyzerManager {
   private readonly idleTtlMs: number;
   private readonly loadAnalyzer: (runtime: Runtime) => Promise<KiwiAnalyzer>;
   private readonly inspectArtifact: (runtime: Pick<Runtime, 'paths' | 'storage'>) => KiwiArtifactState;
+  private readonly probeArtifactIdentity: (runtime: Pick<Runtime, 'paths' | 'storage'>) => string;
   private readonly logger: (message: string) => void;
   private readonly collectGarbage?: () => void;
   private readonly leaseStorage = new AsyncLocalStorage<KiwiAnalyzer | null>();
@@ -149,6 +154,7 @@ export class KiwiAnalyzerManager {
     this.idleTtlMs = options.idleTtlMs ?? KIWI_ANALYZER_IDLE_TTL_MS;
     this.loadAnalyzer = options.loadAnalyzer ?? ((runtime) => loadKiwiAnalyzer(runtime, { installIfMissing: false }));
     this.inspectArtifact = options.inspectArtifact ?? inspectKiwiArtifact;
+    this.probeArtifactIdentity = options.probeArtifactIdentity ?? probeKiwiArtifactIdentity;
     this.logger = options.logger ?? ((message) => backendLog.warn(message));
     this.collectGarbage = options.collectGarbage;
   }
@@ -179,7 +185,7 @@ export class KiwiAnalyzerManager {
   ): KiwiAnalyzerLeaseReadiness {
     const normalized = normalDeclaredAnalyzers(declaredAnalyzers);
     if (!wantsKiwi(normalized) || runtime === undefined) {
-      return { ready: true };
+      return { ready: true, state: 'ok' };
     }
 
     if (this.degraded !== null && this.artifactChangedSinceFailure(runtime, this.degraded)) {
@@ -199,7 +205,7 @@ export class KiwiAnalyzerManager {
 
     const key = runtimeKey(runtime);
     if (this.activeHandle !== null && !this.activeHandle.closed && this.activeHandle.runtimeKey === key) {
-      return { ready: true };
+      return { ready: true, state: 'ok' };
     }
 
     return { ready: false, state: 'unloaded' };
@@ -337,12 +343,14 @@ export class KiwiAnalyzerManager {
   }
 
   private async loadFresh(runtime: Runtime, key: string): Promise<ActiveKiwiHandle> {
+    let failedArtifactIdentity = this.inspectArtifactIdentity(runtime);
     let failedArtifactStateKey = this.inspectArtifactStateKey(runtime);
     try {
       if (this.activeHandle !== null) {
         await this.disposeHandle(this.activeHandle);
       }
 
+      failedArtifactIdentity = this.inspectArtifactIdentity(runtime);
       failedArtifactStateKey = this.inspectArtifactStateKey(runtime);
       const analyzer = await this.loadAnalyzer(runtime);
       const handle: ActiveKiwiHandle = {
@@ -356,7 +364,7 @@ export class KiwiAnalyzerManager {
       this.lastNotifiedDegradedArtifactStateKey = null;
       return handle;
     } catch (error: unknown) {
-      this.markDegraded(runtime, error, failedArtifactStateKey);
+      this.markDegraded(runtime, error, failedArtifactStateKey, failedArtifactIdentity);
       throw new KiwiAnalyzerTerminalLoadError(`Kiwi analyzer load failed: ${errorMessage(error)}`, error);
     }
   }
@@ -369,17 +377,27 @@ export class KiwiAnalyzerManager {
     }
   }
 
-  private markDegraded(runtime: Runtime, error: unknown, stateKey: string): void {
+  private inspectArtifactIdentity(runtime: Runtime): string {
+    try {
+      return this.probeArtifactIdentity(runtime);
+    } catch (error: unknown) {
+      return `probe-error:${errorMessage(error)}`;
+    }
+  }
+
+  private markDegraded(runtime: Runtime, error: unknown, stateKey: string, artifactIdentity: string): void {
     const reason = errorMessage(error);
     this.degraded = {
       reason,
       artifactStateKey: stateKey,
+      artifactIdentity,
       failedAt: runtime.time.now(),
     };
-    const remediation = reason.includes('coral-cli expansion equip kiwi')
-      ? ''
-      : ' Run `coral-cli backend shutdown` so the next command retries Kiwi initialization. ' +
-        'If it fails again, check the Kiwi artifact filesystem permissions and report this error.';
+    const remediation =
+      error instanceof KiwiAnalyzerMissingArtifactError
+        ? ''
+        : ' Run `coral-cli backend shutdown` so the next command retries Kiwi initialization. ' +
+          'If it fails again, check the Kiwi artifact filesystem permissions and report this error.';
     this.logger(`[kiwi] analyzer unavailable; Intl fallback remains active: ${reason}${remediation}`);
     this.notifyDegraded({ reason, artifactStateKey: stateKey });
   }
@@ -409,6 +427,9 @@ export class KiwiAnalyzerManager {
 
   private artifactChangedSinceFailure(runtime: Runtime, degraded: DegradedState): boolean {
     try {
+      if (this.inspectArtifactIdentity(runtime) === degraded.artifactIdentity) {
+        return false;
+      }
       const state = this.inspectArtifact(runtime);
       return state.ready && kiwiArtifactStateKey(state) !== degraded.artifactStateKey;
     } catch {

--- a/src/engines/kiwi/analyzer-manager.ts
+++ b/src/engines/kiwi/analyzer-manager.ts
@@ -6,7 +6,7 @@ import { errorMessage } from '../../infra/error-format.js';
 import { decorateDispose } from '#src/expansion/scope.js';
 import type { KbDeclaredAnalyzer } from '../../kb/extra-langs.js';
 import type { Disposable, Runtime } from '../../runtime/ports.js';
-import { inspectKiwiModelArtifact, type KiwiModelArtifactState } from './model-artifact.js';
+import { inspectKiwiArtifact, kiwiArtifactStateKey, type KiwiArtifactState } from './artifact.js';
 import { loadKiwiAnalyzer, type KiwiAnalyzer } from './loader.js';
 
 const KIWI_ANALYZER_IDLE_TTL_MS = 5 * 60 * 1000;
@@ -21,7 +21,7 @@ type ActiveKiwiHandle = {
 type KiwiAnalyzerManagerOptions = {
   readonly idleTtlMs?: number;
   readonly loadAnalyzer?: (runtime: Runtime) => Promise<KiwiAnalyzer>;
-  readonly inspectModelArtifact?: (runtime: Pick<Runtime, 'paths' | 'storage'>) => KiwiModelArtifactState;
+  readonly inspectArtifact?: (runtime: Pick<Runtime, 'paths' | 'storage'>) => KiwiArtifactState;
   readonly logger?: (message: string) => void;
   readonly collectGarbage?: () => void;
 };
@@ -66,6 +66,8 @@ export type KiwiAnalyzerManagerStatus =
 export type KiwiAnalyzerLeaseReadiness =
   | {
       readonly ready: true;
+      readonly state?: 'degraded';
+      readonly reason?: string;
     }
   | {
       readonly ready: false;
@@ -75,13 +77,13 @@ export type KiwiAnalyzerLeaseReadiness =
 
 type DegradedState = {
   readonly reason: string;
-  readonly modelStateKey: string;
+  readonly artifactStateKey: string;
   readonly failedAt: number;
 };
 
 export type KiwiAnalyzerDegradedEvent = {
   readonly reason: string;
-  readonly modelStateKey: string;
+  readonly artifactStateKey: string;
 };
 
 export type KiwiAnalyzerDegradedObserver = (event: KiwiAnalyzerDegradedEvent) => void | Promise<void>;
@@ -113,16 +115,6 @@ function withoutKiwi(declaredAnalyzers: readonly KbDeclaredAnalyzer[]): readonly
   return normalDeclaredAnalyzers(declaredAnalyzers).filter((analyzer) => analyzer !== 'ko');
 }
 
-function modelStateKey(state: KiwiModelArtifactState): string {
-  if (!state.installed) {
-    return `missing:${state.missingFiles.join(',')}`;
-  }
-  const manifest = state.manifest;
-  return manifest === null
-    ? 'installed:unknown'
-    : `installed:${manifest.kiwiNlpVersion}:${manifest.modelVersion}:${manifest.archiveSha256}:${manifest.installedAt}`;
-}
-
 function runtimeKey(runtime: Runtime): string {
   return runtime.paths.coral.engine.dataDir('kiwi');
 }
@@ -139,7 +131,7 @@ function noopLease(activeAnalyzers: readonly KbDeclaredAnalyzer[]): KiwiLease {
 export class KiwiAnalyzerManager {
   private readonly idleTtlMs: number;
   private readonly loadAnalyzer: (runtime: Runtime) => Promise<KiwiAnalyzer>;
-  private readonly inspectModelArtifact: (runtime: Pick<Runtime, 'paths' | 'storage'>) => KiwiModelArtifactState;
+  private readonly inspectArtifact: (runtime: Pick<Runtime, 'paths' | 'storage'>) => KiwiArtifactState;
   private readonly logger: (message: string) => void;
   private readonly collectGarbage?: () => void;
   private readonly leaseStorage = new AsyncLocalStorage<KiwiAnalyzer | null>();
@@ -151,12 +143,12 @@ export class KiwiAnalyzerManager {
   private readonly zeroLeaseWaiters: Array<() => void> = [];
   private readonly degradedObservers = new Map<Disposable, KiwiAnalyzerDegradedObserver>();
   private degraded: DegradedState | null = null;
-  private lastNotifiedDegradedModelStateKey: string | null = null;
+  private lastNotifiedDegradedArtifactStateKey: string | null = null;
 
   constructor(options: KiwiAnalyzerManagerOptions = {}) {
     this.idleTtlMs = options.idleTtlMs ?? KIWI_ANALYZER_IDLE_TTL_MS;
     this.loadAnalyzer = options.loadAnalyzer ?? ((runtime) => loadKiwiAnalyzer(runtime, { installIfMissing: false }));
-    this.inspectModelArtifact = options.inspectModelArtifact ?? inspectKiwiModelArtifact;
+    this.inspectArtifact = options.inspectArtifact ?? inspectKiwiArtifact;
     this.logger = options.logger ?? ((message) => backendLog.warn(message));
     this.collectGarbage = options.collectGarbage;
   }
@@ -190,13 +182,13 @@ export class KiwiAnalyzerManager {
       return { ready: true };
     }
 
-    if (this.degraded !== null && this.modelChangedSinceFailure(runtime, this.degraded)) {
+    if (this.degraded !== null && this.artifactChangedSinceFailure(runtime, this.degraded)) {
       this.degraded = null;
-      this.lastNotifiedDegradedModelStateKey = null;
+      this.lastNotifiedDegradedArtifactStateKey = null;
     }
 
     if (this.degraded !== null) {
-      return { ready: false, state: 'degraded', reason: this.degraded.reason };
+      return { ready: true, state: 'degraded', reason: this.degraded.reason };
     }
     if (this.evictionPromise !== null) {
       return { ready: false, state: 'evicting' };
@@ -223,6 +215,7 @@ export class KiwiAnalyzerManager {
 
   clearTerminalFailure(): void {
     this.degraded = null;
+    this.lastNotifiedDegradedArtifactStateKey = null;
   }
 
   observeDegraded(scope: Disposable, observer: KiwiAnalyzerDegradedObserver): void {
@@ -243,9 +236,9 @@ export class KiwiAnalyzerManager {
       return normalized;
     }
 
-    if (this.degraded !== null && runtime !== undefined && this.modelChangedSinceFailure(runtime, this.degraded)) {
+    if (this.degraded !== null && runtime !== undefined && this.artifactChangedSinceFailure(runtime, this.degraded)) {
       this.degraded = null;
-      this.lastNotifiedDegradedModelStateKey = null;
+      this.lastNotifiedDegradedArtifactStateKey = null;
     }
 
     return this.degraded === null ? normalized : withoutKiwi(normalized);
@@ -291,9 +284,9 @@ export class KiwiAnalyzerManager {
       return noopLease(normalized);
     }
 
-    if (this.degraded !== null && this.modelChangedSinceFailure(runtime, this.degraded)) {
+    if (this.degraded !== null && this.artifactChangedSinceFailure(runtime, this.degraded)) {
       this.degraded = null;
-      this.lastNotifiedDegradedModelStateKey = null;
+      this.lastNotifiedDegradedArtifactStateKey = null;
     }
 
     if (this.degraded !== null) {
@@ -344,11 +337,13 @@ export class KiwiAnalyzerManager {
   }
 
   private async loadFresh(runtime: Runtime, key: string): Promise<ActiveKiwiHandle> {
+    let failedArtifactStateKey = this.inspectArtifactStateKey(runtime);
     try {
       if (this.activeHandle !== null) {
         await this.disposeHandle(this.activeHandle);
       }
 
+      failedArtifactStateKey = this.inspectArtifactStateKey(runtime);
       const analyzer = await this.loadAnalyzer(runtime);
       const handle: ActiveKiwiHandle = {
         analyzer,
@@ -358,36 +353,42 @@ export class KiwiAnalyzerManager {
       };
       this.activeHandle = handle;
       this.degraded = null;
-      this.lastNotifiedDegradedModelStateKey = null;
+      this.lastNotifiedDegradedArtifactStateKey = null;
       return handle;
     } catch (error: unknown) {
-      this.markDegraded(runtime, error);
+      this.markDegraded(runtime, error, failedArtifactStateKey);
       throw new KiwiAnalyzerTerminalLoadError(`Kiwi analyzer load failed: ${errorMessage(error)}`, error);
     }
   }
 
-  private markDegraded(runtime: Runtime, error: unknown): void {
-    const reason = errorMessage(error);
-    let stateKey: string;
+  private inspectArtifactStateKey(runtime: Runtime): string {
     try {
-      stateKey = modelStateKey(this.inspectModelArtifact(runtime));
-    } catch (inspectError: unknown) {
-      stateKey = `inspect-error:${errorMessage(inspectError)}`;
+      return kiwiArtifactStateKey(this.inspectArtifact(runtime));
+    } catch (error: unknown) {
+      return `inspect-error:${errorMessage(error)}`;
     }
+  }
+
+  private markDegraded(runtime: Runtime, error: unknown, stateKey: string): void {
+    const reason = errorMessage(error);
     this.degraded = {
       reason,
-      modelStateKey: stateKey,
+      artifactStateKey: stateKey,
       failedAt: runtime.time.now(),
     };
-    this.logger(`[kiwi] analyzer unavailable; degrading Orama projection to Intl baseline: ${reason}`);
-    this.notifyDegraded({ reason, modelStateKey: stateKey });
+    const remediation = reason.includes('coral-cli expansion equip kiwi')
+      ? ''
+      : ' Run `coral-cli backend shutdown` so the next command retries Kiwi initialization. ' +
+        'If it fails again, check the Kiwi artifact filesystem permissions and report this error.';
+    this.logger(`[kiwi] analyzer unavailable; Intl fallback remains active: ${reason}${remediation}`);
+    this.notifyDegraded({ reason, artifactStateKey: stateKey });
   }
 
   private notifyDegraded(event: KiwiAnalyzerDegradedEvent): void {
-    if (this.lastNotifiedDegradedModelStateKey === event.modelStateKey) {
+    if (this.lastNotifiedDegradedArtifactStateKey === event.artifactStateKey) {
       return;
     }
-    this.lastNotifiedDegradedModelStateKey = event.modelStateKey;
+    this.lastNotifiedDegradedArtifactStateKey = event.artifactStateKey;
 
     for (const [scope, observer] of [...this.degradedObservers.entries()]) {
       if (this.degradedObservers.get(scope) !== observer) {
@@ -406,10 +407,10 @@ export class KiwiAnalyzerManager {
     }
   }
 
-  private modelChangedSinceFailure(runtime: Runtime, degraded: DegradedState): boolean {
+  private artifactChangedSinceFailure(runtime: Runtime, degraded: DegradedState): boolean {
     try {
-      const state = this.inspectModelArtifact(runtime);
-      return state.installed && modelStateKey(state) !== degraded.modelStateKey;
+      const state = this.inspectArtifact(runtime);
+      return state.ready && kiwiArtifactStateKey(state) !== degraded.artifactStateKey;
     } catch {
       return false;
     }

--- a/src/engines/kiwi/artifact.ts
+++ b/src/engines/kiwi/artifact.ts
@@ -5,6 +5,7 @@ import { isInstallPathUnwritableError, kiwiInstallError, type KiwiInstallError }
 import {
   ensureKiwiModelArtifact,
   inspectKiwiModelArtifact,
+  probeKiwiModelArtifactIdentity,
   type KiwiModelArtifactInstallResult,
   type KiwiModelArtifactState,
 } from './model-artifact.js';
@@ -13,6 +14,7 @@ import { kiwiDataDir } from './paths.js';
 import {
   ensureKiwiWasmArtifactLocked,
   inspectKiwiWasmArtifact,
+  probeKiwiWasmArtifactIdentity,
   type KiwiWasmArtifactState,
   type KiwiWasmInstallOptions,
 } from './wasm-artifact.js';
@@ -45,6 +47,13 @@ export type KiwiArtifactInstallOptions = KiwiPackageOperationOptions &
     readonly ensureWasmArtifact?: EnsureWasmArtifact;
   };
 
+export function probeKiwiArtifactIdentity(runtime: Pick<Runtime, 'paths' | 'storage'>): string {
+  return JSON.stringify({
+    model: probeKiwiModelArtifactIdentity(runtime),
+    wasm: probeKiwiWasmArtifactIdentity(runtime),
+  });
+}
+
 export function inspectKiwiArtifact(runtime: Pick<Runtime, 'paths' | 'storage'>): KiwiArtifactState {
   const model = inspectKiwiModelArtifact(runtime);
   const wasm = inspectKiwiWasmArtifact(runtime);
@@ -73,7 +82,7 @@ export function hasKiwiArtifactDurableState(runtime: Pick<Runtime, 'paths' | 'st
     if (!runtime.storage.statSync(dataDir).isDirectory()) {
       return false;
     }
-    return runtime.storage.readdirSync(dataDir, { withFileTypes: true }).some((entry) => entry.name !== 'install.lock');
+    return runtime.storage.readdirSync(dataDir, { withFileTypes: true }).length > 0;
   } catch {
     return false;
   }
@@ -122,6 +131,23 @@ function installResult(
   };
 }
 
+function artifactInstallError(error: unknown): KiwiInstallError {
+  const causeName = error instanceof Error ? error.name : typeof error;
+  const causeMessage = errorMessage(error);
+  const causeStack = error instanceof Error && typeof error.stack === 'string' ? error.stack : undefined;
+  const causeCode =
+    error instanceof Error && 'code' in error && typeof error.code === 'string' ? error.code : undefined;
+
+  return kiwiInstallError('expansion_install_artifact_failed', {
+    name: KIWI_INSTALL_ONLY_ID,
+    detail: causeMessage,
+    causeName,
+    causeMessage,
+    ...(causeStack === undefined ? {} : { causeStack }),
+    ...(causeCode === undefined ? {} : { causeCode }),
+  });
+}
+
 async function ensureKiwiArtifactLocked(
   runtime: Runtime,
   opts: KiwiArtifactInstallOptions,
@@ -144,11 +170,23 @@ async function ensureKiwiArtifactLocked(
   }
 
   if (!inspectKiwiArtifact(runtime).wasm.installed) {
-    await (opts.ensureWasmArtifact ?? ensureKiwiWasmArtifactLocked)(runtime, {
-      logger: opts.logger,
-      download: opts.download,
-      extract: opts.extract,
-    });
+    try {
+      const wasmResult = await (opts.ensureWasmArtifact ?? ensureKiwiWasmArtifactLocked)(runtime, {
+        logger: opts.logger,
+        download: opts.download,
+        extract: opts.extract,
+      });
+      if (!wasmResult.installed) {
+        return artifactInstallError(
+          new Error(`Kiwi WASM artifact install completed without readiness: ${wasmResult.reason ?? 'unknown reason'}`),
+        );
+      }
+    } catch (error: unknown) {
+      if (isInstallPathUnwritableError(error)) {
+        throw error;
+      }
+      return artifactInstallError(error);
+    }
   }
 
   const installed = inspectKiwiArtifact(runtime);
@@ -168,9 +206,6 @@ export async function ensureKiwiArtifact(
     if (isInstallPathUnwritableError(error)) {
       return kiwiInstallError('expansion_install_path_unwritable', { name: KIWI_INSTALL_ONLY_ID });
     }
-    return kiwiInstallError('expansion_install_artifact_failed', {
-      name: KIWI_INSTALL_ONLY_ID,
-      detail: errorMessage(error),
-    });
+    return artifactInstallError(error);
   }
 }

--- a/src/engines/kiwi/artifact.ts
+++ b/src/engines/kiwi/artifact.ts
@@ -133,17 +133,14 @@ function installResult(
 
 function artifactInstallError(error: unknown): KiwiInstallError {
   const causeName = error instanceof Error ? error.name : typeof error;
-  const causeMessage = errorMessage(error);
-  const causeStack = error instanceof Error && typeof error.stack === 'string' ? error.stack : undefined;
+  const detail = errorMessage(error);
   const causeCode =
     error instanceof Error && 'code' in error && typeof error.code === 'string' ? error.code : undefined;
 
   return kiwiInstallError('expansion_install_artifact_failed', {
     name: KIWI_INSTALL_ONLY_ID,
-    detail: causeMessage,
+    detail,
     causeName,
-    causeMessage,
-    ...(causeStack === undefined ? {} : { causeStack }),
     ...(causeCode === undefined ? {} : { causeCode }),
   });
 }

--- a/src/engines/kiwi/artifact.ts
+++ b/src/engines/kiwi/artifact.ts
@@ -1,0 +1,176 @@
+import { errorMessage } from '../../infra/error-format.js';
+import type { Runtime } from '../../runtime/ports.js';
+import { KIWI_INSTALL_ONLY_ID, KIWI_NLP_VERSION } from './constants.js';
+import { isInstallPathUnwritableError, kiwiInstallError, type KiwiInstallError } from './install-error.js';
+import {
+  ensureKiwiModelArtifact,
+  inspectKiwiModelArtifact,
+  type KiwiModelArtifactInstallResult,
+  type KiwiModelArtifactState,
+} from './model-artifact.js';
+import { type KiwiPackageOperationOptions, withKiwiPackageOperationLock } from './operation-lock.js';
+import { kiwiDataDir } from './paths.js';
+import {
+  ensureKiwiWasmArtifactLocked,
+  inspectKiwiWasmArtifact,
+  type KiwiWasmArtifactState,
+  type KiwiWasmInstallOptions,
+} from './wasm-artifact.js';
+
+export type KiwiArtifactComponent = 'model' | 'wasm';
+
+export type KiwiArtifactState = {
+  readonly ready: boolean;
+  readonly model: KiwiModelArtifactState;
+  readonly wasm: KiwiWasmArtifactState;
+  readonly missingComponents: readonly KiwiArtifactComponent[];
+};
+
+type KiwiArtifactInstallSuccess = {
+  readonly status: 'installed' | 'updated' | 'already_installed' | 'already_up_to_date';
+  readonly method: 'runtime-download';
+  readonly version: string;
+  readonly targetDir: string;
+};
+
+export type KiwiArtifactInstallResult = KiwiArtifactInstallSuccess | KiwiInstallError;
+
+type EnsureModelArtifact = typeof ensureKiwiModelArtifact;
+type EnsureWasmArtifact = typeof ensureKiwiWasmArtifactLocked;
+
+export type KiwiArtifactInstallOptions = KiwiPackageOperationOptions &
+  KiwiWasmInstallOptions & {
+    readonly update?: boolean;
+    readonly ensureModelArtifact?: EnsureModelArtifact;
+    readonly ensureWasmArtifact?: EnsureWasmArtifact;
+  };
+
+export function inspectKiwiArtifact(runtime: Pick<Runtime, 'paths' | 'storage'>): KiwiArtifactState {
+  const model = inspectKiwiModelArtifact(runtime);
+  const wasm = inspectKiwiWasmArtifact(runtime);
+  const missingComponents: KiwiArtifactComponent[] = [];
+  if (!model.installed) {
+    missingComponents.push('model');
+  }
+  if (!wasm.installed) {
+    missingComponents.push('wasm');
+  }
+  return {
+    ready: missingComponents.length === 0,
+    model,
+    wasm,
+    missingComponents,
+  };
+}
+
+export function hasKiwiArtifact(runtime: Pick<Runtime, 'paths' | 'storage'>): boolean {
+  return inspectKiwiArtifact(runtime).ready;
+}
+
+export function hasKiwiArtifactDurableState(runtime: Pick<Runtime, 'paths' | 'storage'>): boolean {
+  const dataDir = kiwiDataDir(runtime);
+  try {
+    if (!runtime.storage.statSync(dataDir).isDirectory()) {
+      return false;
+    }
+    return runtime.storage.readdirSync(dataDir, { withFileTypes: true }).some((entry) => entry.name !== 'install.lock');
+  } catch {
+    return false;
+  }
+}
+
+export function kiwiArtifactStateKey(state: KiwiArtifactState): string {
+  return JSON.stringify({
+    ready: state.ready,
+    missingComponents: state.missingComponents,
+    model: {
+      installed: state.model.installed,
+      missingFiles: state.model.missingFiles,
+      manifest: state.model.manifest,
+    },
+    wasm: {
+      installed: state.wasm.installed,
+      reason: state.wasm.reason,
+      payloadSha256: state.wasm.payloadSha256,
+      manifest: state.wasm.manifest,
+    },
+  });
+}
+
+function isInstallError(
+  result: KiwiModelArtifactInstallResult,
+): result is Extract<KiwiModelArtifactInstallResult, { status: 'error' }> {
+  return result.status === 'error';
+}
+
+function installResult(
+  runtime: Pick<Runtime, 'paths'>,
+  update: boolean | undefined,
+  alreadyReady: boolean,
+): KiwiArtifactInstallSuccess {
+  return {
+    status: alreadyReady
+      ? update === true
+        ? 'already_up_to_date'
+        : 'already_installed'
+      : update === true
+        ? 'updated'
+        : 'installed',
+    method: 'runtime-download',
+    version: KIWI_NLP_VERSION,
+    targetDir: kiwiDataDir(runtime),
+  };
+}
+
+async function ensureKiwiArtifactLocked(
+  runtime: Runtime,
+  opts: KiwiArtifactInstallOptions,
+): Promise<KiwiArtifactInstallResult> {
+  const before = inspectKiwiArtifact(runtime);
+  if (before.ready) {
+    return installResult(runtime, opts.update, true);
+  }
+
+  if (!before.model.installed) {
+    const modelResult = await (opts.ensureModelArtifact ?? ensureKiwiModelArtifact)(runtime, {
+      update: opts.update,
+      lockTimeoutMs: opts.lockTimeoutMs,
+      logger: opts.logger,
+      operationLockHeld: true,
+    });
+    if (isInstallError(modelResult)) {
+      return modelResult;
+    }
+  }
+
+  if (!inspectKiwiArtifact(runtime).wasm.installed) {
+    await (opts.ensureWasmArtifact ?? ensureKiwiWasmArtifactLocked)(runtime, {
+      logger: opts.logger,
+      download: opts.download,
+      extract: opts.extract,
+    });
+  }
+
+  const installed = inspectKiwiArtifact(runtime);
+  if (!installed.ready) {
+    throw new Error(`Kiwi artifact install completed without readiness: ${installed.missingComponents.join(', ')}`);
+  }
+  return installResult(runtime, opts.update, false);
+}
+
+export async function ensureKiwiArtifact(
+  runtime: Runtime,
+  opts: KiwiArtifactInstallOptions = {},
+): Promise<KiwiArtifactInstallResult> {
+  try {
+    return await withKiwiPackageOperationLock(runtime, opts, () => ensureKiwiArtifactLocked(runtime, opts));
+  } catch (error: unknown) {
+    if (isInstallPathUnwritableError(error)) {
+      return kiwiInstallError('expansion_install_path_unwritable', { name: KIWI_INSTALL_ONLY_ID });
+    }
+    return kiwiInstallError('expansion_install_artifact_failed', {
+      name: KIWI_INSTALL_ONLY_ID,
+      detail: errorMessage(error),
+    });
+  }
+}

--- a/src/engines/kiwi/constants.ts
+++ b/src/engines/kiwi/constants.ts
@@ -1,5 +1,14 @@
 export const KIWI_INSTALL_ONLY_ID = 'kiwi';
 export const KIWI_NLP_VERSION = '0.23.0';
+export const KIWI_NLP_PACKAGE_URL = `https://registry.npmjs.org/kiwi-nlp/-/kiwi-nlp-${KIWI_NLP_VERSION}.tgz`;
+export const KIWI_NLP_PACKAGE_INTEGRITY =
+  'sha512-J/rizrydoxwD6kUnzOnWb6A3ALSDZphFmmC7XzWPb0ouXZZyhiWmgQTrI458V6KrkC21zg4G8CPew7rM0x1Cmw==';
+export const KIWI_NLP_PACKAGE_SHA256 = '161965a7115f589cb64afec5d97075a057dee08022f693981b15c1b3b6f58921';
+export const KIWI_NLP_PACKAGE_SIZE_BYTES = 929_082;
+export const KIWI_WASM_TAR_ENTRY = 'package/dist/kiwi-wasm.wasm';
+export const KIWI_WASM_FILE_NAME = 'kiwi-wasm.wasm';
+export const KIWI_WASM_SHA256 = '1b78e48701468610cbb49b34105fd297dc1252774ef5c861ebf80fd6cc7d664e';
+export const KIWI_WASM_SIZE_BYTES = 3_779_034;
 export const KIWI_MODEL_VERSION = '0.23.0';
 export const KIWI_MODEL_TYPE = 'cong-global';
 const KIWI_MODEL_RELEASE_TAG = `v${KIWI_MODEL_VERSION}`;

--- a/src/engines/kiwi/install-error.ts
+++ b/src/engines/kiwi/install-error.ts
@@ -1,0 +1,33 @@
+import { documentedCoralSetupError, type DocumentedCoralSetupErrorCode } from '../../runtime/errors.js';
+
+const INSTALL_PATH_UNWRITABLE_CODES = new Set(['EACCES', 'EPERM', 'EROFS', 'ENOSPC']);
+
+export type KiwiInstallError = {
+  readonly status: 'error';
+  readonly code: string;
+  readonly userMessage: string;
+  readonly remediation: string;
+  readonly context?: Record<string, unknown>;
+};
+
+export function kiwiInstallError(
+  code: DocumentedCoralSetupErrorCode,
+  context?: Record<string, unknown>,
+): KiwiInstallError {
+  const error = documentedCoralSetupError(code, context);
+  return {
+    status: 'error',
+    code: error.code,
+    userMessage: error.userMessage,
+    remediation: error.remediation,
+    ...(error.context === undefined ? {} : { context: error.context }),
+  };
+}
+
+export function isInstallPathUnwritableError(error: unknown): error is NodeJS.ErrnoException {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    INSTALL_PATH_UNWRITABLE_CODES.has(String((error as NodeJS.ErrnoException).code))
+  );
+}

--- a/src/engines/kiwi/install.ts
+++ b/src/engines/kiwi/install.ts
@@ -1,7 +1,7 @@
 import type { EngineInstaller, EngineInstallerOptions, LocalExpansionInstallState } from '../../expansion/contract.js';
 import type { Runtime } from '../../runtime/ports.js';
-import { KIWI_INSTALL_ONLY_ID, KIWI_MODEL_VERSION } from './constants.js';
-import { ensureKiwiModelArtifact, hasKiwiDurableState, inspectKiwiModelArtifact } from './model-artifact.js';
+import { ensureKiwiArtifact, hasKiwiArtifactDurableState, inspectKiwiArtifact } from './artifact.js';
+import { KIWI_INSTALL_ONLY_ID, KIWI_NLP_VERSION } from './constants.js';
 import { withKiwiPackageOperationLock } from './operation-lock.js';
 import { kiwiDataDir } from './paths.js';
 
@@ -23,21 +23,21 @@ function assertKiwiInstallerIdentity(name: string): void {
 export const kiwiInstaller: EngineInstaller = {
   inspect(runtime, name): LocalExpansionInstallState {
     assertKiwiInstallerIdentity(name);
-    const state = inspectKiwiModelArtifact(runtime);
+    const state = inspectKiwiArtifact(runtime);
     return {
       targetDir: kiwiDataDir(runtime),
       addonPath: null,
       installLockPath: runtime.paths.coral.engine.installLockPath(name),
-      version: state.manifest?.modelVersion ?? null,
-      method: state.installed ? 'github-release' : null,
-      installed: state.installed,
+      version: state.ready ? KIWI_NLP_VERSION : null,
+      method: state.ready ? 'runtime-download' : null,
+      installed: state.ready,
       installLocked: isInstallLocked(runtime),
-      durableState: state.installed || hasKiwiDurableState(runtime),
+      durableState: hasKiwiArtifactDurableState(runtime),
     };
   },
   async install(ctx: EngineInstallerOptions): Promise<unknown> {
     assertKiwiInstallerIdentity(ctx.name);
-    return ensureKiwiModelArtifact(ctx.runtime, {
+    return ensureKiwiArtifact(ctx.runtime, {
       logger: ctx.logger,
       lockTimeoutMs: ctx.lockTimeoutMs,
       update: ctx.update,
@@ -54,4 +54,4 @@ export const kiwiInstaller: EngineInstaller = {
   },
 };
 
-export const KIWI_INSTALLER_VERSION = KIWI_MODEL_VERSION;
+export const KIWI_INSTALLER_VERSION = KIWI_NLP_VERSION;

--- a/src/engines/kiwi/loader.ts
+++ b/src/engines/kiwi/loader.ts
@@ -1,12 +1,10 @@
-import { randomUUID } from 'node:crypto';
-
 import { Match, type Kiwi, type ModelFiles, type TokenInfo } from 'kiwi-nlp';
-import initKiwiModule from 'kiwi-nlp/dist/build/kiwi-wasm.js';
 
 import type { Runtime } from '../../runtime/ports.js';
+import { ensureKiwiArtifact, inspectKiwiArtifact } from './artifact.js';
 import { KIWI_MODEL_FILES, KIWI_MODEL_TYPE, KIWI_MODEL_VERSION, KIWI_NLP_VERSION } from './constants.js';
-import { ensureKiwiModelArtifact, inspectKiwiModelArtifact } from './model-artifact.js';
-import { kiwiModelFilePath, kiwiWasmPath } from './paths.js';
+import { kiwiModelFilePath } from './paths.js';
+import { createKiwiApi, type KiwiApi } from './wasm-loader.js';
 
 type KiwiAnalyzerIdentity = {
   readonly engine: 'kiwi';
@@ -41,28 +39,6 @@ function readModelFiles(runtime: Pick<Runtime, 'paths' | 'storage'>): ModelFiles
   return modelFiles;
 }
 
-type KiwiWasmModule = {
-  readonly FS: {
-    mkdir(path: string): void;
-    writeFile(path: string, data: Uint8Array): void;
-    unlink(path: string): void;
-    rmdir(path: string): void;
-  };
-  api(command: string): string;
-};
-
-type KiwiWasmInitializer = (moduleArg?: Record<string, unknown>) => Promise<unknown>;
-
-const initKiwi = initKiwiModule as unknown as KiwiWasmInitializer;
-
-type KiwiApi = {
-  cmd<T = unknown>(command: Record<string, unknown>): T;
-  loadModelFiles(files: ModelFiles): Promise<{
-    readonly modelPath: string;
-    unload(): Promise<void>;
-  }>;
-};
-
 function createKiwiProxy(api: KiwiApi, id: number): Kiwi {
   return new Proxy(
     {},
@@ -82,70 +58,14 @@ function createKiwiProxy(api: KiwiApi, id: number): Kiwi {
   ) as Kiwi;
 }
 
-async function createKiwiApi(): Promise<KiwiApi> {
-  const kiwi = (await initKiwi({
-    locateFile: (path: string) => (path.endsWith('.wasm') ? kiwiWasmPath() : path),
-  })) as KiwiWasmModule;
-
-  return {
-    cmd<T = unknown>(command: Record<string, unknown>): T {
-      return JSON.parse(kiwi.api(JSON.stringify(command))) as T;
-    },
-    async loadModelFiles(files: ModelFiles) {
-      const modelPath = `kiwi-model-${randomUUID()}`;
-      kiwi.FS.mkdir(modelPath);
-      const loadedFiles: string[] = [];
-      try {
-        for (const [name, data] of Object.entries(files)) {
-          if (typeof data === 'string') {
-            throw new Error('Kiwi model files must be installed locally before loading.');
-          }
-          const path = `${modelPath}/${name}`;
-          kiwi.FS.writeFile(path, data as Uint8Array);
-          loadedFiles.push(path);
-        }
-      } catch (error: unknown) {
-        for (const path of loadedFiles.reverse()) {
-          try {
-            kiwi.FS.unlink(path);
-          } catch {
-            /* best-effort cleanup */
-          }
-        }
-        try {
-          kiwi.FS.rmdir(modelPath);
-        } catch {
-          /* best-effort cleanup */
-        }
-        throw error;
-      }
-
-      return {
-        modelPath,
-        async unload(): Promise<void> {
-          for (const path of loadedFiles.reverse()) {
-            try {
-              kiwi.FS.unlink(path);
-            } catch {
-              /* best-effort cleanup */
-            }
-          }
-          try {
-            kiwi.FS.rmdir(modelPath);
-          } catch {
-            /* best-effort cleanup */
-          }
-        },
-      };
-    },
-  };
-}
-
-async function buildDisposableKiwi(modelFiles: ModelFiles): Promise<{
+async function buildDisposableKiwi(
+  runtime: Pick<Runtime, 'paths'>,
+  modelFiles: ModelFiles,
+): Promise<{
   readonly kiwi: Kiwi;
   dispose(): Promise<void>;
 }> {
-  const api = await createKiwiApi();
+  const api = await createKiwiApi(runtime);
   const loadedModel = await api.loadModelFiles(modelFiles);
   let disposed = false;
   try {
@@ -184,18 +104,21 @@ function kiwiAnalyzerIdentity(): KiwiAnalyzerIdentity {
 
 export async function loadKiwiAnalyzer(runtime: Runtime, options: LoadKiwiAnalyzerOptions = {}): Promise<KiwiAnalyzer> {
   if (options.installIfMissing === true) {
-    const result = await ensureKiwiModelArtifact(runtime);
+    const result = await ensureKiwiArtifact(runtime);
     if (result.status === 'error') {
-      throw new Error(result.userMessage);
+      throw new Error(`${result.userMessage} ${result.remediation}`, { cause: result });
     }
   }
 
-  const state = inspectKiwiModelArtifact(runtime);
-  if (!state.installed) {
-    throw new Error('Kiwi model artifact is not installed. Run `coral equip kiwi` to install it.');
+  const state = inspectKiwiArtifact(runtime);
+  if (!state.ready) {
+    throw new Error(
+      `Kiwi runtime artifacts are not installed (${state.missingComponents.join(', ')} missing). ` +
+        'Run `coral-cli expansion equip kiwi` to install them.',
+    );
   }
 
-  const loaded = await buildDisposableKiwi(readModelFiles(runtime));
+  const loaded = await buildDisposableKiwi(runtime, readModelFiles(runtime));
   const { kiwi } = loaded;
 
   if (!kiwi.ready()) {

--- a/src/engines/kiwi/loader.ts
+++ b/src/engines/kiwi/loader.ts
@@ -25,6 +25,16 @@ export type LoadKiwiAnalyzerOptions = {
   readonly installIfMissing?: boolean;
 };
 
+export class KiwiAnalyzerMissingArtifactError extends Error {
+  constructor(missingComponents: readonly string[]) {
+    super(
+      `Kiwi runtime artifacts are not installed (${missingComponents.join(', ')} missing). ` +
+        'Run `coral-cli expansion equip kiwi` to install them.',
+    );
+    this.name = 'KiwiAnalyzerMissingArtifactError';
+  }
+}
+
 function readBinaryFile(runtime: Pick<Runtime, 'storage'>, path: string): Uint8Array {
   const readFileSync = runtime.storage.readFileSync as unknown as (filePath: string) => Uint8Array | Buffer;
   const content = readFileSync(path);
@@ -112,10 +122,7 @@ export async function loadKiwiAnalyzer(runtime: Runtime, options: LoadKiwiAnalyz
 
   const state = inspectKiwiArtifact(runtime);
   if (!state.ready) {
-    throw new Error(
-      `Kiwi runtime artifacts are not installed (${state.missingComponents.join(', ')} missing). ` +
-        'Run `coral-cli expansion equip kiwi` to install them.',
-    );
+    throw new KiwiAnalyzerMissingArtifactError(state.missingComponents);
   }
 
   const loaded = await buildDisposableKiwi(runtime, readModelFiles(runtime));

--- a/src/engines/kiwi/model-artifact.ts
+++ b/src/engines/kiwi/model-artifact.ts
@@ -6,6 +6,7 @@ import { gunzipSync } from 'node:zlib';
 
 import { downloadBuffer } from '#src/runtime/download.js';
 import { sha256Hex } from '../../infra/hash.js';
+import { isNoEntryError } from '../../infra/fs-errors.js';
 import { isRecord } from '../../infra/json.js';
 import type { Runtime } from '../../runtime/ports.js';
 import { extractTarGzEntriesInWorker } from '../../infra/archive-extraction-worker.js';
@@ -120,6 +121,26 @@ export type KiwiModelArtifactState = {
   readonly missingFiles: readonly string[];
 };
 
+type KiwiModelPathIdentity =
+  | { readonly state: 'missing' | 'unreadable' }
+  | {
+      readonly state: 'present';
+      readonly regularFile: boolean;
+      readonly dev: string;
+      readonly ino: string;
+      readonly mode: string;
+      readonly size: string;
+      readonly mtimeNs: string;
+    };
+
+export type KiwiModelArtifactIdentity = {
+  readonly manifest: KiwiModelPathIdentity;
+  readonly files: readonly {
+    readonly fileName: KiwiModelFileName;
+    readonly identity: KiwiModelPathIdentity;
+  }[];
+};
+
 export type KiwiModelArtifactInstallResult =
   | {
       readonly status: 'installed' | 'updated' | 'already_installed' | 'already_up_to_date';
@@ -173,6 +194,34 @@ function isFile(runtime: Pick<Runtime, 'storage'>, path: string): boolean {
   } catch {
     return false;
   }
+}
+
+function probePathIdentity(runtime: Pick<Runtime, 'storage'>, path: string): KiwiModelPathIdentity {
+  try {
+    const kind = runtime.storage.lstatSync(path);
+    const stat = runtime.storage.statSync(path, { bigint: true });
+    return {
+      state: 'present',
+      regularFile: kind.isFile() && !kind.isSymbolicLink(),
+      dev: stat.dev.toString(),
+      ino: stat.ino.toString(),
+      mode: stat.mode.toString(),
+      size: stat.size.toString(),
+      mtimeNs: stat.mtimeNs.toString(),
+    };
+  } catch (error: unknown) {
+    return { state: isNoEntryError(error) ? 'missing' : 'unreadable' };
+  }
+}
+
+export function probeKiwiModelArtifactIdentity(runtime: Pick<Runtime, 'paths' | 'storage'>): KiwiModelArtifactIdentity {
+  return {
+    manifest: probePathIdentity(runtime, kiwiModelManifestPath(runtime)),
+    files: KIWI_MODEL_FILES.map((fileName) => ({
+      fileName,
+      identity: probePathIdentity(runtime, kiwiModelFilePath(runtime, fileName)),
+    })),
+  };
 }
 
 function isKiwiModelArtifactManifest(value: unknown): value is KiwiModelArtifactManifest {

--- a/src/engines/kiwi/model-artifact.ts
+++ b/src/engines/kiwi/model-artifact.ts
@@ -7,7 +7,6 @@ import { gunzipSync } from 'node:zlib';
 import { downloadBuffer } from '#src/runtime/download.js';
 import { sha256Hex } from '../../infra/hash.js';
 import { isRecord } from '../../infra/json.js';
-import { documentedCoralSetupError } from '../../runtime/errors.js';
 import type { Runtime } from '../../runtime/ports.js';
 import { extractTarGzEntriesInWorker } from '../../infra/archive-extraction-worker.js';
 import {
@@ -24,10 +23,10 @@ import {
 } from './constants.js';
 import { kiwiDataDir, kiwiModelDir, kiwiModelFilePath, kiwiModelManifestPath } from './paths.js';
 import { withKiwiPackageOperationLock } from './operation-lock.js';
+import { isInstallPathUnwritableError, kiwiInstallError, type KiwiInstallError } from './install-error.js';
 
 const TAR_BLOCK_SIZE = 512;
 const TAR_FILE_TYPES = new Set(['0', '']);
-const INSTALL_PATH_UNWRITABLE_CODES = new Set(['EACCES', 'EPERM', 'EROFS', 'ENOSPC']);
 export const KIWI_MODEL_TAR_MAX_BYTES = 512 * 1024 * 1024;
 const KIWI_MODEL_EXTRACTION_WORKER_TIMEOUT_MS = 60_000;
 const KIWI_MODEL_WRITE_WORKER_TIMEOUT_MS = 60_000;
@@ -128,13 +127,7 @@ export type KiwiModelArtifactInstallResult =
       readonly version: string;
       readonly targetDir: string;
     }
-  | {
-      readonly status: 'error';
-      readonly code: string;
-      readonly userMessage: string;
-      readonly remediation: string;
-      readonly context?: Record<string, unknown>;
-    };
+  | KiwiInstallError;
 
 type KiwiModelInstallOptions = {
   readonly update?: boolean;
@@ -174,39 +167,9 @@ function logInstallEvent(opts: KiwiModelInstallOptions, kind: string, message: s
   opts.logger?.({ kind, message });
 }
 
-function toInstallError(
-  code: Parameters<typeof documentedCoralSetupError>[0],
-  context: Parameters<typeof documentedCoralSetupError>[1],
-): Extract<KiwiModelArtifactInstallResult, { status: 'error' }> {
-  const error = documentedCoralSetupError(code, context);
-  return {
-    status: 'error',
-    code: error.code,
-    userMessage: error.userMessage,
-    remediation: error.remediation,
-    ...(error.context === undefined ? {} : { context: error.context }),
-  };
-}
-
-function isInstallPathUnwritableError(error: unknown): error is NodeJS.ErrnoException {
-  return (
-    error instanceof Error &&
-    'code' in error &&
-    INSTALL_PATH_UNWRITABLE_CODES.has(String((error as NodeJS.ErrnoException).code))
-  );
-}
-
 function isFile(runtime: Pick<Runtime, 'storage'>, path: string): boolean {
   try {
     return runtime.storage.statSync(path).isFile();
-  } catch {
-    return false;
-  }
-}
-
-function isDirectory(runtime: Pick<Runtime, 'storage'>, path: string): boolean {
-  try {
-    return runtime.storage.statSync(path).isDirectory();
   } catch {
     return false;
   }
@@ -249,22 +212,6 @@ export function inspectKiwiModelArtifact(runtime: Pick<Runtime, 'paths' | 'stora
     manifest,
     missingFiles,
   };
-}
-
-export function hasKiwiModelArtifact(runtime: Pick<Runtime, 'paths' | 'storage'>): boolean {
-  return inspectKiwiModelArtifact(runtime).installed;
-}
-
-export function hasKiwiDurableState(runtime: Pick<Runtime, 'paths' | 'storage'>): boolean {
-  const dataDir = kiwiDataDir(runtime);
-  if (!isDirectory(runtime, dataDir)) {
-    return false;
-  }
-  try {
-    return runtime.storage.readdirSync(dataDir, { withFileTypes: true }).some((entry) => entry.name !== 'install.lock');
-  } catch {
-    return false;
-  }
 }
 
 function tarFieldToString(buffer: Buffer): string {
@@ -580,7 +527,7 @@ export async function ensureKiwiModelArtifact(
     });
   } catch (error: unknown) {
     if (isInstallPathUnwritableError(error)) {
-      return toInstallError('expansion_install_path_unwritable', { name: KIWI_INSTALL_ONLY_ID });
+      return kiwiInstallError('expansion_install_path_unwritable', { name: KIWI_INSTALL_ONLY_ID });
     }
     throw error;
   }

--- a/src/engines/kiwi/operation-lock.ts
+++ b/src/engines/kiwi/operation-lock.ts
@@ -3,39 +3,24 @@ import {
   acquirePackageOperationLockAtPath,
   PACKAGE_OPERATION_LOCK_TIMEOUT_MS,
 } from '../../infra/package-operation-lock.js';
-import { documentedCoralSetupError } from '../../runtime/errors.js';
 import type { Runtime } from '../../runtime/ports.js';
 import { KIWI_INSTALL_ONLY_ID } from './constants.js';
+import { kiwiInstallError, type KiwiInstallError } from './install-error.js';
 
-type KiwiPackageOperationOptions = {
+export type KiwiPackageOperationOptions = {
   readonly lockTimeoutMs?: number;
   readonly operationLockHeld?: true;
 };
 
-export type KiwiPackageOperationLockError = {
-  readonly status: 'error';
-  readonly code: string;
-  readonly userMessage: string;
-  readonly remediation: string;
-  readonly context?: Record<string, unknown>;
-};
-
-function lockContendedError(): KiwiPackageOperationLockError {
-  const error = documentedCoralSetupError('expansion_install_lock_contended', { name: KIWI_INSTALL_ONLY_ID });
-  return {
-    status: 'error',
-    code: error.code,
-    userMessage: error.userMessage,
-    remediation: error.remediation,
-    ...(error.context === undefined ? {} : { context: error.context }),
-  };
+function lockContendedError(): KiwiInstallError {
+  return kiwiInstallError('expansion_install_lock_contended', { name: KIWI_INSTALL_ONLY_ID });
 }
 
 export async function withKiwiPackageOperationLock<T>(
   runtime: Runtime,
   options: KiwiPackageOperationOptions,
   run: () => Promise<T>,
-): Promise<T | KiwiPackageOperationLockError> {
+): Promise<T | KiwiInstallError> {
   if (options.operationLockHeld === true) {
     return run();
   }

--- a/src/engines/kiwi/paths.ts
+++ b/src/engines/kiwi/paths.ts
@@ -1,12 +1,11 @@
-import { createRequire } from 'node:module';
 import { join } from 'node:path';
 
 import type { Runtime } from '../../runtime/ports.js';
-import { KIWI_INSTALL_ONLY_ID, KIWI_MODEL_VERSION } from './constants.js';
+import { KIWI_INSTALL_ONLY_ID, KIWI_MODEL_VERSION, KIWI_NLP_VERSION, KIWI_WASM_FILE_NAME } from './constants.js';
 
-const require = createRequire(import.meta.url);
 const KIWI_MODEL_DIR_NAME = 'cong-base';
 const KIWI_MODEL_MANIFEST_FILE = 'manifest.json';
+const KIWI_WASM_MANIFEST_FILE = 'manifest.json';
 
 export function kiwiDataDir(runtime: Pick<Runtime, 'paths'>): string {
   return runtime.paths.coral.engine.dataDir(KIWI_INSTALL_ONLY_ID);
@@ -24,6 +23,14 @@ export function kiwiModelFilePath(runtime: Pick<Runtime, 'paths'>, fileName: str
   return join(kiwiModelDir(runtime), fileName);
 }
 
-export function kiwiWasmPath(): string {
-  return require.resolve('kiwi-nlp/dist/kiwi-wasm.wasm');
+export function kiwiWasmDir(runtime: Pick<Runtime, 'paths'>): string {
+  return join(kiwiDataDir(runtime), 'wasm', `v${KIWI_NLP_VERSION}`);
+}
+
+export function kiwiWasmManifestPath(runtime: Pick<Runtime, 'paths'>): string {
+  return join(kiwiWasmDir(runtime), KIWI_WASM_MANIFEST_FILE);
+}
+
+export function kiwiWasmPath(runtime: Pick<Runtime, 'paths'>): string {
+  return join(kiwiWasmDir(runtime), KIWI_WASM_FILE_NAME);
 }

--- a/src/engines/kiwi/wasm-artifact.ts
+++ b/src/engines/kiwi/wasm-artifact.ts
@@ -61,6 +61,23 @@ export type KiwiWasmArtifactState = {
   readonly reason: KiwiWasmArtifactReason | null;
 };
 
+type KiwiWasmPathIdentity =
+  | { readonly state: 'missing' | 'unreadable' }
+  | {
+      readonly state: 'present';
+      readonly regularFile: boolean;
+      readonly dev: string;
+      readonly ino: string;
+      readonly mode: string;
+      readonly size: string;
+      readonly mtimeNs: string;
+    };
+
+export type KiwiWasmArtifactIdentity = {
+  readonly manifest: KiwiWasmPathIdentity;
+  readonly payload: KiwiWasmPathIdentity;
+};
+
 type KiwiWasmDownload = (runtime: Runtime, url: string, options: { readonly maxBytes: number }) => Promise<Buffer>;
 
 export type KiwiWasmInstallOptions = {
@@ -80,6 +97,31 @@ function isRegularFile(runtime: Pick<Runtime, 'storage'>, path: string): boolean
   } catch {
     return false;
   }
+}
+
+function probePathIdentity(runtime: Pick<Runtime, 'storage'>, path: string): KiwiWasmPathIdentity {
+  try {
+    const kind = runtime.storage.lstatSync(path);
+    const stat = runtime.storage.statSync(path, { bigint: true });
+    return {
+      state: 'present',
+      regularFile: kind.isFile() && !kind.isSymbolicLink(),
+      dev: stat.dev.toString(),
+      ino: stat.ino.toString(),
+      mode: stat.mode.toString(),
+      size: stat.size.toString(),
+      mtimeNs: stat.mtimeNs.toString(),
+    };
+  } catch (error: unknown) {
+    return { state: isNoEntryError(error) ? 'missing' : 'unreadable' };
+  }
+}
+
+export function probeKiwiWasmArtifactIdentity(runtime: Pick<Runtime, 'paths' | 'storage'>): KiwiWasmArtifactIdentity {
+  return {
+    manifest: probePathIdentity(runtime, kiwiWasmManifestPath(runtime)),
+    payload: probePathIdentity(runtime, kiwiWasmPath(runtime)),
+  };
 }
 
 function isKiwiWasmArtifactManifest(value: unknown): value is KiwiWasmArtifactManifest {
@@ -246,6 +288,8 @@ export function inspectKiwiWasmArtifact(runtime: Pick<Runtime, 'paths' | 'storag
     targetDir: kiwiWasmDir(runtime),
     manifestPath: kiwiWasmManifestPath(runtime),
     wasmPath: kiwiWasmPath(runtime),
+    // The manifest remains load-bearing for install provenance (when and from where);
+    // a missing one is republished without downloading when the pinned payload digest is valid.
     installed: manifest !== null && payload.payloadValid,
     manifest,
     ...payload,

--- a/src/engines/kiwi/wasm-artifact.ts
+++ b/src/engines/kiwi/wasm-artifact.ts
@@ -1,0 +1,393 @@
+import { createHash } from 'node:crypto';
+
+import { extractTarGzEntriesInWorker } from '../../infra/archive-extraction-worker.js';
+import { isNoEntryError } from '../../infra/fs-errors.js';
+import { sha256Hex } from '../../infra/hash.js';
+import { isRecord } from '../../infra/json.js';
+import { downloadBuffer } from '../../runtime/download.js';
+import type { Runtime } from '../../runtime/ports.js';
+import {
+  KIWI_INSTALL_ONLY_ID,
+  KIWI_NLP_PACKAGE_INTEGRITY,
+  KIWI_NLP_PACKAGE_SHA256,
+  KIWI_NLP_PACKAGE_SIZE_BYTES,
+  KIWI_NLP_PACKAGE_URL,
+  KIWI_NLP_VERSION,
+  KIWI_WASM_FILE_NAME,
+  KIWI_WASM_SHA256,
+  KIWI_WASM_SIZE_BYTES,
+  KIWI_WASM_TAR_ENTRY,
+} from './constants.js';
+import { kiwiWasmDir, kiwiWasmManifestPath, kiwiWasmPath } from './paths.js';
+
+const KIWI_WASM_MANIFEST_SCHEMA_VERSION = 1;
+const KIWI_WASM_ARTIFACT_KIND = 'kiwi-wasm';
+const KIWI_WASM_MANIFEST_MAX_BYTES = 64 * 1024;
+const KIWI_WASM_TAR_MAX_BYTES = 4 * 1024 * 1024;
+const KIWI_WASM_EXTRACTION_WORKER_TIMEOUT_MS = 60_000;
+
+type KiwiWasmArtifactReason =
+  | 'manifest_missing_or_invalid'
+  | 'file_missing'
+  | 'file_not_regular'
+  | 'file_size_mismatch'
+  | 'file_unreadable'
+  | 'file_digest_mismatch';
+
+export type KiwiWasmArtifactManifest = {
+  readonly schemaVersion: typeof KIWI_WASM_MANIFEST_SCHEMA_VERSION;
+  readonly artifact: typeof KIWI_WASM_ARTIFACT_KIND;
+  readonly packageId: typeof KIWI_INSTALL_ONLY_ID;
+  readonly kiwiNlpVersion: string;
+  readonly sourceUrl: string;
+  readonly archiveIntegrity: string;
+  readonly archiveSha256: string;
+  readonly archiveSizeBytes: number;
+  readonly archiveEntry: string;
+  readonly wasmSha256: string;
+  readonly wasmSizeBytes: number;
+  readonly file: typeof KIWI_WASM_FILE_NAME;
+  readonly installedAt: string;
+};
+
+export type KiwiWasmArtifactState = {
+  readonly targetDir: string;
+  readonly manifestPath: string;
+  readonly wasmPath: string;
+  readonly installed: boolean;
+  readonly manifest: KiwiWasmArtifactManifest | null;
+  readonly payloadValid: boolean;
+  readonly payloadSha256: string | null;
+  readonly reason: KiwiWasmArtifactReason | null;
+};
+
+type KiwiWasmDownload = (runtime: Runtime, url: string, options: { readonly maxBytes: number }) => Promise<Buffer>;
+
+export type KiwiWasmInstallOptions = {
+  readonly logger?: (event: { readonly kind: string; readonly message: string }) => void;
+  readonly download?: KiwiWasmDownload;
+  readonly extract?: (archive: Buffer) => Promise<Buffer>;
+};
+
+function logInstallEvent(opts: KiwiWasmInstallOptions, kind: string, message: string): void {
+  opts.logger?.({ kind, message });
+}
+
+function isRegularFile(runtime: Pick<Runtime, 'storage'>, path: string): boolean {
+  try {
+    const stat = runtime.storage.lstatSync(path);
+    return stat.isFile() && !stat.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function isKiwiWasmArtifactManifest(value: unknown): value is KiwiWasmArtifactManifest {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === KIWI_WASM_MANIFEST_SCHEMA_VERSION &&
+    value.artifact === KIWI_WASM_ARTIFACT_KIND &&
+    value.packageId === KIWI_INSTALL_ONLY_ID &&
+    value.kiwiNlpVersion === KIWI_NLP_VERSION &&
+    value.sourceUrl === KIWI_NLP_PACKAGE_URL &&
+    value.archiveIntegrity === KIWI_NLP_PACKAGE_INTEGRITY &&
+    value.archiveSha256 === KIWI_NLP_PACKAGE_SHA256 &&
+    value.archiveSizeBytes === KIWI_NLP_PACKAGE_SIZE_BYTES &&
+    value.archiveEntry === KIWI_WASM_TAR_ENTRY &&
+    value.wasmSha256 === KIWI_WASM_SHA256 &&
+    value.wasmSizeBytes === KIWI_WASM_SIZE_BYTES &&
+    value.file === KIWI_WASM_FILE_NAME &&
+    typeof value.installedAt === 'string'
+  );
+}
+
+function readInstalledManifest(runtime: Pick<Runtime, 'paths' | 'storage'>): KiwiWasmArtifactManifest | null {
+  const manifestPath = kiwiWasmManifestPath(runtime);
+  try {
+    if (
+      !isRegularFile(runtime, manifestPath) ||
+      runtime.storage.statSync(manifestPath).size > KIWI_WASM_MANIFEST_MAX_BYTES
+    ) {
+      return null;
+    }
+    const parsed = JSON.parse(runtime.storage.readFileSync(manifestPath, 'utf-8')) as unknown;
+    return isKiwiWasmArtifactManifest(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+type StableFileStat = {
+  readonly dev: bigint;
+  readonly ino: bigint;
+  readonly mode: bigint;
+  readonly size: bigint;
+  readonly mtimeNs: bigint;
+};
+
+function sameStableFile(left: StableFileStat, right: StableFileStat): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs
+  );
+}
+
+function hashOpenFile(
+  runtime: Pick<Runtime, 'storage'>,
+  descriptor: number,
+  expectedSize: bigint,
+  path: string,
+): { readonly digest: string; readonly bytesRead: bigint } {
+  const hash = createHash('sha256');
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  let bytesRead = 0n;
+  while (bytesRead < expectedSize) {
+    const remaining = Number(expectedSize - bytesRead);
+    const read = runtime.storage.readSync(descriptor, buffer, 0, Math.min(buffer.length, remaining), null);
+    if (read <= 0) {
+      throw new Error(`Unexpected end of file while hashing ${path}`);
+    }
+    bytesRead += BigInt(read);
+    hash.update(buffer.subarray(0, read));
+  }
+  const probe = Buffer.allocUnsafe(1);
+  if (runtime.storage.readSync(descriptor, probe, 0, 1, null) !== 0) {
+    throw new Error(`Kiwi WASM grew while hashing: ${path}`);
+  }
+  return { digest: hash.digest('hex'), bytesRead };
+}
+
+function assertStableFileIdentity(
+  runtime: Pick<Runtime, 'storage'>,
+  path: string,
+  descriptor: number,
+  opened: StableFileStat,
+  bytesRead: bigint,
+): void {
+  const openedAfter = runtime.storage.fstatSync(descriptor, { bigint: true });
+  const pathAfter = runtime.storage.statSync(path, { bigint: true });
+  const pathKindAfter = runtime.storage.lstatSync(path);
+  if (
+    pathKindAfter.isSymbolicLink() ||
+    !pathKindAfter.isFile() ||
+    bytesRead !== opened.size ||
+    !sameStableFile(opened, openedAfter) ||
+    !sameStableFile(opened, pathAfter)
+  ) {
+    throw new Error(`Kiwi WASM identity changed while hashing: ${path}`);
+  }
+}
+
+/**
+ * Hashes fresh bytes and proves the descriptor still names the canonical path.
+ * This prevents same-metadata replacement races from being accepted as ready.
+ */
+function stableFileSha256(runtime: Pick<Runtime, 'storage'>, path: string): string {
+  const pathBefore = runtime.storage.statSync(path, { bigint: true });
+  const descriptor = runtime.storage.openSync(path, 'r');
+  let digest: string | undefined;
+  let closeError: unknown = null;
+  try {
+    const opened = runtime.storage.fstatSync(descriptor, { bigint: true });
+    if (!opened.isFile() || !sameStableFile(pathBefore, opened)) {
+      throw new Error(`Kiwi WASM identity changed before hashing: ${path}`);
+    }
+    const hashed = hashOpenFile(runtime, descriptor, opened.size, path);
+    assertStableFileIdentity(runtime, path, descriptor, opened, hashed.bytesRead);
+    digest = hashed.digest;
+  } finally {
+    try {
+      runtime.storage.closeSync(descriptor);
+    } catch (error: unknown) {
+      closeError = error;
+    }
+  }
+  if (closeError !== null || digest === undefined) {
+    throw new Error(`Kiwi WASM descriptor could not be closed safely: ${path}`, {
+      cause: closeError,
+    });
+  }
+  return digest;
+}
+
+function inspectPayload(
+  runtime: Pick<Runtime, 'paths' | 'storage'>,
+): Pick<KiwiWasmArtifactState, 'payloadValid' | 'payloadSha256' | 'reason'> {
+  const wasmPath = kiwiWasmPath(runtime);
+  try {
+    const lstat = runtime.storage.lstatSync(wasmPath);
+    if (!lstat.isFile() || lstat.isSymbolicLink()) {
+      return { payloadValid: false, payloadSha256: null, reason: 'file_not_regular' };
+    }
+  } catch {
+    return { payloadValid: false, payloadSha256: null, reason: 'file_missing' };
+  }
+
+  try {
+    if (runtime.storage.statSync(wasmPath).size !== KIWI_WASM_SIZE_BYTES) {
+      return { payloadValid: false, payloadSha256: null, reason: 'file_size_mismatch' };
+    }
+    const payloadSha256 = stableFileSha256(runtime, wasmPath);
+    return payloadSha256 === KIWI_WASM_SHA256
+      ? { payloadValid: true, payloadSha256, reason: null }
+      : { payloadValid: false, payloadSha256, reason: 'file_digest_mismatch' };
+  } catch {
+    return { payloadValid: false, payloadSha256: null, reason: 'file_unreadable' };
+  }
+}
+
+export function inspectKiwiWasmArtifact(runtime: Pick<Runtime, 'paths' | 'storage'>): KiwiWasmArtifactState {
+  const manifest = readInstalledManifest(runtime);
+  const payload = inspectPayload(runtime);
+  return {
+    targetDir: kiwiWasmDir(runtime),
+    manifestPath: kiwiWasmManifestPath(runtime),
+    wasmPath: kiwiWasmPath(runtime),
+    installed: manifest !== null && payload.payloadValid,
+    manifest,
+    ...payload,
+    reason: payload.reason ?? (manifest === null ? 'manifest_missing_or_invalid' : null),
+  };
+}
+
+function createManifest(now: number): KiwiWasmArtifactManifest {
+  return {
+    schemaVersion: KIWI_WASM_MANIFEST_SCHEMA_VERSION,
+    artifact: KIWI_WASM_ARTIFACT_KIND,
+    packageId: KIWI_INSTALL_ONLY_ID,
+    kiwiNlpVersion: KIWI_NLP_VERSION,
+    sourceUrl: KIWI_NLP_PACKAGE_URL,
+    archiveIntegrity: KIWI_NLP_PACKAGE_INTEGRITY,
+    archiveSha256: KIWI_NLP_PACKAGE_SHA256,
+    archiveSizeBytes: KIWI_NLP_PACKAGE_SIZE_BYTES,
+    archiveEntry: KIWI_WASM_TAR_ENTRY,
+    wasmSha256: KIWI_WASM_SHA256,
+    wasmSizeBytes: KIWI_WASM_SIZE_BYTES,
+    file: KIWI_WASM_FILE_NAME,
+    installedAt: new Date(now).toISOString(),
+  };
+}
+
+function removeNonRegularReservedTarget(runtime: Pick<Runtime, 'storage'>, path: string): void {
+  try {
+    const stat = runtime.storage.lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      runtime.storage.rmSync(path, { recursive: true, force: true });
+    }
+  } catch (error: unknown) {
+    if (!isNoEntryError(error)) {
+      throw error;
+    }
+  }
+}
+
+function publishManifest(runtime: Runtime): void {
+  const manifest = createManifest(runtime.time.now());
+  const manifestPath = kiwiWasmManifestPath(runtime);
+  removeNonRegularReservedTarget(runtime, manifestPath);
+  const published = runtime.storage.writeAtomicDurableSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+    encoding: 'utf-8',
+    mode: 0o644,
+  });
+  if (!published) {
+    throw new Error('Kiwi WASM manifest could not be published durably');
+  }
+}
+
+function sha512Integrity(input: Uint8Array): string {
+  return `sha512-${createHash('sha512').update(input).digest('base64')}`;
+}
+
+export function verifyKiwiNlpArchive(archive: Buffer): void {
+  if (archive.length !== KIWI_NLP_PACKAGE_SIZE_BYTES) {
+    throw new Error(`Kiwi npm archive size mismatch: expected ${KIWI_NLP_PACKAGE_SIZE_BYTES}, got ${archive.length}`);
+  }
+  const digest = sha256Hex(archive);
+  if (digest !== KIWI_NLP_PACKAGE_SHA256) {
+    throw new Error(`Kiwi npm archive digest mismatch: expected ${KIWI_NLP_PACKAGE_SHA256}, got ${digest}`);
+  }
+  const integrity = sha512Integrity(archive);
+  if (integrity !== KIWI_NLP_PACKAGE_INTEGRITY) {
+    throw new Error(`Kiwi npm archive integrity mismatch: expected ${KIWI_NLP_PACKAGE_INTEGRITY}, got ${integrity}`);
+  }
+}
+
+function verifyKiwiWasmPayload(wasm: Buffer): void {
+  if (wasm.length !== KIWI_WASM_SIZE_BYTES) {
+    throw new Error(`Kiwi WASM size mismatch: expected ${KIWI_WASM_SIZE_BYTES}, got ${wasm.length}`);
+  }
+  const digest = sha256Hex(wasm);
+  if (digest !== KIWI_WASM_SHA256) {
+    throw new Error(`Kiwi WASM digest mismatch: expected ${KIWI_WASM_SHA256}, got ${digest}`);
+  }
+}
+
+export async function extractKiwiWasm(archive: Buffer, maxTarBytes = KIWI_WASM_TAR_MAX_BYTES): Promise<Buffer> {
+  const entries = await extractTarGzEntriesInWorker(
+    {
+      archive,
+      archiveLabel: 'Kiwi npm archive',
+      maxTarBytes,
+      entries: [{ key: 'wasm', exactPath: KIWI_WASM_TAR_ENTRY }],
+      missingMessage: `Kiwi npm archive is missing ${KIWI_WASM_TAR_ENTRY}`,
+    },
+    { timeoutMs: KIWI_WASM_EXTRACTION_WORKER_TIMEOUT_MS },
+  );
+  const wasm = entries.get('wasm');
+  if (wasm === undefined) {
+    throw new Error(`Kiwi npm archive is missing ${KIWI_WASM_TAR_ENTRY}`);
+  }
+  return wasm;
+}
+
+export function publishKiwiWasmArtifact(runtime: Runtime, wasm: Buffer): KiwiWasmArtifactState {
+  verifyKiwiWasmPayload(wasm);
+  runtime.storage.mkdirSync(kiwiWasmDir(runtime), { recursive: true });
+  const wasmPath = kiwiWasmPath(runtime);
+  removeNonRegularReservedTarget(runtime, wasmPath);
+  const published = runtime.storage.writeAtomicDurableSync(wasmPath, wasm, { mode: 0o644 });
+  if (!published) {
+    throw new Error('Kiwi WASM could not be published durably');
+  }
+  publishManifest(runtime);
+  const installed = inspectKiwiWasmArtifact(runtime);
+  if (!installed.installed) {
+    throw new Error(`Kiwi WASM artifact failed post-install validation: ${installed.reason ?? 'unknown reason'}`);
+  }
+  return installed;
+}
+
+export async function ensureKiwiWasmArtifactLocked(
+  runtime: Runtime,
+  opts: KiwiWasmInstallOptions = {},
+): Promise<KiwiWasmArtifactState> {
+  const current = inspectKiwiWasmArtifact(runtime);
+  if (current.installed) {
+    return current;
+  }
+
+  runtime.storage.mkdirSync(kiwiWasmDir(runtime), { recursive: true });
+  if (!current.payloadValid) {
+    logInstallEvent(opts, 'expansion.install.download', `Downloading ${KIWI_NLP_PACKAGE_URL}`);
+    const archive = await (opts.download ?? downloadBuffer)(runtime, KIWI_NLP_PACKAGE_URL, {
+      maxBytes: KIWI_NLP_PACKAGE_SIZE_BYTES,
+    });
+    verifyKiwiNlpArchive(archive);
+
+    logInstallEvent(opts, 'expansion.install.extract', `Extracting ${KIWI_WASM_TAR_ENTRY}`);
+    const wasm = await (opts.extract ?? extractKiwiWasm)(archive);
+
+    logInstallEvent(opts, 'expansion.install.write', 'Installing Kiwi WASM');
+    return publishKiwiWasmArtifact(runtime, wasm);
+  }
+
+  publishManifest(runtime);
+  const installed = inspectKiwiWasmArtifact(runtime);
+  if (!installed.installed) {
+    throw new Error(`Kiwi WASM artifact failed post-install validation: ${installed.reason ?? 'unknown reason'}`);
+  }
+  return installed;
+}

--- a/src/engines/kiwi/wasm-loader.ts
+++ b/src/engines/kiwi/wasm-loader.ts
@@ -1,0 +1,93 @@
+import { randomUUID } from 'node:crypto';
+
+import type { ModelFiles } from 'kiwi-nlp';
+import initKiwiModule from 'kiwi-nlp/dist/build/kiwi-wasm.js';
+
+import type { Runtime } from '../../runtime/ports.js';
+import { KIWI_WASM_FILE_NAME } from './constants.js';
+import { kiwiWasmPath } from './paths.js';
+
+type KiwiWasmModule = {
+  readonly FS: {
+    mkdir(path: string): void;
+    writeFile(path: string, data: Uint8Array): void;
+    unlink(path: string): void;
+    rmdir(path: string): void;
+  };
+  api(command: string): string;
+};
+
+export type KiwiWasmInitializer = (moduleArg?: Record<string, unknown>) => Promise<unknown>;
+
+const initKiwi = initKiwiModule as unknown as KiwiWasmInitializer;
+
+export type KiwiApi = {
+  cmd<T = unknown>(command: Record<string, unknown>): T;
+  loadModelFiles(files: ModelFiles): Promise<{
+    readonly modelPath: string;
+    unload(): Promise<void>;
+  }>;
+};
+
+export async function createKiwiApi(
+  runtime: Pick<Runtime, 'paths'>,
+  initialize: KiwiWasmInitializer = initKiwi,
+): Promise<KiwiApi> {
+  const kiwi = (await initialize({
+    locateFile: (path: string, prefix = '') =>
+      path === KIWI_WASM_FILE_NAME ? kiwiWasmPath(runtime) : `${prefix}${path}`,
+  })) as KiwiWasmModule;
+
+  return {
+    cmd<T = unknown>(command: Record<string, unknown>): T {
+      return JSON.parse(kiwi.api(JSON.stringify(command))) as T;
+    },
+    async loadModelFiles(files: ModelFiles) {
+      const modelPath = `kiwi-model-${randomUUID()}`;
+      kiwi.FS.mkdir(modelPath);
+      const loadedFiles: string[] = [];
+      try {
+        for (const [name, data] of Object.entries(files)) {
+          if (typeof data === 'string') {
+            throw new Error('Kiwi model files must be installed locally before loading.');
+          }
+          const path = `${modelPath}/${name}`;
+          kiwi.FS.writeFile(path, data as Uint8Array);
+          loadedFiles.push(path);
+        }
+      } catch (error: unknown) {
+        for (const path of loadedFiles.reverse()) {
+          try {
+            kiwi.FS.unlink(path);
+          } catch {
+            /* best-effort cleanup */
+          }
+        }
+        try {
+          kiwi.FS.rmdir(modelPath);
+        } catch {
+          /* best-effort cleanup */
+        }
+        throw error;
+      }
+
+      return {
+        modelPath,
+        async unload(): Promise<void> {
+          for (const path of loadedFiles.reverse()) {
+            try {
+              kiwi.FS.unlink(path);
+            } catch {
+              /* best-effort cleanup */
+            }
+          }
+          try {
+            kiwi.FS.rmdir(modelPath);
+          } catch {
+            /* best-effort cleanup */
+          }
+        },
+      };
+    },
+  };
+}

--- a/src/expansion/bundled.ts
+++ b/src/expansion/bundled.ts
@@ -44,7 +44,7 @@ export const BUNDLED_INSTALL_ONLY_PACKAGES: readonly InstallOnlyManifest[] = [
       {
         kind: 'confirm-download',
         message:
-          "This downloads the Kiwi CoNg base model (~88 MB) from github.com/bab2min/Kiwi releases into Coral's engine data directory. Continue?",
+          "This downloads only missing or invalid Kiwi artifacts into Coral's engine data directory: an ~88 MB CoNg base model from GitHub Releases and a ~0.9 MB pinned kiwi-nlp archive from npm on a clean install. A valid existing model is preserved. Continue?",
       },
     ],
   },

--- a/src/expansion/rpc-contract.ts
+++ b/src/expansion/rpc-contract.ts
@@ -122,6 +122,7 @@ const installOnlyEntrySchema = z
     activation: z.literal('none'),
     status: z.enum(installOnlyCatalogStatusLiterals),
     command: z.string().min(1).optional(),
+    confirmDownload: z.string().min(1).optional(),
   })
   .strict();
 

--- a/src/expansion/rpc-contract.ts
+++ b/src/expansion/rpc-contract.ts
@@ -28,6 +28,9 @@ const expansionCatalogStatusLiterals = [
 ] as const;
 
 const installOnlyCatalogStatusLiterals = ['not_installed', 'installed', 'installing'] as const;
+export const installMethodSchema = z.enum(['runtime-download', 'shell']);
+export type InstallMethod = z.infer<typeof installMethodSchema>;
+
 const providesSchema = z
   .object({
     retrievalRoles: z.array(retrievalRoleDescriptorSchema).optional(),
@@ -51,7 +54,7 @@ const catalogEntryCommonShape = {
   description: z.string().min(1),
   statusDescription: z.string().min(1).optional(),
   version: z.string().min(1).optional(),
-  method: z.string().min(1).optional(),
+  method: installMethodSchema.optional(),
   provides: providesSchema.optional(),
   capabilityStatus: z.array(capabilityStatusSchema).optional(),
 } as const;
@@ -122,6 +125,7 @@ const installOnlyEntrySchema = z
     activation: z.literal('none'),
     status: z.enum(installOnlyCatalogStatusLiterals),
     command: z.string().min(1).optional(),
+    targetDir: z.string().min(1).optional(),
     confirmDownload: z.string().min(1).optional(),
   })
   .strict();
@@ -327,7 +331,7 @@ export interface ExpansionRequestPort {
 const installedResultSchema = z
   .object({
     status: z.literal('installed'),
-    method: z.string().min(1),
+    method: installMethodSchema,
     version: z.string().min(1).optional(),
     targetDir: z.string().min(1).optional(),
     postInstall: postInstallSchema.optional(),
@@ -339,7 +343,7 @@ const installedResultSchema = z
 const updatedResultSchema = z
   .object({
     status: z.literal('updated'),
-    method: z.string().min(1),
+    method: installMethodSchema,
     version: z.string().min(1).optional(),
     targetDir: z.string().min(1).optional(),
     postInstall: postInstallSchema.optional(),
@@ -351,7 +355,7 @@ const updatedResultSchema = z
 const alreadyInstalledResultSchema = z
   .object({
     status: z.literal('already_installed'),
-    method: z.string().min(1),
+    method: installMethodSchema,
     version: z.string().min(1).optional(),
     targetDir: z.string().min(1).optional(),
     postInstall: postInstallSchema.optional(),
@@ -363,7 +367,7 @@ const alreadyInstalledResultSchema = z
 const alreadyUpToDateResultSchema = z
   .object({
     status: z.literal('already_up_to_date'),
-    method: z.string().min(1),
+    method: installMethodSchema,
     version: z.string().min(1).optional(),
     targetDir: z.string().min(1).optional(),
     postInstall: postInstallSchema.optional(),

--- a/src/kb-daemon/expansion/kiwi-boot.ts
+++ b/src/kb-daemon/expansion/kiwi-boot.ts
@@ -172,7 +172,7 @@ async function ensureArtifactWithContentionRetry(params: {
     }
     if (!contentionLogged) {
       contentionLogged = true;
-      backendLog.raw(
+      backendLog.info(
         '[kiwi] another package operation holds the install lock; background recovery will keep retrying ' +
           'until it completes or the daemon shuts down.',
       );
@@ -230,7 +230,7 @@ export function startKiwiArtifactFetchOnBoot({
     const snapshot = kb.getCorpusStateSnapshot();
     await forceOramaReindexAfterKiwiFetch(kb, driver, snapshot, timeoutMs, signal);
     if (!signal.aborted) {
-      backendLog.raw('[kiwi] runtime artifacts are ready; Korean search reindex completed without a restart.');
+      backendLog.info('[kiwi] runtime artifacts are ready; Korean search reindex completed without a restart.');
     }
   })().catch((error: unknown) => {
     if (!signal.aborted) {

--- a/src/kb-daemon/expansion/kiwi-boot.ts
+++ b/src/kb-daemon/expansion/kiwi-boot.ts
@@ -1,10 +1,14 @@
 import { backendLog } from '../../infra/backend-log.js';
 import { errorMessage } from '../../infra/error-format.js';
-import { hasKiwiModelArtifact, ensureKiwiModelArtifact } from '../../engines/kiwi/model-artifact.js';
+import { ensureKiwiArtifact, hasKiwiArtifact } from '../../engines/kiwi/artifact.js';
 import { ORAMA_BASE_CONSUMER_ID } from '../../engines/orama/constants.js';
 import type { KbCorpusSnapshot, KbRuntime } from '../../kb/contract.js';
 import type { Runtime } from '../../runtime/ports.js';
 import type { GeneratedCommunityFreshness } from '../../kb/curate/community/generated-projection-store.js';
+
+const KIWI_BOOT_LOCK_PROBE_TIMEOUT_MS = 250;
+const KIWI_BOOT_LOCK_RETRY_INITIAL_DELAY_MS = 250;
+const KIWI_BOOT_LOCK_RETRY_MAX_DELAY_MS = 5_000;
 
 export type KiwiArtifactBootHandle = {
   readonly started: boolean;
@@ -43,10 +47,13 @@ export type StartKiwiArtifactFetchOnBootOptions = {
   readonly driver: KiwiArtifactBootDriver;
   readonly timeoutMs: number;
   readonly signal: AbortSignal;
-  readonly hasModelArtifact?: (runtime: Runtime) => boolean;
-  readonly ensureModelArtifact?: typeof ensureKiwiModelArtifact;
-  readonly onModelFetchStart?: () => void;
-  readonly onModelFetchEnd?: () => void;
+  readonly hasArtifact?: (runtime: Runtime) => boolean;
+  readonly ensureArtifact?: typeof ensureKiwiArtifact;
+  readonly onArtifactFetchStart?: () => void;
+  readonly onArtifactFetchEnd?: () => void;
+  readonly lockProbeTimeoutMs?: number;
+  readonly lockRetryDelayMs?: number;
+  readonly lockRetryMaxDelayMs?: number;
 };
 
 async function forceOramaReindexAfterKiwiFetch(
@@ -54,14 +61,24 @@ async function forceOramaReindexAfterKiwiFetch(
   driver: KiwiArtifactBootDriver,
   snapshot: KbCorpusSnapshot,
   timeoutMs: number,
+  signal: AbortSignal,
 ): Promise<void> {
-  kb.invalidateTextSnapshot('kiwi-model-installed');
+  if (signal.aborted) {
+    return;
+  }
+  kb.invalidateTextSnapshot('kiwi-artifact-installed');
+  if (signal.aborted) {
+    return;
+  }
   const generatedCommunityFreshness = kb.generatedCommunityProjectionStore.readActiveFreshness();
   const forced = driver.forceCorpusApply(snapshot, {
     reason: 'projection-artifact-lag',
     consumers: [ORAMA_BASE_CONSUMER_ID],
     generatedCommunityFreshness,
   });
+  if (signal.aborted) {
+    return;
+  }
   await Promise.all(
     forced.consumers.map((consumerId) =>
       driver.waitFreshUntil(
@@ -74,45 +91,154 @@ async function forceOramaReindexAfterKiwiFetch(
   );
 }
 
+type ArtifactEnsureAttempt =
+  | { readonly kind: 'ready' }
+  | { readonly kind: 'contended' }
+  | { readonly kind: 'incomplete'; readonly status: string }
+  | {
+      readonly kind: 'failed';
+      readonly userMessage: string;
+      readonly remediation: string;
+    };
+
+async function attemptArtifactEnsure(params: {
+  readonly runtime: Runtime;
+  readonly hasArtifact: (runtime: Runtime) => boolean;
+  readonly ensureArtifact: typeof ensureKiwiArtifact;
+  readonly lockProbeTimeoutMs: number;
+}): Promise<ArtifactEnsureAttempt> {
+  if (params.hasArtifact(params.runtime)) {
+    return { kind: 'ready' };
+  }
+  const result = await params.ensureArtifact(params.runtime, {
+    logger: (event) => backendLog.raw(`[kiwi] ${event.message}`),
+    lockTimeoutMs: params.lockProbeTimeoutMs,
+  });
+  if (result.status !== 'error') {
+    return params.hasArtifact(params.runtime) ? { kind: 'ready' } : { kind: 'incomplete', status: result.status };
+  }
+  if (result.code !== 'expansion_install_lock_contended') {
+    return {
+      kind: 'failed',
+      userMessage: result.userMessage,
+      remediation: result.remediation,
+    };
+  }
+  return params.hasArtifact(params.runtime) ? { kind: 'ready' } : { kind: 'contended' };
+}
+
+function resolveTerminalArtifactAttempt(attempt: ArtifactEnsureAttempt): boolean | null {
+  if (attempt.kind === 'ready') {
+    return true;
+  }
+  if (attempt.kind === 'incomplete') {
+    backendLog.warn(
+      `[kiwi] artifact install returned ${attempt.status}, but composite readiness is still incomplete. ` +
+        'Intl fallback remains active; run `coral-cli expansion equip kiwi` to repair the artifacts.',
+    );
+    return false;
+  }
+  if (attempt.kind === 'failed') {
+    backendLog.warn(
+      `[kiwi] artifact fetch failed: ${attempt.userMessage} ${attempt.remediation} ` + 'Intl fallback remains active.',
+    );
+    return false;
+  }
+  return null;
+}
+
+async function ensureArtifactWithContentionRetry(params: {
+  readonly runtime: Runtime;
+  readonly signal: AbortSignal;
+  readonly hasArtifact: (runtime: Runtime) => boolean;
+  readonly ensureArtifact: typeof ensureKiwiArtifact;
+  readonly lockProbeTimeoutMs: number;
+  readonly initialRetryDelayMs: number;
+  readonly maxRetryDelayMs: number;
+}): Promise<boolean> {
+  let retryDelayMs = Math.max(1, params.initialRetryDelayMs);
+  const maxRetryDelayMs = Math.max(retryDelayMs, params.maxRetryDelayMs);
+  let contentionLogged = false;
+  while (!params.signal.aborted) {
+    const attempt = await attemptArtifactEnsure({
+      runtime: params.runtime,
+      hasArtifact: params.hasArtifact,
+      ensureArtifact: params.ensureArtifact,
+      lockProbeTimeoutMs: params.lockProbeTimeoutMs,
+    });
+    const terminal = resolveTerminalArtifactAttempt(attempt);
+    if (terminal !== null) {
+      return terminal;
+    }
+    if (!contentionLogged) {
+      contentionLogged = true;
+      backendLog.raw(
+        '[kiwi] another package operation holds the install lock; background recovery will keep retrying ' +
+          'until it completes or the daemon shuts down.',
+      );
+    }
+    try {
+      await params.runtime.time.sleep(retryDelayMs, { signal: params.signal });
+    } catch (error: unknown) {
+      if (params.signal.aborted) {
+        return false;
+      }
+      throw error;
+    }
+    retryDelayMs = Math.min(maxRetryDelayMs, retryDelayMs * 2);
+  }
+  return false;
+}
+
 export function startKiwiArtifactFetchOnBoot({
   runtime,
   kb,
   driver,
   timeoutMs,
   signal,
-  hasModelArtifact = hasKiwiModelArtifact,
-  ensureModelArtifact = ensureKiwiModelArtifact,
-  onModelFetchStart,
-  onModelFetchEnd,
+  hasArtifact = hasKiwiArtifact,
+  ensureArtifact = ensureKiwiArtifact,
+  onArtifactFetchStart,
+  onArtifactFetchEnd,
+  lockProbeTimeoutMs = KIWI_BOOT_LOCK_PROBE_TIMEOUT_MS,
+  lockRetryDelayMs = KIWI_BOOT_LOCK_RETRY_INITIAL_DELAY_MS,
+  lockRetryMaxDelayMs = KIWI_BOOT_LOCK_RETRY_MAX_DELAY_MS,
 }: StartKiwiArtifactFetchOnBootOptions): KiwiArtifactBootHandle {
-  if (!kb.declaredAnalyzers?.includes('ko')) {
+  if (!kb.declaredAnalyzers?.includes('ko') || signal.aborted || hasArtifact(runtime)) {
     return { started: false, completed: null };
   }
 
   const completed = (async () => {
-    if (hasModelArtifact(runtime)) {
+    onArtifactFetchStart?.();
+    let ready: boolean;
+    try {
+      ready = await ensureArtifactWithContentionRetry({
+        runtime,
+        signal,
+        hasArtifact,
+        ensureArtifact,
+        lockProbeTimeoutMs: Math.max(1, lockProbeTimeoutMs),
+        initialRetryDelayMs: lockRetryDelayMs,
+        maxRetryDelayMs: lockRetryMaxDelayMs,
+      });
+    } finally {
+      onArtifactFetchEnd?.();
+    }
+    if (!ready || signal.aborted) {
       return;
     }
     const snapshot = kb.getCorpusStateSnapshot();
-    onModelFetchStart?.();
-    let result: Awaited<ReturnType<typeof ensureKiwiModelArtifact>>;
-    try {
-      result = await ensureModelArtifact(runtime, {
-        logger: (event) => backendLog.raw(`[kiwi] ${event.message}`),
-      });
-    } finally {
-      onModelFetchEnd?.();
+    await forceOramaReindexAfterKiwiFetch(kb, driver, snapshot, timeoutMs, signal);
+    if (!signal.aborted) {
+      backendLog.raw('[kiwi] runtime artifacts are ready; Korean search reindex completed without a restart.');
     }
-    if (result.status === 'error') {
-      backendLog.warn(`[kiwi] model fetch failed: ${result.userMessage}`);
-      return;
-    }
-    if (signal.aborted) {
-      return;
-    }
-    await forceOramaReindexAfterKiwiFetch(kb, driver, snapshot, timeoutMs);
   })().catch((error: unknown) => {
-    backendLog.warn(`[kiwi] background model fetch failed: ${errorMessage(error)}`);
+    if (!signal.aborted) {
+      backendLog.warn(
+        `[kiwi] background artifact recovery failed: ${errorMessage(error)}. Intl fallback remains active. ` +
+          'Run `coral-cli expansion equip kiwi` to retry.',
+      );
+    }
   });
 
   return { started: true, completed };

--- a/src/kb-daemon/runtime-host.ts
+++ b/src/kb-daemon/runtime-host.ts
@@ -140,8 +140,7 @@ type KbDaemonSearchRuntimeReadiness =
         | 'fts_binding_unavailable'
         | 'kiwi_analyzer_unloaded'
         | 'kiwi_analyzer_loading'
-        | 'kiwi_analyzer_evicting'
-        | 'kiwi_analyzer_degraded';
+        | 'kiwi_analyzer_evicting';
       message: string;
       detail?: Record<string, unknown>;
     };

--- a/src/kb-daemon/runtime-host.ts
+++ b/src/kb-daemon/runtime-host.ts
@@ -250,6 +250,50 @@ async function drainCorpusMutationLock(
   });
 }
 
+type KiwiArtifactBootTaskOwner = {
+  start(): AbortController;
+  track(controller: AbortController, completed: Promise<void> | null): void;
+  abort(controller: AbortController): void;
+  abortCurrent(): void;
+};
+
+function createKiwiArtifactBootTaskOwner(): KiwiArtifactBootTaskOwner {
+  let current: AbortController | null = null;
+  const clear = (controller: AbortController): void => {
+    if (current === controller) {
+      current = null;
+    }
+  };
+  const abort = (controller: AbortController): void => {
+    controller.abort();
+    clear(controller);
+  };
+  return {
+    start() {
+      current?.abort();
+      const controller = new AbortController();
+      current = controller;
+      return controller;
+    },
+    track(controller, completed) {
+      if (completed === null) {
+        clear(controller);
+        return;
+      }
+      void completed.then(
+        () => clear(controller),
+        () => clear(controller),
+      );
+    },
+    abort,
+    abortCurrent() {
+      if (current !== null) {
+        abort(current);
+      }
+    },
+  };
+}
+
 export function createKbDaemonWriteRuntimeHost(options: KbDaemonWriteRuntimeOptions): KbDaemonWriteRuntimeHost {
   const now = options.now ?? Date.now;
   let phase: KbDaemonKbReadHealth['phase'] = 'not_initialized';
@@ -262,8 +306,8 @@ export function createKbDaemonWriteRuntimeHost(options: KbDaemonWriteRuntimeOpti
   let lastSearchWarmupError: string | undefined;
   const kiwiAnalyzerManager = options.kiwiAnalyzer ?? resolveKiwiSearchAnalyzerPort();
   // Cancels the post-fetch Korean (Kiwi) re-tokenization reproject when the daemon
-  // disposes; the in-flight model download takes no signal and runs to completion detached.
-  let kiwiArtifactBootController: AbortController | null = null;
+  // disposes; an in-flight artifact download runs to completion detached.
+  const kiwiArtifactBootTasks = createKiwiArtifactBootTaskOwner();
 
   const markReady = (): void => {
     phase = 'ready';
@@ -296,6 +340,7 @@ export function createKbDaemonWriteRuntimeHost(options: KbDaemonWriteRuntimeOpti
   const disposedError = (): KbToolResult => kbError('kb_unavailable', `KB daemon write runtime is ${phase}.`);
 
   const build = async (): Promise<KbDaemonWriteRuntimeState> => {
+    const buildKiwiArtifactBootController = kiwiArtifactBootTasks.start();
     const runtime = options.runtime ?? createRealRuntime(readBuildFlavor(options.pluginRoot));
     const ownsDb = options.db === undefined;
     let db: WritableDatabase | null = null;
@@ -447,18 +492,18 @@ export function createKbDaemonWriteRuntimeHost(options: KbDaemonWriteRuntimeOpti
       await activeExpansionLifecycleService.recoverOnBoot();
       activeConsumerDriver.notifyCorpus(kb.getCorpusStateSnapshot());
       await repairProjectionArtifactLagOnBoot(kb, activeConsumerDriver, corpusReadinessTimeoutMs);
-      // When CORAL_KB_EXTRA_LANGS declares 'ko', fetch the Kiwi model in the background and
+      // When CORAL_KB_EXTRA_LANGS declares 'ko', fetch the Kiwi runtime artifacts in the background and
       // reproject once it lands. Boot does not await this: the text lane serves Intl-segmented
       // results until the Korean analyzer is ready, so the first note mutation is never blocked
-      // on an 88MB model download or a corpus-scale Korean re-tokenization.
-      kiwiArtifactBootController = new AbortController();
-      startKiwiArtifactFetchOnBoot({
+      // on the ~89MB artifact downloads or a corpus-scale Korean re-tokenization.
+      const kiwiArtifactBootHandle = startKiwiArtifactFetchOnBoot({
         runtime,
         kb,
         driver: activeConsumerDriver,
         timeoutMs: corpusReadinessTimeoutMs,
-        signal: kiwiArtifactBootController.signal,
+        signal: buildKiwiArtifactBootController.signal,
       });
+      kiwiArtifactBootTasks.track(buildKiwiArtifactBootController, kiwiArtifactBootHandle.completed);
       const kbRuntime: DaemonKnowledgeBaseRuntime = {
         kb,
         readDb: activeDb,
@@ -531,6 +576,7 @@ export function createKbDaemonWriteRuntimeHost(options: KbDaemonWriteRuntimeOpti
       markReady();
       return state;
     } catch (error: unknown) {
+      kiwiArtifactBootTasks.abort(buildKiwiArtifactBootController);
       daemonConsumerDriver = null;
       await expansionLifecycleService?.shutdownActiveExpansions().catch(() => undefined);
       await consumerDriver?.shutdown({ drainTimeoutMs: 0 }).catch(() => undefined);
@@ -706,7 +752,7 @@ export function createKbDaemonWriteRuntimeHost(options: KbDaemonWriteRuntimeOpti
     }
     disposePromise = (async () => {
       markDisposing();
-      kiwiArtifactBootController?.abort();
+      kiwiArtifactBootTasks.abortCurrent();
       try {
         let activeState = state;
         if (activeState === null && initPromise !== null) {
@@ -717,6 +763,7 @@ export function createKbDaemonWriteRuntimeHost(options: KbDaemonWriteRuntimeOpti
             return;
           }
         }
+        kiwiArtifactBootTasks.abortCurrent();
         if (activeState !== null) {
           await disposeState(activeState, options.signal);
         }

--- a/src/runtime/errors.ts
+++ b/src/runtime/errors.ts
@@ -21,6 +21,7 @@ export type SerializedCoralSetupError = CoralSetupErrorInit;
 export type DocumentedCoralSetupErrorCode =
   | 'expansion_install_lock_contended'
   | 'expansion_install_command_failed'
+  | 'expansion_install_artifact_failed'
   | 'startup_not_ready'
   | 'store_schema_outdated'
   | 'store_reset_lock_contended'
@@ -95,6 +96,17 @@ const DOCUMENTED_CORAL_SETUP_ERRORS = {
     remediation: (context) => {
       const detail = stringContextValue(context, 'detail', '');
       const base = 'Check network access and the prerequisites named by the install script, then retry.';
+      return detail.length > 0 ? `${detail}\n${base}` : base;
+    },
+  },
+  expansion_install_artifact_failed: {
+    userMessage: (context) =>
+      `Coral could not install the runtime artifacts for ${stringContextValue(context, 'name', 'this expansion')}.`,
+    remediation: (context) => {
+      const detail = stringContextValue(context, 'detail', '');
+      const base =
+        `Check network access, filesystem permissions, and free space, then retry ` +
+        `'coral-cli expansion equip ${stringContextValue(context, 'name', '<name>')}'.`;
       return detail.length > 0 ? `${detail}\n${base}` : base;
     },
   },

--- a/tests/helpers/kiwi-artifact-state.ts
+++ b/tests/helpers/kiwi-artifact-state.ts
@@ -1,0 +1,99 @@
+import type { KiwiArtifactComponent, KiwiArtifactState } from '#src/engines/kiwi/artifact.js';
+import {
+  KIWI_INSTALL_ONLY_ID,
+  KIWI_MODEL_ARCHIVE_SIZE_BYTES,
+  KIWI_MODEL_FILES,
+  KIWI_MODEL_SHA256,
+  KIWI_MODEL_TYPE,
+  KIWI_MODEL_URL,
+  KIWI_MODEL_VERSION,
+  KIWI_NLP_PACKAGE_INTEGRITY,
+  KIWI_NLP_PACKAGE_SHA256,
+  KIWI_NLP_PACKAGE_SIZE_BYTES,
+  KIWI_NLP_PACKAGE_URL,
+  KIWI_NLP_VERSION,
+  KIWI_WASM_FILE_NAME,
+  KIWI_WASM_SHA256,
+  KIWI_WASM_SIZE_BYTES,
+  KIWI_WASM_TAR_ENTRY,
+} from '#src/engines/kiwi/constants.js';
+
+const INSTALLED_AT = '2026-06-19T00:00:00.000Z';
+
+export function installedKiwiArtifactState(installedAt = INSTALLED_AT): KiwiArtifactState {
+  return {
+    ready: true,
+    missingComponents: [],
+    model: {
+      targetDir: '/tmp/kiwi/model',
+      manifestPath: '/tmp/kiwi/model/manifest.json',
+      installed: true,
+      missingFiles: [],
+      manifest: {
+        packageId: KIWI_INSTALL_ONLY_ID,
+        kiwiNlpVersion: KIWI_NLP_VERSION,
+        modelVersion: KIWI_MODEL_VERSION,
+        modelType: KIWI_MODEL_TYPE,
+        sourceUrl: KIWI_MODEL_URL,
+        archiveSha256: KIWI_MODEL_SHA256,
+        archiveSizeBytes: KIWI_MODEL_ARCHIVE_SIZE_BYTES,
+        files: KIWI_MODEL_FILES,
+        installedAt,
+      },
+    },
+    wasm: {
+      targetDir: '/tmp/kiwi/wasm',
+      manifestPath: '/tmp/kiwi/wasm/manifest.json',
+      wasmPath: `/tmp/kiwi/wasm/${KIWI_WASM_FILE_NAME}`,
+      installed: true,
+      manifest: {
+        schemaVersion: 1,
+        artifact: 'kiwi-wasm',
+        packageId: KIWI_INSTALL_ONLY_ID,
+        kiwiNlpVersion: KIWI_NLP_VERSION,
+        sourceUrl: KIWI_NLP_PACKAGE_URL,
+        archiveIntegrity: KIWI_NLP_PACKAGE_INTEGRITY,
+        archiveSha256: KIWI_NLP_PACKAGE_SHA256,
+        archiveSizeBytes: KIWI_NLP_PACKAGE_SIZE_BYTES,
+        archiveEntry: KIWI_WASM_TAR_ENTRY,
+        wasmSha256: KIWI_WASM_SHA256,
+        wasmSizeBytes: KIWI_WASM_SIZE_BYTES,
+        file: KIWI_WASM_FILE_NAME,
+        installedAt,
+      },
+      payloadValid: true,
+      payloadSha256: KIWI_WASM_SHA256,
+      reason: null,
+    },
+  };
+}
+
+export function missingKiwiArtifactState(missingComponent: KiwiArtifactComponent = 'model'): KiwiArtifactState {
+  const installed = installedKiwiArtifactState();
+  if (missingComponent === 'wasm') {
+    return {
+      ...installed,
+      ready: false,
+      missingComponents: ['wasm'],
+      wasm: {
+        ...installed.wasm,
+        installed: false,
+        manifest: null,
+        payloadValid: false,
+        payloadSha256: null,
+        reason: 'file_missing',
+      },
+    };
+  }
+  return {
+    ...installed,
+    ready: false,
+    missingComponents: ['model'],
+    model: {
+      ...installed.model,
+      installed: false,
+      manifest: null,
+      missingFiles: ['cong.mdl'],
+    },
+  };
+}

--- a/tests/integration/engines/kiwi-runtime-download.integration.test.ts
+++ b/tests/integration/engines/kiwi-runtime-download.integration.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { KIWI_NLP_PACKAGE_URL, KIWI_NLP_VERSION, KIWI_WASM_SHA256 } from '#src/engines/kiwi/constants.js';
+import { ensureKiwiWasmArtifactLocked } from '#src/engines/kiwi/wasm-artifact.js';
+import { createRealRuntime } from '#src/runtime/real.js';
+
+const networkTest = process.env.CORAL_TEST_NETWORK === '1' ? it : it.skip;
+
+describe('Kiwi pinned runtime download', () => {
+  networkTest('downloads, verifies, extracts, and publishes the pinned npm WASM artifact', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'coral-kiwi-network-'));
+    const runtime = createRealRuntime('prod', { baseDir: root });
+    try {
+      const installed = await ensureKiwiWasmArtifactLocked(runtime);
+
+      expect(installed).toMatchObject({
+        installed: true,
+        payloadValid: true,
+        payloadSha256: KIWI_WASM_SHA256,
+        manifest: {
+          kiwiNlpVersion: KIWI_NLP_VERSION,
+          sourceUrl: KIWI_NLP_PACKAGE_URL,
+          wasmSha256: KIWI_WASM_SHA256,
+        },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/cli/bootstrap.test.ts
+++ b/tests/unit/cli/bootstrap.test.ts
@@ -1,51 +1,39 @@
 import { CommanderError } from 'commander';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// `bootstrap.ts` runs `runBootstrap()` at module load, so each case must re-import it after
-// `vi.resetModules()` to get a fresh execution. Whichever case imports first therefore absorbs a cold
-// transform+resolve of the CLI module graph (~1s idle). `vitest/default.ts` oversubscribes workers on CI
-// (4 workers on a 2-core runner) by design, so that second inflates under contention and the 5s default
-// timeout leaves too little headroom. Budget for the import; a genuine hang still trips this.
-describe('cli bootstrap', { timeout: 30_000 }, () => {
+const parseAsync = vi.hoisted(() => vi.fn());
+const emitError = vi.hoisted(() => vi.fn());
+
+vi.mock('#src/cli/program.js', () => ({
+  buildProgram: () => ({ parseAsync }),
+}));
+vi.mock('#src/cli/emit.js', () => ({ emitError }));
+
+// Static import: `runCli` is invoked per case, so no case needs `vi.resetModules()` plus a re-import to get a
+// fresh run. That keeps the command graph's cold transform in this file's collection phase instead of
+// charging it to whichever case imports first, which is what made these cases flake against the 5s default.
+import { runCli } from '#src/cli/run.js';
+
+describe('cli bootstrap', () => {
   const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => undefined) as typeof process.exit);
+  });
 
   afterEach(() => {
     process.argv = [...originalArgv];
     vi.restoreAllMocks();
-    vi.resetModules();
+    parseAsync.mockReset();
+    emitError.mockReset();
     process.exitCode = undefined;
   });
 
-  async function importBootstrapWith(options: { parseError?: unknown }): Promise<{
-    emitError: ReturnType<typeof vi.fn>;
-    parseAsync: ReturnType<typeof vi.fn>;
-  }> {
-    const emitError = vi.fn();
-    const parseAsync =
-      options.parseError === undefined
-        ? vi.fn().mockResolvedValue(undefined)
-        : vi.fn().mockRejectedValue(options.parseError);
-    const program = { parseAsync };
-
-    vi.doMock('#src/cli/program.js', () => ({
-      buildProgram: () => program,
-    }));
-    vi.doMock('#src/cli/emit.js', () => ({ emitError }));
-
-    vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => undefined) as typeof process.exit);
-
-    const { bootstrapCompletion } = await import('#src/cli/bootstrap.js');
-    await bootstrapCompletion;
-
-    return { emitError, parseAsync };
-  }
-
   it('exits 0 for --help CommanderError without emitting an envelope', async () => {
     process.argv = ['node', 'coral-cli', '--help'];
+    parseAsync.mockRejectedValue(new CommanderError(0, 'commander.helpDisplayed', '(outputHelp)'));
 
-    const { emitError, parseAsync } = await importBootstrapWith({
-      parseError: new CommanderError(0, 'commander.helpDisplayed', '(outputHelp)'),
-    });
+    await runCli();
 
     expect(parseAsync).toHaveBeenCalledWith(process.argv);
     expect(process.exit).not.toHaveBeenCalled();
@@ -55,10 +43,9 @@ describe('cli bootstrap', { timeout: 30_000 }, () => {
 
   it('exits 0 for --version CommanderError without emitting an envelope', async () => {
     process.argv = ['node', 'coral-cli', '--version'];
+    parseAsync.mockRejectedValue(new CommanderError(0, 'commander.version', '1.2.3'));
 
-    const { emitError, parseAsync } = await importBootstrapWith({
-      parseError: new CommanderError(0, 'commander.version', '1.2.3'),
-    });
+    await runCli();
 
     expect(parseAsync).toHaveBeenCalledWith(process.argv);
     expect(process.exit).not.toHaveBeenCalled();
@@ -68,25 +55,15 @@ describe('cli bootstrap', { timeout: 30_000 }, () => {
 
   it('routes non-zero CommanderError through emitError and preserves exit 2', async () => {
     process.argv = ['node', 'coral-cli', 'wait'];
-
-    const emitError = vi.fn((_error: unknown) => {
+    parseAsync.mockRejectedValue(
+      new CommanderError(2, 'commander.missingArgument', "error: missing required argument 'jobIds'"),
+    );
+    emitError.mockImplementation((_error: unknown) => {
       // Simulate real emitError setting exit code for CommanderError → 2.
       process.exitCode = 2;
     });
-    const parseAsync = vi
-      .fn()
-      .mockRejectedValue(
-        new CommanderError(2, 'commander.missingArgument', "error: missing required argument 'jobIds'"),
-      );
-    const program = { parseAsync };
-    vi.doMock('#src/cli/program.js', () => ({
-      buildProgram: () => program,
-    }));
-    vi.doMock('#src/cli/emit.js', () => ({ emitError }));
-    vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => undefined) as typeof process.exit);
 
-    const { bootstrapCompletion } = await import('#src/cli/bootstrap.js');
-    await bootstrapCompletion;
+    await runCli();
 
     expect(parseAsync).toHaveBeenCalledWith(process.argv);
     expect(emitError).toHaveBeenCalledTimes(1);

--- a/tests/unit/cli/bootstrap.test.ts
+++ b/tests/unit/cli/bootstrap.test.ts
@@ -1,7 +1,12 @@
 import { CommanderError } from 'commander';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-describe('cli bootstrap', () => {
+// `bootstrap.ts` runs `runBootstrap()` at module load, so each case must re-import it after
+// `vi.resetModules()` to get a fresh execution. Whichever case imports first therefore absorbs a cold
+// transform+resolve of the CLI module graph (~1s idle). `vitest/default.ts` oversubscribes workers on CI
+// (4 workers on a 2-core runner) by design, so that second inflates under contention and the 5s default
+// timeout leaves too little headroom. Budget for the import; a genuine hang still trips this.
+describe('cli bootstrap', { timeout: 30_000 }, () => {
   const originalArgv = [...process.argv];
 
   afterEach(() => {

--- a/tests/unit/cli/coral-store-read-parity.test.ts
+++ b/tests/unit/cli/coral-store-read-parity.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import type { Command } from 'commander';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as MainMod from '#src/cli/program.js';
 
 import { pluginRootNamespace } from '#src/infra/plugin-identity.js';
@@ -134,6 +134,13 @@ async function runCli(program: Command, args: string[]): Promise<{ stdout: strin
 }
 
 describe('cli coral-store read parity', () => {
+  // `loadMainModule()` resets the module registry per case because these cases swap module doubles, but a
+  // registry reset does not clear vitest's transform cache. Warm it once here so the first case does not
+  // absorb ~1.4s of cold command-graph transform inside its 5s budget, which flaked under CI contention.
+  beforeAll(async () => {
+    await import('#src/cli/program.js');
+  });
+
   let tempHome: string;
   let projectRoot: string;
   let originalHome: string | undefined;

--- a/tests/unit/cli/expansion-help.test.ts
+++ b/tests/unit/cli/expansion-help.test.ts
@@ -1,27 +1,26 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { runCli } from '#src/cli/run.js';
 import { installErrorSchema } from '#src/expansion/rpc-contract.js';
 
 function toText(chunk: string | Uint8Array): string {
   return typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
 }
 
-// Each case re-imports `bootstrap.ts` after `vi.resetModules()` (it runs on load) and deliberately uses the
-// real `buildProgram()`, so the first case absorbs a cold transform+resolve of the whole CLI command graph
-// (~1.2s idle). `vitest/default.ts` oversubscribes workers on CI (4 workers on a 2-core runner) by design, so
-// that inflates under contention past the 5s default. Budget for the import; a genuine hang still trips this.
-describe('expansion bootstrap output', { timeout: 30_000 }, () => {
+// Static import of `runCli`, invoked per case. Re-importing a self-executing entry through
+// `vi.resetModules()` used to charge this file's cold transform of the real command graph to whichever case
+// ran first, which flaked against the 5s default; collection absorbs it now.
+describe('expansion bootstrap output', () => {
   const originalArgv = [...process.argv];
   let stdout = '';
   let stderr = '';
 
-  async function runBootstrap(argv: string[]): Promise<void> {
+  async function run(argv: string[]): Promise<void> {
     stdout = '';
     stderr = '';
     process.argv = ['node', 'coral-cli', ...argv];
     process.exitCode = undefined;
 
-    vi.resetModules();
     vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => undefined) as typeof process.exit);
     vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
       stdout += toText(chunk);
@@ -32,19 +31,17 @@ describe('expansion bootstrap output', { timeout: 30_000 }, () => {
       return true;
     }) as typeof process.stderr.write);
 
-    const { bootstrapCompletion } = await import('#src/cli/bootstrap.js');
-    await bootstrapCompletion;
+    await runCli();
   }
 
   afterEach(() => {
     process.argv = [...originalArgv];
     process.exitCode = undefined;
     vi.restoreAllMocks();
-    vi.resetModules();
   });
 
   it('keeps expansion --help visible on stdout with exit 0', async () => {
-    await runBootstrap(['expansion', '--help']);
+    await run(['expansion', '--help']);
 
     expect(stderr).toBe('');
     expect(stdout.trim().length).toBeGreaterThan(0);
@@ -55,7 +52,7 @@ describe('expansion bootstrap output', { timeout: 30_000 }, () => {
   });
 
   it('normalizes expansion equip missing-argument failures to one stdout InstallError JSON line', async () => {
-    await runBootstrap(['expansion', 'equip']);
+    await run(['expansion', 'equip']);
 
     expect(stderr).toBe('');
     expect(stdout.endsWith('\n')).toBe(true);

--- a/tests/unit/cli/expansion-help.test.ts
+++ b/tests/unit/cli/expansion-help.test.ts
@@ -6,7 +6,11 @@ function toText(chunk: string | Uint8Array): string {
   return typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
 }
 
-describe('expansion bootstrap output', () => {
+// Each case re-imports `bootstrap.ts` after `vi.resetModules()` (it runs on load) and deliberately uses the
+// real `buildProgram()`, so the first case absorbs a cold transform+resolve of the whole CLI command graph
+// (~1.2s idle). `vitest/default.ts` oversubscribes workers on CI (4 workers on a 2-core runner) by design, so
+// that inflates under contention past the 5s default. Budget for the import; a genuine hang still trips this.
+describe('expansion bootstrap output', { timeout: 30_000 }, () => {
   const originalArgv = [...process.argv];
   let stdout = '';
   let stderr = '';

--- a/tests/unit/cli/kb-diagnose.test.ts
+++ b/tests/unit/cli/kb-diagnose.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import type { Command } from 'commander';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as MainMod from '#src/cli/program.js';
 
 import { createRealRuntime } from '#src/runtime/real.js';
@@ -106,6 +106,13 @@ async function runCli(program: Command, args: string[]): Promise<{ stdout: strin
 }
 
 describe('kb diagnose integration', () => {
+  // `loadMainModule()` resets the module registry per case because these cases swap module doubles, but a
+  // registry reset does not clear vitest's transform cache. Warm it once here so the first case does not
+  // absorb ~1.4s of cold command-graph transform inside its 5s budget, which flaked under CI contention.
+  beforeAll(async () => {
+    await import('#src/cli/program.js');
+  });
+
   let tempHome: string;
   let projectRoot: string;
   let originalHome: string | undefined;

--- a/tests/unit/cli/main-routing.test.ts
+++ b/tests/unit/cli/main-routing.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { Command } from 'commander';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as CommandClientMod from '#src/cli/dispatch.js';
 import type * as CommandOutputMod from '#src/cli/emit.js';
 import type * as ErrorsMod from '#src/cli/errors.js';
@@ -338,6 +338,13 @@ function createCauseRenderFixture(): { home: string; cleanup(): void } {
 }
 
 describe('cli main routing', () => {
+  // `loadMainModule()` resets the module registry per case because these cases swap module doubles, but a
+  // registry reset does not clear vitest's transform cache. Warm it once here so the first case does not
+  // absorb ~1.4s of cold command-graph transform inside its 5s budget, which flaked under CI contention.
+  beforeAll(async () => {
+    await import('#src/cli/program.js');
+  });
+
   let stdout = '';
   let stderr = '';
   let originalArgv: string[];

--- a/tests/unit/cli/main-routing.test.ts
+++ b/tests/unit/cli/main-routing.test.ts
@@ -8,7 +8,7 @@ import type * as CommandClientMod from '#src/cli/dispatch.js';
 import type * as CommandOutputMod from '#src/cli/emit.js';
 import type * as ErrorsMod from '#src/cli/errors.js';
 import type * as MainMod from '#src/cli/program.js';
-import { installErrorSchema, installResultSchema } from '#src/expansion/rpc-contract.js';
+import { installErrorSchema, installResultSchema, type InstallMethod } from '#src/expansion/rpc-contract.js';
 import { serializeWaitCursor } from '#src/jobs/wait.js';
 import type { JobDetailResponse, JobStatus } from '#src/jobs/records.js';
 import { formatErrorEnvelope } from '#src/cli/format/error.js';
@@ -25,6 +25,8 @@ import { formatWaitProgress, formatWaitTerminal, formatWaitWaiting } from '#src/
 import { createRealRuntime } from '#src/runtime/real.js';
 import { openStoreDatabase } from '#src/store/db.js';
 import { storePaths } from '#src/infra/path/store.js';
+
+const genericInstallMethod = 'shell' satisfies InstallMethod;
 
 const mockState = vi.hoisted(() => ({
   createSession: vi.fn(),
@@ -463,7 +465,7 @@ describe('cli main routing', () => {
       setup: () => {
         mockState.expansionEquip.mockResolvedValueOnce({
           status: 'installed',
-          method: 'prebuild',
+          method: genericInstallMethod,
           version: '1.0.0',
           targetDir: '/tmp/vector',
         });
@@ -502,7 +504,7 @@ describe('cli main routing', () => {
       setup: () => {
         mockState.expansionUpdate.mockResolvedValueOnce({
           status: 'updated',
-          method: 'prebuild',
+          method: genericInstallMethod,
           version: '1.0.1',
           targetDir: '/tmp/vector',
         });

--- a/tests/unit/coordinator/kiwi-artifact-boot.test.ts
+++ b/tests/unit/coordinator/kiwi-artifact-boot.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { startKiwiArtifactFetchOnBoot } from '#src/kb-daemon/expansion/kiwi-boot.js';
 import type { ForcedCorpusFreshnessTarget } from '#src/projection-consumers/index.js';
 import { ORAMA_BASE_CONSUMER_ID } from '#src/engines/orama/constants.js';
+import { backendLog } from '#src/infra/backend-log.js';
 import type { KbCorpusSnapshot } from '#src/kb/contract.js';
 import type { Runtime } from '#src/runtime/ports.js';
 import { createEmptyGeneratedCommunityProjectionStore } from '#tests/fixtures/test-runtime.js';
@@ -17,9 +18,23 @@ function createSnapshot(): KbCorpusSnapshot {
   };
 }
 
+function createRuntime(options: { now?: () => number; sleep?: Runtime['time']['sleep'] } = {}): Runtime {
+  return {
+    time: {
+      now: options.now ?? (() => 0),
+      sleep: options.sleep ?? (async () => {}),
+    },
+  } as Runtime;
+}
+
 describe('startKiwiArtifactFetchOnBoot', () => {
-  it('starts model fetch without blocking boot and forces Orama reindex after fetch', async () => {
-    const snapshot = createSnapshot();
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts artifact fetch without blocking boot and reindexes the latest snapshot after fetch', async () => {
+    let snapshot = createSnapshot();
+    let ready = false;
     let resolveFetch!: () => void;
     const fetchGate = new Promise<void>((resolve) => {
       resolveFetch = resolve;
@@ -27,7 +42,7 @@ describe('startKiwiArtifactFetchOnBoot', () => {
     const events: string[] = [];
 
     const handle = startKiwiArtifactFetchOnBoot({
-      runtime: {} as Runtime,
+      runtime: createRuntime(),
       kb: {
         declaredAnalyzers: ['ko'],
         generatedCommunityProjectionStore: createEmptyGeneratedCommunityProjectionStore(),
@@ -49,20 +64,22 @@ describe('startKiwiArtifactFetchOnBoot', () => {
       },
       timeoutMs: 25,
       signal: new AbortController().signal,
-      onModelFetchStart: () => {
+      onArtifactFetchStart: () => {
         events.push('health:fetching');
       },
-      onModelFetchEnd: () => {
+      onArtifactFetchEnd: () => {
         events.push('health:idle');
       },
-      hasModelArtifact: () => false,
-      ensureModelArtifact: async () => {
+      hasArtifact: () => ready,
+      ensureArtifact: async () => {
         events.push('fetch:start');
         await fetchGate;
         events.push('fetch:done');
+        snapshot = { ...snapshot, snapshotId: 'snapshot-2', contentSeq: 3 };
+        ready = true;
         return {
           status: 'installed',
-          method: 'github-release',
+          method: 'runtime-download',
           version: '0.23.0',
           targetDir: '/tmp/kiwi',
         };
@@ -80,8 +97,8 @@ describe('startKiwiArtifactFetchOnBoot', () => {
       'fetch:start',
       'fetch:done',
       'health:idle',
-      'invalidate:kiwi-model-installed',
-      `force:snapshot-1:${ORAMA_BASE_CONSUMER_ID}`,
+      'invalidate:kiwi-artifact-installed',
+      `force:snapshot-2:${ORAMA_BASE_CONSUMER_ID}`,
       `wait:${ORAMA_BASE_CONSUMER_ID}:7`,
     ]);
   });
@@ -101,12 +118,235 @@ describe('startKiwiArtifactFetchOnBoot', () => {
       },
       timeoutMs: 25,
       signal: new AbortController().signal,
-      hasModelArtifact: () => false,
-      ensureModelArtifact: async () => {
+      hasArtifact: () => false,
+      ensureArtifact: async () => {
         throw new Error('should not fetch');
       },
     });
 
     expect(handle).toEqual({ started: false, completed: null });
+  });
+
+  it('waits through lock contention and reindexes when another actor completes the artifact', async () => {
+    let now = 0;
+    let ready = false;
+    const events: string[] = [];
+    const ensureArtifact = vi.fn(async () => ({
+      status: 'error' as const,
+      code: 'expansion_install_lock_contended',
+      userMessage: 'busy',
+      remediation: 'wait',
+    }));
+    const runtime = createRuntime({
+      now: () => now,
+      sleep: async (ms) => {
+        events.push(`sleep:${ms}`);
+        now += ms;
+        ready = true;
+      },
+    });
+
+    const handle = startKiwiArtifactFetchOnBoot({
+      runtime,
+      kb: {
+        declaredAnalyzers: ['ko'],
+        generatedCommunityProjectionStore: createEmptyGeneratedCommunityProjectionStore(),
+        getCorpusStateSnapshot: createSnapshot,
+        invalidateTextSnapshot: (reason) => {
+          events.push(`invalidate:${reason}`);
+          return { contentSeq: 1, metadataSeq: 2, textStaleReason: reason };
+        },
+      },
+      driver: {
+        forceCorpusApply: (_snapshot, options) => {
+          events.push('force');
+          return { generation: 1, consumers: options.consumers };
+        },
+        waitFreshUntil: async () => {},
+      },
+      timeoutMs: 25,
+      signal: new AbortController().signal,
+      hasArtifact: () => ready,
+      ensureArtifact,
+      lockProbeTimeoutMs: 3,
+      lockRetryDelayMs: 10,
+    });
+
+    await handle.completed;
+
+    expect(ensureArtifact).toHaveBeenCalledTimes(1);
+    expect(ensureArtifact).toHaveBeenCalledWith(runtime, expect.objectContaining({ lockTimeoutMs: 3 }));
+    expect(events).toEqual(['sleep:10', 'invalidate:kiwi-artifact-installed', 'force']);
+  });
+
+  it('retries after contention beyond the former 30-second horizon and installs after the lock is released', async () => {
+    let ready = false;
+    let attempts = 0;
+    const sleepDelays: number[] = [];
+    const rawLog = vi.spyOn(backendLog, 'raw').mockImplementation(() => {});
+    const runtime = createRuntime({
+      now: () => (attempts === 0 ? 0 : 31_000),
+      sleep: async (ms) => {
+        sleepDelays.push(ms);
+      },
+    });
+    const invalidateTextSnapshot = vi.fn(() => ({ contentSeq: 1, metadataSeq: 2 }));
+    const forceCorpusApply = vi.fn((_snapshot, options) => ({
+      generation: 1,
+      consumers: options.consumers,
+    }));
+    const observedLockTimeouts: Array<number | undefined> = [];
+    const ensureArtifact = vi.fn(async (_runtime: Runtime, options?: { readonly lockTimeoutMs?: number }) => {
+      observedLockTimeouts.push(options?.lockTimeoutMs);
+      attempts += 1;
+      if (attempts < 5) {
+        return {
+          status: 'error' as const,
+          code: 'expansion_install_lock_contended',
+          userMessage: 'busy',
+          remediation: 'wait',
+        };
+      }
+      ready = true;
+      return {
+        status: 'installed' as const,
+        method: 'runtime-download' as const,
+        version: '0.23.0',
+        targetDir: '/tmp/kiwi',
+      };
+    });
+
+    const handle = startKiwiArtifactFetchOnBoot({
+      runtime,
+      kb: {
+        declaredAnalyzers: ['ko'],
+        generatedCommunityProjectionStore: createEmptyGeneratedCommunityProjectionStore(),
+        getCorpusStateSnapshot: createSnapshot,
+        invalidateTextSnapshot,
+      },
+      driver: {
+        forceCorpusApply,
+        waitFreshUntil: async () => {},
+      },
+      timeoutMs: 25,
+      signal: new AbortController().signal,
+      hasArtifact: () => ready,
+      ensureArtifact,
+      lockProbeTimeoutMs: 7,
+      lockRetryDelayMs: 10,
+      lockRetryMaxDelayMs: 25,
+    });
+
+    await handle.completed;
+
+    expect(ensureArtifact).toHaveBeenCalledTimes(5);
+    expect(observedLockTimeouts).toEqual([7, 7, 7, 7, 7]);
+    expect(sleepDelays).toEqual([10, 20, 25, 25]);
+    expect(invalidateTextSnapshot).toHaveBeenCalledTimes(1);
+    expect(forceCorpusApply).toHaveBeenCalledTimes(1);
+    expect(
+      rawLog.mock.calls.filter(([message]) => String(message).includes('another package operation holds')).length,
+    ).toBe(1);
+  });
+
+  it('logs structured recovery guidance when background artifact installation fails', async () => {
+    const warning = vi.spyOn(backendLog, 'warn').mockImplementation(() => {});
+    const handle = startKiwiArtifactFetchOnBoot({
+      runtime: createRuntime(),
+      kb: {
+        declaredAnalyzers: ['ko'],
+        generatedCommunityProjectionStore: createEmptyGeneratedCommunityProjectionStore(),
+        getCorpusStateSnapshot: createSnapshot,
+        invalidateTextSnapshot: () => ({ contentSeq: 0, metadataSeq: 0 }),
+      },
+      driver: {
+        forceCorpusApply: () => ({ generation: 1, consumers: [] }),
+        waitFreshUntil: async () => {},
+      },
+      timeoutMs: 25,
+      signal: new AbortController().signal,
+      hasArtifact: () => false,
+      ensureArtifact: async () => ({
+        status: 'error',
+        code: 'expansion_install_artifact_failed',
+        userMessage: 'download failed',
+        remediation: 'run the equip command',
+      }),
+    });
+
+    await handle.completed;
+
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining('download failed'));
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining('run the equip command'));
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining('Intl fallback remains active'));
+  });
+
+  it('keeps a detached download result but suppresses reindex after disposal', async () => {
+    let ready = false;
+    let finishDownload!: () => void;
+    const download = new Promise<void>((resolve) => {
+      finishDownload = resolve;
+    });
+    const controller = new AbortController();
+    const invalidateTextSnapshot = vi.fn(() => ({ contentSeq: 1, metadataSeq: 2 }));
+    const forceCorpusApply = vi.fn(() => ({ generation: 1, consumers: [ORAMA_BASE_CONSUMER_ID] }));
+    const handle = startKiwiArtifactFetchOnBoot({
+      runtime: createRuntime(),
+      kb: {
+        declaredAnalyzers: ['ko'],
+        generatedCommunityProjectionStore: createEmptyGeneratedCommunityProjectionStore(),
+        getCorpusStateSnapshot: createSnapshot,
+        invalidateTextSnapshot,
+      },
+      driver: {
+        forceCorpusApply,
+        waitFreshUntil: async () => {},
+      },
+      timeoutMs: 25,
+      signal: controller.signal,
+      hasArtifact: () => ready,
+      ensureArtifact: async () => {
+        await download;
+        ready = true;
+        return {
+          status: 'installed',
+          method: 'runtime-download',
+          version: '0.23.0',
+          targetDir: '/tmp/kiwi',
+        };
+      },
+    });
+
+    controller.abort();
+    finishDownload();
+    await handle.completed;
+
+    expect(ready).toBe(true);
+    expect(invalidateTextSnapshot).not.toHaveBeenCalled();
+    expect(forceCorpusApply).not.toHaveBeenCalled();
+  });
+
+  it('does not start when the composite artifact is already ready', () => {
+    const ensureArtifact = vi.fn();
+    const handle = startKiwiArtifactFetchOnBoot({
+      runtime: createRuntime(),
+      kb: {
+        declaredAnalyzers: ['ko'],
+        generatedCommunityProjectionStore: createEmptyGeneratedCommunityProjectionStore(),
+        getCorpusStateSnapshot: createSnapshot,
+        invalidateTextSnapshot: () => ({ contentSeq: 0, metadataSeq: 0 }),
+      },
+      driver: {
+        forceCorpusApply: () => ({ generation: 1, consumers: [] }),
+        waitFreshUntil: async () => {},
+      },
+      timeoutMs: 25,
+      signal: new AbortController().signal,
+      hasArtifact: () => true,
+      ensureArtifact,
+    });
+
+    expect(handle).toEqual({ started: false, completed: null });
+    expect(ensureArtifact).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/coordinator/kiwi-artifact-boot.test.ts
+++ b/tests/unit/coordinator/kiwi-artifact-boot.test.ts
@@ -183,7 +183,7 @@ describe('startKiwiArtifactFetchOnBoot', () => {
     let ready = false;
     let attempts = 0;
     const sleepDelays: number[] = [];
-    const rawLog = vi.spyOn(backendLog, 'raw').mockImplementation(() => {});
+    const infoLog = vi.spyOn(backendLog, 'info').mockImplementation(() => {});
     const runtime = createRuntime({
       now: () => (attempts === 0 ? 0 : 31_000),
       sleep: async (ms) => {
@@ -245,7 +245,7 @@ describe('startKiwiArtifactFetchOnBoot', () => {
     expect(invalidateTextSnapshot).toHaveBeenCalledTimes(1);
     expect(forceCorpusApply).toHaveBeenCalledTimes(1);
     expect(
-      rawLog.mock.calls.filter(([message]) => String(message).includes('another package operation holds')).length,
+      infoLog.mock.calls.filter(([message]) => String(message).includes('another package operation holds')).length,
     ).toBe(1);
   });
 

--- a/tests/unit/coordinator/orama-reconcile-ac5-ac6.test.ts
+++ b/tests/unit/coordinator/orama-reconcile-ac5-ac6.test.ts
@@ -8,9 +8,9 @@ import {
   createOramaProjectionReconcileRequester,
   type OramaProjectionReconcileRuntime,
 } from '#src/kb-daemon/expansion/projection-reconcile.js';
+import { kiwiArtifactStateKey } from '#src/engines/kiwi/artifact.js';
 import { KiwiAnalyzerManager, isKiwiAnalyzerTerminalLoadError } from '#src/engines/kiwi/analyzer-manager.js';
 import type { KiwiAnalyzer } from '#src/engines/kiwi/loader.js';
-import type { KiwiModelArtifactState } from '#src/engines/kiwi/model-artifact.js';
 import {
   ORAMA_PROJECTION_IDENTITY_HASH,
   createOramaProjectionIdentityInput,
@@ -34,6 +34,7 @@ import type { Database } from '#src/store/db.js';
 import { createScope } from '#src/expansion/scope.js';
 import { createEmptyGeneratedCommunityProjectionStore, createTestKbRuntime } from '#tests/fixtures/test-runtime.js';
 import { REAL_CONSUMER_DRIVER_TIMERS, realConsumerDriverNow } from '#tests/helpers/consumer-driver-defaults.js';
+import { installedKiwiArtifactState, missingKiwiArtifactState } from '#tests/helpers/kiwi-artifact-state.js';
 import { createKbTestDb } from '#tests/unit/kb/runtime-test-helpers.js';
 
 const tempRoots: string[] = [];
@@ -116,36 +117,6 @@ function withKoEnv(runtime: Runtime): Runtime {
       get: (key) => (key === 'CORAL_KB_EXTRA_LANGS' ? 'ko' : runtime.env.get(key)),
       fullSnapshot: () => ({ ...runtime.env.fullSnapshot(), CORAL_KB_EXTRA_LANGS: 'ko' }),
       coralSnapshot: () => ({ ...runtime.env.coralSnapshot(), CORAL_KB_EXTRA_LANGS: 'ko' }),
-    },
-  };
-}
-
-function missingKiwiState(): KiwiModelArtifactState {
-  return {
-    targetDir: '/tmp/kiwi',
-    manifestPath: '/tmp/kiwi/manifest.json',
-    installed: false,
-    missingFiles: ['cong.mdl'],
-    manifest: null,
-  };
-}
-
-function installedKiwiState(): KiwiModelArtifactState {
-  return {
-    targetDir: '/tmp/kiwi',
-    manifestPath: '/tmp/kiwi/manifest.json',
-    installed: true,
-    missingFiles: [],
-    manifest: {
-      packageId: 'kiwi',
-      kiwiNlpVersion: '0.23.0',
-      modelVersion: '0.23.0',
-      modelType: 'cong-global',
-      sourceUrl: 'https://example.invalid/kiwi.tgz',
-      archiveSha256: 'digest',
-      archiveSizeBytes: 1,
-      files: [],
-      installedAt: '2026-06-20T00:00:00.000Z',
     },
   };
 }
@@ -321,7 +292,7 @@ describe('Orama coordinator reconcile ownership', () => {
     await requester.waitForIdle();
     requester.requestKiwiDegradedReconcile({
       reason: 'Kiwi model missing',
-      modelStateKey: 'missing:cong.mdl',
+      artifactStateKey: 'missing:model',
     });
     await requester.waitForIdle();
 
@@ -377,7 +348,7 @@ describe('Orama coordinator reconcile ownership', () => {
 
     requester.requestKiwiDegradedReconcile({
       reason: 'Kiwi model missing',
-      modelStateKey: 'missing:cong.mdl',
+      artifactStateKey: 'missing:model',
     });
     await requester.waitForIdle();
 
@@ -396,7 +367,7 @@ describe('Orama coordinator reconcile ownership', () => {
     publishSnapshot(db, kb, snapshot);
     let failKiwiLoad = false;
     const manager = new KiwiAnalyzerManager({
-      inspectModelArtifact: () => (failKiwiLoad ? missingKiwiState() : installedKiwiState()),
+      inspectArtifact: () => (failKiwiLoad ? missingKiwiArtifactState() : installedKiwiArtifactState()),
       loadAnalyzer: async () => {
         if (failKiwiLoad) {
           throw new Error('Kiwi model deleted');
@@ -470,7 +441,7 @@ describe('Orama coordinator reconcile ownership', () => {
   it('does not fire a Kiwi degraded observer after its scope is disposed', async () => {
     const runtime = createRuntime();
     const manager = new KiwiAnalyzerManager({
-      inspectModelArtifact: () => missingKiwiState(),
+      inspectArtifact: () => missingKiwiArtifactState(),
       loadAnalyzer: async () => {
         throw new Error('Kiwi model missing');
       },
@@ -481,10 +452,10 @@ describe('Orama coordinator reconcile ownership', () => {
     const events: string[] = [];
 
     manager.observeDegraded(activeScope, (event) => {
-      events.push(`active:${event.modelStateKey}`);
+      events.push(`active:${event.artifactStateKey}`);
     });
     manager.observeDegraded(disposedScope, (event) => {
-      events.push(`disposed:${event.modelStateKey}`);
+      events.push(`disposed:${event.artifactStateKey}`);
     });
     disposedScope[Symbol.dispose]();
 
@@ -496,13 +467,13 @@ describe('Orama coordinator reconcile ownership', () => {
     }
     await flushMicrotasks();
 
-    expect(events).toEqual(['active:missing:cong.mdl']);
+    expect(events).toEqual([`active:${kiwiArtifactStateKey(missingKiwiArtifactState())}`]);
   });
 
   it('isolates Kiwi degraded observer exceptions from the terminal load error path', async () => {
     const runtime = createRuntime();
     const manager = new KiwiAnalyzerManager({
-      inspectModelArtifact: () => missingKiwiState(),
+      inspectArtifact: () => missingKiwiArtifactState(),
       loadAnalyzer: async () => {
         throw new Error('Kiwi model missing');
       },

--- a/tests/unit/engines/kiwi/analyzer-manager.test.ts
+++ b/tests/unit/engines/kiwi/analyzer-manager.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { KiwiAnalyzerManager, isKiwiAnalyzerTerminalLoadError } from '#src/engines/kiwi/analyzer-manager.js';
-import type { KiwiAnalyzer } from '#src/engines/kiwi/loader.js';
+import { KiwiAnalyzerMissingArtifactError, type KiwiAnalyzer } from '#src/engines/kiwi/loader.js';
 import type { TimerHandle } from '#src/infra/port-types.js';
 import type { Runtime } from '#src/runtime/ports.js';
 import { installedKiwiArtifactState, missingKiwiArtifactState } from '#tests/helpers/kiwi-artifact-state.js';
@@ -216,9 +216,11 @@ describe('KiwiAnalyzerManager', () => {
     const runtime = createRuntime();
     let loadCalls = 0;
     let state = modelOnlyState();
+    let artifactIdentity = 'model-only';
     const manager = new KiwiAnalyzerManager({
       idleTtlMs: 300_000,
       inspectArtifact: () => state,
+      probeArtifactIdentity: () => artifactIdentity,
       loadAnalyzer: async () => {
         loadCalls += 1;
         if (loadCalls === 1) {
@@ -244,6 +246,7 @@ describe('KiwiAnalyzerManager', () => {
     expect(loadCalls).toBe(1);
 
     state = installedState('2026-06-19T00:01:00.000Z');
+    artifactIdentity = 'installed';
     expect(manager.leaseReadiness(runtime, ['ko'])).toEqual({ ready: false, state: 'unloaded' });
     expect(loadCalls).toBe(1);
   });
@@ -251,8 +254,10 @@ describe('KiwiAnalyzerManager', () => {
   it('recovers through effectiveDeclaredAnalyzers without a prior readiness probe', async () => {
     const runtime = createRuntime();
     let state = modelOnlyState();
+    let artifactIdentity = 'model-only';
     const manager = new KiwiAnalyzerManager({
       inspectArtifact: () => state,
+      probeArtifactIdentity: () => artifactIdentity,
       loadAnalyzer: async () => {
         throw new Error('WASM missing');
       },
@@ -261,6 +266,7 @@ describe('KiwiAnalyzerManager', () => {
 
     await expectTerminalFailure(manager, runtime);
     state = installedState('2026-06-19T00:01:00.000Z');
+    artifactIdentity = 'installed';
 
     expect(manager.effectiveDeclaredAnalyzers(['ko'], runtime)).toEqual(['ko']);
     expect(manager.status()).toEqual({ state: 'unloaded', leaseCount: 0 });
@@ -269,9 +275,11 @@ describe('KiwiAnalyzerManager', () => {
   it('recovers through lease acquisition without a prior readiness or effective-analyzer probe', async () => {
     const runtime = createRuntime();
     let state = modelOnlyState();
+    let artifactIdentity = 'model-only';
     let loadCalls = 0;
     const manager = new KiwiAnalyzerManager({
       inspectArtifact: () => state,
+      probeArtifactIdentity: () => artifactIdentity,
       loadAnalyzer: async () => {
         loadCalls += 1;
         if (loadCalls === 1) {
@@ -284,6 +292,7 @@ describe('KiwiAnalyzerManager', () => {
 
     await expectTerminalFailure(manager, runtime);
     state = installedState('2026-06-19T00:01:00.000Z');
+    artifactIdentity = 'installed';
 
     await manager.withAnalyzerLease(runtime, ['ko'], (lease) => {
       expect(lease.analyzer?.identity.modelVersion).toBe('recovered');
@@ -295,13 +304,16 @@ describe('KiwiAnalyzerManager', () => {
   it('records the pre-load artifact key when recovery completes before a failing load rejects', async () => {
     const runtime = createRuntime();
     let state = modelOnlyState();
+    let artifactIdentity = 'model-only';
     let loadCalls = 0;
     const manager = new KiwiAnalyzerManager({
       inspectArtifact: () => state,
+      probeArtifactIdentity: () => artifactIdentity,
       loadAnalyzer: async () => {
         loadCalls += 1;
         if (loadCalls === 1) {
           state = installedState('2026-06-19T00:01:00.000Z');
+          artifactIdentity = 'installed';
           throw new Error('load raced artifact publication');
         }
         return createAnalyzer('recovered-after-race');
@@ -316,6 +328,40 @@ describe('KiwiAnalyzerManager', () => {
       expect(lease.analyzer?.identity.modelVersion).toBe('recovered-after-race');
     });
     expect(loadCalls).toBe(2);
+  });
+
+  it('uses only the identity probe while a degraded artifact is unchanged', async () => {
+    const runtime = createRuntime();
+    let state = modelOnlyState();
+    let artifactIdentity = 'model-only';
+    const inspectArtifact = vi.fn(() => state);
+    const probeArtifactIdentity = vi.fn(() => artifactIdentity);
+    const manager = new KiwiAnalyzerManager({
+      inspectArtifact,
+      probeArtifactIdentity,
+      loadAnalyzer: async () => {
+        throw new Error('WASM missing');
+      },
+      logger: () => {},
+    });
+
+    await expectTerminalFailure(manager, runtime);
+    inspectArtifact.mockClear();
+    probeArtifactIdentity.mockClear();
+
+    expect(manager.leaseReadiness(runtime, ['ko'])).toEqual({
+      ready: true,
+      state: 'degraded',
+      reason: 'WASM missing',
+    });
+    expect(probeArtifactIdentity).toHaveBeenCalledTimes(1);
+    expect(inspectArtifact).not.toHaveBeenCalled();
+
+    state = installedState('2026-06-19T00:01:00.000Z');
+    artifactIdentity = 'installed';
+    expect(manager.leaseReadiness(runtime, ['ko'])).toEqual({ ready: false, state: 'unloaded' });
+    expect(probeArtifactIdentity).toHaveBeenCalledTimes(2);
+    expect(inspectArtifact).toHaveBeenCalledTimes(1);
   });
 
   it('recommends a daemon retry instead of equip when valid artifacts fail to initialize', async () => {
@@ -341,10 +387,7 @@ describe('KiwiAnalyzerManager', () => {
     const manager = new KiwiAnalyzerManager({
       inspectArtifact: () => modelOnlyState(),
       loadAnalyzer: async () => {
-        throw new Error(
-          'Kiwi runtime artifacts are not installed (wasm missing). ' +
-            'Run `coral-cli expansion equip kiwi` to install them.',
-        );
+        throw new KiwiAnalyzerMissingArtifactError(['wasm']);
       },
       logger: (message) => logs.push(message),
     });

--- a/tests/unit/engines/kiwi/analyzer-manager.test.ts
+++ b/tests/unit/engines/kiwi/analyzer-manager.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import { KiwiAnalyzerManager, isKiwiAnalyzerTerminalLoadError } from '#src/engines/kiwi/analyzer-manager.js';
 import type { KiwiAnalyzer } from '#src/engines/kiwi/loader.js';
-import type { KiwiModelArtifactState } from '#src/engines/kiwi/model-artifact.js';
 import type { TimerHandle } from '#src/infra/port-types.js';
 import type { Runtime } from '#src/runtime/ports.js';
+import { installedKiwiArtifactState, missingKiwiArtifactState } from '#tests/helpers/kiwi-artifact-state.js';
 
 type FakeTimer = TimerHandle & {
   active: boolean;
@@ -40,44 +40,12 @@ function createRuntime(timers: FakeTimer[] = []): Runtime {
   } as unknown as Runtime;
 }
 
-function installedState(installedAt = '2026-06-19T00:00:00.000Z'): KiwiModelArtifactState {
-  return {
-    targetDir: '/tmp/kiwi',
-    manifestPath: '/tmp/kiwi/manifest.json',
-    installed: true,
-    missingFiles: [],
-    manifest: {
-      packageId: 'kiwi',
-      kiwiNlpVersion: '0.23.0',
-      modelVersion: '0.23.0',
-      modelType: 'cong-global',
-      sourceUrl: 'https://example.invalid/kiwi.tgz',
-      archiveSha256: 'digest',
-      archiveSizeBytes: 1,
-      files: [
-        'sj.morph',
-        'default.dict',
-        'dialect.dict',
-        'multi.dict',
-        'typo.dict',
-        'combiningRule.txt',
-        'cong.mdl',
-        'extract.mdl',
-        'nounchr.mdl',
-      ],
-      installedAt,
-    },
-  };
+function installedState(installedAt = '2026-06-19T00:00:00.000Z') {
+  return installedKiwiArtifactState(installedAt);
 }
 
-function missingState(): KiwiModelArtifactState {
-  return {
-    targetDir: '/tmp/kiwi',
-    manifestPath: '/tmp/kiwi/manifest.json',
-    installed: false,
-    missingFiles: ['cong.mdl'],
-    manifest: null,
-  };
+function modelOnlyState() {
+  return missingKiwiArtifactState('wasm');
 }
 
 function createAnalyzer(label: string, dispose: () => Promise<void> | void = () => {}): KiwiAnalyzer {
@@ -97,6 +65,15 @@ function createAnalyzer(label: string, dispose: () => Promise<void> | void = () 
   };
 }
 
+async function expectTerminalFailure(manager: KiwiAnalyzerManager, runtime: Runtime): Promise<void> {
+  try {
+    await manager.withAnalyzerLease(runtime, ['ko'], () => {});
+    throw new Error('expected load failure');
+  } catch (error: unknown) {
+    expect(isKiwiAnalyzerTerminalLoadError(error)).toBe(true);
+  }
+}
+
 describe('KiwiAnalyzerManager', () => {
   it('single-flights concurrent loads and exposes the lease through AsyncLocalStorage', async () => {
     const runtime = createRuntime();
@@ -108,7 +85,7 @@ describe('KiwiAnalyzerManager', () => {
     const analyzer = createAnalyzer('a');
     const manager = new KiwiAnalyzerManager({
       idleTtlMs: 300_000,
-      inspectModelArtifact: () => installedState(),
+      inspectArtifact: () => installedState(),
       loadAnalyzer: async () => {
         loadCalls += 1;
         await loadGate;
@@ -143,7 +120,7 @@ describe('KiwiAnalyzerManager', () => {
     let evictionResolved = false;
     const manager = new KiwiAnalyzerManager({
       idleTtlMs: 300_000,
-      inspectModelArtifact: () => installedState(),
+      inspectArtifact: () => installedState(),
       loadAnalyzer: async () =>
         createAnalyzer('a', () => {
           disposeCalls += 1;
@@ -176,7 +153,7 @@ describe('KiwiAnalyzerManager', () => {
     });
     const manager = new KiwiAnalyzerManager({
       idleTtlMs: 300_000,
-      inspectModelArtifact: () => installedState(),
+      inspectArtifact: () => installedState(),
       loadAnalyzer: async () => {
         loadCalls += 1;
         return createAnalyzer(`load-${loadCalls}`, loadCalls === 1 ? () => disposeGate : () => {});
@@ -207,7 +184,7 @@ describe('KiwiAnalyzerManager', () => {
     let disposeCalls = 0;
     const manager = new KiwiAnalyzerManager({
       idleTtlMs: 300_000,
-      inspectModelArtifact: () => installedState(),
+      inspectArtifact: () => installedState(),
       loadAnalyzer: async () =>
         createAnalyzer('a', () => {
           disposeCalls += 1;
@@ -235,30 +212,30 @@ describe('KiwiAnalyzerManager', () => {
     expect(disposeCalls).toBe(1);
   });
 
-  it('degrades to Intl baseline after terminal load failure and retries when the model changes', async () => {
+  it('degrades to Intl baseline after terminal load failure and retries when WASM completes', async () => {
     const runtime = createRuntime();
     let loadCalls = 0;
-    let state = missingState();
+    let state = modelOnlyState();
     const manager = new KiwiAnalyzerManager({
       idleTtlMs: 300_000,
-      inspectModelArtifact: () => state,
+      inspectArtifact: () => state,
       loadAnalyzer: async () => {
         loadCalls += 1;
         if (loadCalls === 1) {
-          throw new Error('model missing');
+          throw new Error('WASM missing');
         }
         return createAnalyzer('recovered');
       },
       logger: () => {},
     });
 
-    try {
-      await manager.withAnalyzerLease(runtime, ['ko'], () => {});
-      throw new Error('expected load failure');
-    } catch (error: unknown) {
-      expect(isKiwiAnalyzerTerminalLoadError(error)).toBe(true);
-    }
+    await expectTerminalFailure(manager, runtime);
     expect(manager.effectiveDeclaredAnalyzers(['ko'], runtime)).toEqual([]);
+    expect(manager.leaseReadiness(runtime, ['ko'])).toEqual({
+      ready: true,
+      state: 'degraded',
+      reason: 'WASM missing',
+    });
 
     await manager.withAnalyzerLease(runtime, ['ko'], (lease) => {
       expect(lease.analyzer).toBeNull();
@@ -267,11 +244,114 @@ describe('KiwiAnalyzerManager', () => {
     expect(loadCalls).toBe(1);
 
     state = installedState('2026-06-19T00:01:00.000Z');
+    expect(manager.leaseReadiness(runtime, ['ko'])).toEqual({ ready: false, state: 'unloaded' });
+    expect(loadCalls).toBe(1);
+  });
+
+  it('recovers through effectiveDeclaredAnalyzers without a prior readiness probe', async () => {
+    const runtime = createRuntime();
+    let state = modelOnlyState();
+    const manager = new KiwiAnalyzerManager({
+      inspectArtifact: () => state,
+      loadAnalyzer: async () => {
+        throw new Error('WASM missing');
+      },
+      logger: () => {},
+    });
+
+    await expectTerminalFailure(manager, runtime);
+    state = installedState('2026-06-19T00:01:00.000Z');
+
+    expect(manager.effectiveDeclaredAnalyzers(['ko'], runtime)).toEqual(['ko']);
+    expect(manager.status()).toEqual({ state: 'unloaded', leaseCount: 0 });
+  });
+
+  it('recovers through lease acquisition without a prior readiness or effective-analyzer probe', async () => {
+    const runtime = createRuntime();
+    let state = modelOnlyState();
+    let loadCalls = 0;
+    const manager = new KiwiAnalyzerManager({
+      inspectArtifact: () => state,
+      loadAnalyzer: async () => {
+        loadCalls += 1;
+        if (loadCalls === 1) {
+          throw new Error('WASM missing');
+        }
+        return createAnalyzer('recovered');
+      },
+      logger: () => {},
+    });
+
+    await expectTerminalFailure(manager, runtime);
+    state = installedState('2026-06-19T00:01:00.000Z');
+
     await manager.withAnalyzerLease(runtime, ['ko'], (lease) => {
       expect(lease.analyzer?.identity.modelVersion).toBe('recovered');
       expect(lease.activeAnalyzers).toEqual(['ko']);
     });
-    expect(manager.effectiveDeclaredAnalyzers(['ko'], runtime)).toEqual(['ko']);
     expect(loadCalls).toBe(2);
+  });
+
+  it('records the pre-load artifact key when recovery completes before a failing load rejects', async () => {
+    const runtime = createRuntime();
+    let state = modelOnlyState();
+    let loadCalls = 0;
+    const manager = new KiwiAnalyzerManager({
+      inspectArtifact: () => state,
+      loadAnalyzer: async () => {
+        loadCalls += 1;
+        if (loadCalls === 1) {
+          state = installedState('2026-06-19T00:01:00.000Z');
+          throw new Error('load raced artifact publication');
+        }
+        return createAnalyzer('recovered-after-race');
+      },
+      logger: () => {},
+    });
+
+    await expectTerminalFailure(manager, runtime);
+    expect(manager.leaseReadiness(runtime, ['ko'])).toEqual({ ready: false, state: 'unloaded' });
+
+    await manager.withAnalyzerLease(runtime, ['ko'], (lease) => {
+      expect(lease.analyzer?.identity.modelVersion).toBe('recovered-after-race');
+    });
+    expect(loadCalls).toBe(2);
+  });
+
+  it('recommends a daemon retry instead of equip when valid artifacts fail to initialize', async () => {
+    const runtime = createRuntime();
+    const logs: string[] = [];
+    const manager = new KiwiAnalyzerManager({
+      inspectArtifact: () => installedState(),
+      loadAnalyzer: async () => {
+        throw new Error('Emscripten initializer crashed');
+      },
+      logger: (message) => logs.push(message),
+    });
+
+    await expectTerminalFailure(manager, runtime);
+
+    expect(logs).toEqual([expect.stringContaining('coral-cli backend shutdown')]);
+    expect(logs.join('\n')).not.toContain('coral-cli expansion equip kiwi');
+  });
+
+  it('preserves the canonical equip remediation for missing runtime artifacts', async () => {
+    const runtime = createRuntime();
+    const logs: string[] = [];
+    const manager = new KiwiAnalyzerManager({
+      inspectArtifact: () => modelOnlyState(),
+      loadAnalyzer: async () => {
+        throw new Error(
+          'Kiwi runtime artifacts are not installed (wasm missing). ' +
+            'Run `coral-cli expansion equip kiwi` to install them.',
+        );
+      },
+      logger: (message) => logs.push(message),
+    });
+
+    await expectTerminalFailure(manager, runtime);
+
+    expect(logs.join('\n')).toContain('coral-cli expansion equip kiwi');
+    expect(logs.join('\n')).not.toContain('coral-cli backend shutdown');
   });
 });

--- a/tests/unit/engines/kiwi/artifact.test.ts
+++ b/tests/unit/engines/kiwi/artifact.test.ts
@@ -1,0 +1,324 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ensureKiwiArtifact, inspectKiwiArtifact } from '#src/engines/kiwi/artifact.js';
+import { KIWI_MODEL_FILES, type KiwiModelFileName } from '#src/engines/kiwi/constants.js';
+import { type ensureKiwiModelArtifact, writeKiwiModelFilesAtomicInWorker } from '#src/engines/kiwi/model-artifact.js';
+import { withKiwiPackageOperationLock } from '#src/engines/kiwi/operation-lock.js';
+import { kiwiModelFilePath, kiwiModelManifestPath } from '#src/engines/kiwi/paths.js';
+import { publishKiwiWasmArtifact } from '#src/engines/kiwi/wasm-artifact.js';
+import { createRealRuntime } from '#src/runtime/real.js';
+
+const wasmFixture = readFileSync(join(process.cwd(), 'node_modules', 'kiwi-nlp', 'dist', 'kiwi-wasm.wasm'));
+
+function createTestRuntime() {
+  const root = mkdtempSync(join(tmpdir(), 'coral-kiwi-artifact-'));
+  return {
+    root,
+    runtime: createRealRuntime('prod', { baseDir: root }),
+  };
+}
+
+function modelFiles(): ReadonlyMap<KiwiModelFileName, Buffer> {
+  return new Map(KIWI_MODEL_FILES.map((name) => [name, Buffer.from(`model:${name}`)]));
+}
+
+describe('Kiwi composite artifact', () => {
+  it('installs both missing components in model-then-WASM order', async () => {
+    const { root, runtime } = createTestRuntime();
+    const events: string[] = [];
+    try {
+      const ensureModelArtifact = vi.fn(async () => {
+        events.push('model');
+        await writeKiwiModelFilesAtomicInWorker(runtime, modelFiles());
+        return {
+          status: 'installed' as const,
+          method: 'github-release' as const,
+          version: '0.23.0',
+          targetDir: root,
+        };
+      });
+      const ensureWasmArtifact = vi.fn(async () => {
+        expect(inspectKiwiArtifact(runtime).model.installed).toBe(true);
+        events.push('wasm');
+        return publishKiwiWasmArtifact(runtime, wasmFixture);
+      });
+
+      const result = await ensureKiwiArtifact(runtime, {
+        ensureModelArtifact,
+        ensureWasmArtifact,
+      });
+
+      expect(result).toMatchObject({ status: 'installed', method: 'runtime-download' });
+      expect(events).toEqual(['model', 'wasm']);
+      expect(inspectKiwiArtifact(runtime).ready).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves an existing model while installing only missing WASM', async () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      await writeKiwiModelFilesAtomicInWorker(runtime, modelFiles());
+      const modelManifestBefore = readFileSync(kiwiModelManifestPath(runtime));
+      const modelMtimeBefore = statSync(kiwiModelFilePath(runtime, KIWI_MODEL_FILES[0]), { bigint: true }).mtimeNs;
+      const ensureModelArtifact = vi.fn();
+      const ensureWasmArtifact = vi.fn(async () => publishKiwiWasmArtifact(runtime, wasmFixture));
+
+      const result = await ensureKiwiArtifact(runtime, {
+        ensureModelArtifact,
+        ensureWasmArtifact,
+      });
+
+      expect(result).toMatchObject({ status: 'installed', method: 'runtime-download' });
+      expect(ensureModelArtifact).not.toHaveBeenCalled();
+      expect(ensureWasmArtifact).toHaveBeenCalledTimes(1);
+      expect(readFileSync(kiwiModelManifestPath(runtime))).toEqual(modelManifestBefore);
+      expect(statSync(kiwiModelFilePath(runtime, KIWI_MODEL_FILES[0]), { bigint: true }).mtimeNs).toBe(
+        modelMtimeBefore,
+      );
+      expect(inspectKiwiArtifact(runtime).ready).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves an existing WASM while installing only the missing model', async () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      publishKiwiWasmArtifact(runtime, wasmFixture);
+      const wasmPath = inspectKiwiArtifact(runtime).wasm.wasmPath;
+      const wasmBefore = readFileSync(wasmPath);
+      const wasmMtimeBefore = statSync(wasmPath, { bigint: true }).mtimeNs;
+      const ensureModelArtifact = vi.fn(async () => {
+        await writeKiwiModelFilesAtomicInWorker(runtime, modelFiles());
+        return {
+          status: 'installed' as const,
+          method: 'github-release' as const,
+          version: '0.23.0',
+          targetDir: root,
+        };
+      });
+      const ensureWasmArtifact = vi.fn();
+
+      const result = await ensureKiwiArtifact(runtime, {
+        ensureModelArtifact,
+        ensureWasmArtifact,
+      });
+
+      expect(result).toMatchObject({ status: 'installed', method: 'runtime-download' });
+      expect(ensureModelArtifact).toHaveBeenCalledTimes(1);
+      expect(ensureWasmArtifact).not.toHaveBeenCalled();
+      expect(statSync(wasmPath).size).toBe(wasmBefore.length);
+      expect(readFileSync(wasmPath).compare(wasmBefore)).toBe(0);
+      expect(statSync(wasmPath, { bigint: true }).mtimeNs).toBe(wasmMtimeBefore);
+      expect(inspectKiwiArtifact(runtime).ready).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps a successfully installed model when WASM installation fails', async () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      const ensureModelArtifact = vi.fn(async () => {
+        await writeKiwiModelFilesAtomicInWorker(runtime, modelFiles());
+        return {
+          status: 'installed' as const,
+          method: 'github-release' as const,
+          version: '0.23.0',
+          targetDir: root,
+        };
+      });
+
+      const result = await ensureKiwiArtifact(runtime, {
+        ensureModelArtifact,
+        ensureWasmArtifact: async () => {
+          throw new Error('WASM download failed');
+        },
+      });
+
+      expect(result).toMatchObject({
+        status: 'error',
+        code: 'expansion_install_artifact_failed',
+        remediation: expect.stringContaining('coral-cli expansion equip kiwi'),
+        context: { name: 'kiwi', detail: 'WASM download failed' },
+      });
+      expect(inspectKiwiArtifact(runtime)).toMatchObject({
+        ready: false,
+        missingComponents: ['wasm'],
+        model: { installed: true },
+        wasm: { installed: false },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does no component work when both artifacts are ready', async () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      await writeKiwiModelFilesAtomicInWorker(runtime, modelFiles());
+      publishKiwiWasmArtifact(runtime, wasmFixture);
+      const ensureModelArtifact = vi.fn();
+      const ensureWasmArtifact = vi.fn();
+
+      const result = await ensureKiwiArtifact(runtime, {
+        ensureModelArtifact,
+        ensureWasmArtifact,
+      });
+
+      expect(result).toMatchObject({ status: 'already_installed' });
+      expect(ensureModelArtifact).not.toHaveBeenCalled();
+      expect(ensureWasmArtifact).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports already_up_to_date and updated through the observable update contract', async () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      const ensureModelArtifact = vi.fn(async () => {
+        await writeKiwiModelFilesAtomicInWorker(runtime, modelFiles());
+        return {
+          status: 'updated' as const,
+          method: 'github-release' as const,
+          version: '0.23.0',
+          targetDir: root,
+        };
+      });
+      const ensureWasmArtifact = vi.fn(async () => publishKiwiWasmArtifact(runtime, wasmFixture));
+
+      const result = await ensureKiwiArtifact(runtime, {
+        update: true,
+        ensureModelArtifact,
+        ensureWasmArtifact,
+      });
+
+      expect(result.status).toBe('updated');
+      expect(inspectKiwiArtifact(runtime).ready).toBe(true);
+
+      await expect(ensureKiwiArtifact(runtime, { update: true })).resolves.toMatchObject({
+        status: 'already_up_to_date',
+        method: 'runtime-download',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes concurrent public ensures so component installation runs once', async () => {
+    const { root, runtime } = createTestRuntime();
+    let releaseModel!: () => void;
+    const modelGate = new Promise<void>((resolve) => {
+      releaseModel = resolve;
+    });
+    const ensureModelArtifact = vi.fn(async () => {
+      await modelGate;
+      await writeKiwiModelFilesAtomicInWorker(runtime, modelFiles());
+      return {
+        status: 'installed' as const,
+        method: 'github-release' as const,
+        version: '0.23.0',
+        targetDir: root,
+      };
+    });
+    const ensureWasmArtifact = vi.fn(async () => publishKiwiWasmArtifact(runtime, wasmFixture));
+
+    try {
+      const first = ensureKiwiArtifact(runtime, { ensureModelArtifact, ensureWasmArtifact });
+      await vi.waitFor(() => expect(ensureModelArtifact).toHaveBeenCalledTimes(1));
+      const second = ensureKiwiArtifact(runtime, {
+        ensureModelArtifact,
+        ensureWasmArtifact,
+        lockTimeoutMs: 5_000,
+      });
+
+      releaseModel();
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        expect.objectContaining({ status: 'installed' }),
+        expect.objectContaining({ status: 'already_installed' }),
+      ]);
+      expect(ensureModelArtifact).toHaveBeenCalledTimes(1);
+      expect(ensureWasmArtifact).toHaveBeenCalledTimes(1);
+    } finally {
+      releaseModel();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('hands the composite lock into the real model lock harness without reacquiring it', async () => {
+    const { root, runtime } = createTestRuntime();
+    let modelWriteRan = false;
+    const ensureModelArtifact: typeof ensureKiwiModelArtifact = async (innerRuntime, options = {}) =>
+      withKiwiPackageOperationLock(innerRuntime, options, async () => {
+        modelWriteRan = true;
+        await writeKiwiModelFilesAtomicInWorker(innerRuntime, modelFiles());
+        return {
+          status: 'installed',
+          method: 'github-release',
+          version: '0.23.0',
+          targetDir: root,
+        };
+      });
+    try {
+      const result = await ensureKiwiArtifact(runtime, {
+        ensureModelArtifact,
+        ensureWasmArtifact: async () => publishKiwiWasmArtifact(runtime, wasmFixture),
+        lockTimeoutMs: 25,
+      });
+
+      expect(modelWriteRan).toBe(true);
+      expect(result).toMatchObject({ status: 'installed', method: 'runtime-download' });
+      expect(inspectKiwiArtifact(runtime).ready).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each(['EACCES', 'EPERM', 'EROFS', 'ENOSPC'])(
+    'maps a component %s failure to the structured unwritable-path result',
+    async (code) => {
+      const { root, runtime } = createTestRuntime();
+      try {
+        const result = await ensureKiwiArtifact(runtime, {
+          ensureModelArtifact: async () => {
+            throw Object.assign(new Error(`model ${code}`), { code });
+          },
+        });
+
+        expect(result).toMatchObject({
+          status: 'error',
+          code: 'expansion_install_path_unwritable',
+          context: { name: 'kiwi' },
+        });
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it('maps an unrelated component exception to the structured artifact failure', async () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      const result = await ensureKiwiArtifact(runtime, {
+        ensureModelArtifact: async () => {
+          throw new Error('model exploded');
+        },
+      });
+
+      expect(result).toMatchObject({
+        status: 'error',
+        code: 'expansion_install_artifact_failed',
+        context: { name: 'kiwi', detail: 'model exploded' },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/engines/kiwi/artifact.test.ts
+++ b/tests/unit/engines/kiwi/artifact.test.ts
@@ -4,12 +4,13 @@ import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { ensureKiwiArtifact, inspectKiwiArtifact } from '#src/engines/kiwi/artifact.js';
+import { ensureKiwiArtifact, inspectKiwiArtifact, probeKiwiArtifactIdentity } from '#src/engines/kiwi/artifact.js';
 import { KIWI_MODEL_FILES, type KiwiModelFileName } from '#src/engines/kiwi/constants.js';
 import { type ensureKiwiModelArtifact, writeKiwiModelFilesAtomicInWorker } from '#src/engines/kiwi/model-artifact.js';
 import { withKiwiPackageOperationLock } from '#src/engines/kiwi/operation-lock.js';
-import { kiwiModelFilePath, kiwiModelManifestPath } from '#src/engines/kiwi/paths.js';
+import { kiwiModelFilePath, kiwiModelManifestPath, kiwiWasmPath } from '#src/engines/kiwi/paths.js';
 import { publishKiwiWasmArtifact } from '#src/engines/kiwi/wasm-artifact.js';
+import { installErrorSchema } from '#src/expansion/rpc-contract.js';
 import { createRealRuntime } from '#src/runtime/real.js';
 
 const wasmFixture = readFileSync(join(process.cwd(), 'node_modules', 'kiwi-nlp', 'dist', 'kiwi-wasm.wasm'));
@@ -180,6 +181,35 @@ describe('Kiwi composite artifact', () => {
     }
   });
 
+  it('probes model and WASM identity without reading artifact contents', async () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      await writeKiwiModelFilesAtomicInWorker(runtime, modelFiles());
+      publishKiwiWasmArtifact(runtime, wasmFixture);
+      const readFileSpy = vi.spyOn(runtime.storage, 'readFileSync');
+      const openSpy = vi.spyOn(runtime.storage, 'openSync');
+      const readSpy = vi.spyOn(runtime.storage, 'readSync');
+
+      const before = probeKiwiArtifactIdentity(runtime);
+      expect(probeKiwiArtifactIdentity(runtime)).toBe(before);
+      expect(readFileSpy).not.toHaveBeenCalled();
+      expect(openSpy).not.toHaveBeenCalled();
+      expect(readSpy).not.toHaveBeenCalled();
+
+      runtime.storage.rmSync(kiwiModelFilePath(runtime, KIWI_MODEL_FILES[0]));
+      const withoutModelFile = probeKiwiArtifactIdentity(runtime);
+      expect(withoutModelFile).not.toBe(before);
+
+      runtime.storage.rmSync(kiwiWasmPath(runtime));
+      expect(probeKiwiArtifactIdentity(runtime)).not.toBe(withoutModelFile);
+      expect(readFileSpy).not.toHaveBeenCalled();
+      expect(openSpy).not.toHaveBeenCalled();
+      expect(readSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('reports already_up_to_date and updated through the observable update contract', async () => {
     const { root, runtime } = createTestRuntime();
     try {
@@ -281,6 +311,38 @@ describe('Kiwi composite artifact', () => {
     }
   });
 
+  it('returns a schema-valid error when installation completes without readiness', async () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      const result = await ensureKiwiArtifact(runtime, {
+        ensureModelArtifact: async () => ({
+          status: 'installed',
+          method: 'github-release',
+          version: '0.23.0',
+          targetDir: root,
+        }),
+        ensureWasmArtifact: async () => publishKiwiWasmArtifact(runtime, wasmFixture),
+      });
+
+      expect(result).toMatchObject({
+        status: 'error',
+        code: 'expansion_install_artifact_failed',
+        context: {
+          name: 'kiwi',
+          detail: 'Kiwi artifact install completed without readiness: model',
+          causeName: 'Error',
+          causeMessage: 'Kiwi artifact install completed without readiness: model',
+          causeStack: expect.stringContaining('Kiwi artifact install completed without readiness: model'),
+        },
+      });
+      expect(result).not.toHaveProperty('cause');
+      expect(JSON.parse(JSON.stringify(result))).toEqual(result);
+      expect(installErrorSchema.safeParse(result).success).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it.each(['EACCES', 'EPERM', 'EROFS', 'ENOSPC'])(
     'maps a component %s failure to the structured unwritable-path result',
     async (code) => {
@@ -297,6 +359,7 @@ describe('Kiwi composite artifact', () => {
           code: 'expansion_install_path_unwritable',
           context: { name: 'kiwi' },
         });
+        expect(installErrorSchema.safeParse(result).success).toBe(true);
       } finally {
         rmSync(root, { recursive: true, force: true });
       }

--- a/tests/unit/engines/kiwi/artifact.test.ts
+++ b/tests/unit/engines/kiwi/artifact.test.ts
@@ -327,13 +327,11 @@ describe('Kiwi composite artifact', () => {
       expect(result).toMatchObject({
         status: 'error',
         code: 'expansion_install_artifact_failed',
-        context: {
-          name: 'kiwi',
-          detail: 'Kiwi artifact install completed without readiness: model',
-          causeName: 'Error',
-          causeMessage: 'Kiwi artifact install completed without readiness: model',
-          causeStack: expect.stringContaining('Kiwi artifact install completed without readiness: model'),
-        },
+      });
+      expect(result).toHaveProperty('context', {
+        name: 'kiwi',
+        detail: expect.stringContaining('Kiwi artifact install completed without readiness: model'),
+        causeName: 'Error',
       });
       expect(result).not.toHaveProperty('cause');
       expect(JSON.parse(JSON.stringify(result))).toEqual(result);

--- a/tests/unit/engines/kiwi/install-error.test.ts
+++ b/tests/unit/engines/kiwi/install-error.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { isInstallPathUnwritableError, kiwiInstallError } from '#src/engines/kiwi/install-error.js';
+
+function errno(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(code), { code });
+}
+
+describe('Kiwi install errors', () => {
+  it.each(['EACCES', 'EPERM', 'EROFS', 'ENOSPC'])('classifies %s as an unwritable install path', (code) => {
+    expect(isInstallPathUnwritableError(errno(code))).toBe(true);
+  });
+
+  it('does not classify unrelated or non-error values as unwritable paths', () => {
+    expect(isInstallPathUnwritableError(errno('ETIMEDOUT'))).toBe(false);
+    expect(isInstallPathUnwritableError(new Error('plain failure'))).toBe(false);
+    expect(isInstallPathUnwritableError({ code: 'EACCES' })).toBe(false);
+  });
+
+  it('uses the canonical structured setup-error registry', () => {
+    expect(kiwiInstallError('expansion_install_artifact_failed', { name: 'kiwi', detail: 'broken' })).toEqual({
+      status: 'error',
+      code: 'expansion_install_artifact_failed',
+      userMessage: 'Coral could not install the runtime artifacts for kiwi.',
+      remediation: expect.stringContaining('coral-cli expansion equip kiwi'),
+      context: { name: 'kiwi', detail: 'broken' },
+    });
+  });
+});

--- a/tests/unit/engines/kiwi/loader.test.ts
+++ b/tests/unit/engines/kiwi/loader.test.ts
@@ -1,0 +1,105 @@
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { loadKiwiAnalyzer } from '#src/engines/kiwi/loader.js';
+import { kiwiWasmPath } from '#src/engines/kiwi/paths.js';
+import { createKiwiApi, type KiwiWasmInitializer } from '#src/engines/kiwi/wasm-loader.js';
+import type { Runtime } from '#src/runtime/ports.js';
+import { createRealRuntime } from '#src/runtime/real.js';
+
+function createRuntime(): Pick<Runtime, 'paths'> {
+  return {
+    paths: {
+      coral: {
+        engine: {
+          dataDir: (name: string) => `/runtime/engines/${name}`,
+        },
+      },
+    },
+  } as Pick<Runtime, 'paths'>;
+}
+
+describe('Kiwi WASM loader wiring', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves only kiwi-wasm.wasm from the installed runtime artifact', async () => {
+    const runtime = createRuntime();
+    let locateFile: ((path: string, prefix?: string) => string) | undefined;
+    const initialize: KiwiWasmInitializer = async (moduleArg) => {
+      locateFile = (moduleArg as { locateFile: (path: string, prefix?: string) => string }).locateFile;
+      return {
+        FS: {
+          mkdir: () => {},
+          writeFile: () => {},
+          unlink: () => {},
+          rmdir: () => {},
+        },
+        api: () => '{}',
+      };
+    };
+
+    await createKiwiApi(runtime, initialize);
+
+    expect(locateFile).toBeDefined();
+    expect(locateFile!('kiwi-wasm.wasm', '/bundle/')).toBe(kiwiWasmPath(runtime));
+    expect(locateFile!('worker.js', '/bundle/')).toBe('/bundle/worker.js');
+    expect(locateFile!('nested/kiwi-wasm.wasm', '/bundle/')).toBe('/bundle/nested/kiwi-wasm.wasm');
+  });
+
+  it('instantiates the real pinned Emscripten initializer from the runtime WASM path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'coral-kiwi-loader-'));
+    const runtime = createRealRuntime('prod', { baseDir: root });
+    const runtimeWasmPath = kiwiWasmPath(runtime);
+    try {
+      mkdirSync(dirname(runtimeWasmPath), { recursive: true });
+      copyFileSync(join(process.cwd(), 'node_modules', 'kiwi-nlp', 'dist', 'kiwi-wasm.wasm'), runtimeWasmPath);
+
+      const api = await createKiwiApi(runtime);
+
+      expect(api.cmd).toBeTypeOf('function');
+      expect(api.loadModelFiles).toBeTypeOf('function');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports every missing composite component through the public analyzer loader', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'coral-kiwi-loader-missing-'));
+    const runtime = createRealRuntime('prod', { baseDir: root });
+    try {
+      await expect(loadKiwiAnalyzer(runtime)).rejects.toThrow(
+        /Kiwi runtime artifacts are not installed \(model, wasm missing\).*coral-cli expansion equip kiwi/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces a structured install-path failure through the public analyzer loader', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'coral-kiwi-loader-install-error-'));
+    const runtime = createRealRuntime('prod', { baseDir: root });
+    vi.spyOn(runtime.storage, 'mkdirSync').mockImplementation(() => {
+      throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    });
+    try {
+      const failure = loadKiwiAnalyzer(runtime, { installIfMissing: true });
+      await expect(failure).rejects.toThrow(
+        /Cannot write to the Coral expansion install path for kiwi.*Check filesystem permissions and free space/s,
+      );
+      await expect(failure).rejects.toMatchObject({
+        cause: {
+          status: 'error',
+          code: 'expansion_install_path_unwritable',
+          context: { name: 'kiwi' },
+        },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/engines/kiwi/wasm-artifact.test.ts
+++ b/tests/unit/engines/kiwi/wasm-artifact.test.ts
@@ -1,0 +1,356 @@
+import {
+  chmodSync,
+  closeSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  KIWI_NLP_PACKAGE_INTEGRITY,
+  KIWI_NLP_PACKAGE_SIZE_BYTES,
+  KIWI_NLP_PACKAGE_URL,
+  KIWI_NLP_VERSION,
+  KIWI_WASM_TAR_ENTRY,
+  KIWI_WASM_SHA256,
+  KIWI_WASM_SIZE_BYTES,
+} from '#src/engines/kiwi/constants.js';
+import { kiwiWasmDir, kiwiWasmManifestPath, kiwiWasmPath } from '#src/engines/kiwi/paths.js';
+import {
+  ensureKiwiWasmArtifactLocked,
+  extractKiwiWasm,
+  inspectKiwiWasmArtifact,
+  publishKiwiWasmArtifact,
+  verifyKiwiNlpArchive,
+} from '#src/engines/kiwi/wasm-artifact.js';
+import { sha256Hex } from '#src/infra/hash.js';
+import { createRealRuntime } from '#src/runtime/real.js';
+
+const wasmFixture = readFileSync(join(process.cwd(), 'node_modules', 'kiwi-nlp', 'dist', 'kiwi-wasm.wasm'));
+
+function writeTarString(header: Buffer, value: string, offset: number, length: number): void {
+  Buffer.from(value, 'utf-8').copy(header, offset, 0, length);
+}
+
+function writeTarOctal(header: Buffer, value: number, offset: number, length: number): void {
+  Buffer.from(`${value.toString(8).padStart(length - 1, '0')}\0`, 'utf-8').copy(header, offset, 0, length);
+}
+
+function createTarHeader(name: string, size: number): Buffer {
+  const header = Buffer.alloc(512, 0);
+  writeTarString(header, name, 0, 100);
+  writeTarOctal(header, 0o644, 100, 8);
+  writeTarOctal(header, 0, 108, 8);
+  writeTarOctal(header, 0, 116, 8);
+  writeTarOctal(header, size, 124, 12);
+  writeTarOctal(header, 0, 136, 12);
+  header.fill(0x20, 148, 156);
+  header[156] = '0'.charCodeAt(0);
+  writeTarString(header, 'ustar', 257, 6);
+  writeTarString(header, '00', 263, 2);
+  let checksum = 0;
+  for (const byte of header) {
+    checksum += byte;
+  }
+  writeTarOctal(header, checksum, 148, 8);
+  return header;
+}
+
+function createWasmArchive(path = KIWI_WASM_TAR_ENTRY, payload = wasmFixture): Buffer {
+  const padding = Buffer.alloc((512 - (payload.length % 512)) % 512, 0);
+  return gzipSync(Buffer.concat([createTarHeader(path, payload.length), payload, padding, Buffer.alloc(1024)]), {
+    level: 1,
+  });
+}
+
+function createTestRuntime() {
+  const root = mkdtempSync(join(tmpdir(), 'coral-kiwi-wasm-'));
+  return {
+    root,
+    runtime: createRealRuntime('prod', { baseDir: root }),
+  };
+}
+
+describe('Kiwi WASM artifact', () => {
+  it('pins the installed glue and WASM to the declared version and digest', () => {
+    const projectPackage = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8')) as {
+      dependencies: Record<string, string>;
+    };
+    const lockfile = JSON.parse(readFileSync(join(process.cwd(), 'package-lock.json'), 'utf-8')) as {
+      packages: Record<
+        string,
+        {
+          version?: string;
+          resolved?: string;
+          integrity?: string;
+          dependencies?: Record<string, string>;
+        }
+      >;
+    };
+    const packageJson = JSON.parse(
+      readFileSync(join(process.cwd(), 'node_modules', 'kiwi-nlp', 'package.json'), 'utf-8'),
+    ) as { version: string };
+
+    expect(projectPackage.dependencies['kiwi-nlp']).toBe(KIWI_NLP_VERSION);
+    expect(lockfile.packages[''].dependencies?.['kiwi-nlp']).toBe(KIWI_NLP_VERSION);
+    expect(lockfile.packages['node_modules/kiwi-nlp']).toMatchObject({
+      version: KIWI_NLP_VERSION,
+      resolved: KIWI_NLP_PACKAGE_URL,
+      integrity: KIWI_NLP_PACKAGE_INTEGRITY,
+    });
+    expect(packageJson.version).toBe(KIWI_NLP_VERSION);
+    expect(wasmFixture).toHaveLength(KIWI_WASM_SIZE_BYTES);
+    expect(sha256Hex(wasmFixture)).toBe(KIWI_WASM_SHA256);
+  });
+
+  it('rejects archives before extraction when size or digest differs', () => {
+    expect(() => verifyKiwiNlpArchive(Buffer.alloc(1))).toThrow(/archive size mismatch/);
+    expect(() => verifyKiwiNlpArchive(Buffer.alloc(KIWI_NLP_PACKAGE_SIZE_BYTES))).toThrow(/archive digest mismatch/);
+  });
+
+  it('extracts only the exact WASM entry within the decompression bound', async () => {
+    const archive = createWasmArchive();
+
+    const extracted = await extractKiwiWasm(archive);
+    expect(extracted).toHaveLength(KIWI_WASM_SIZE_BYTES);
+    expect(sha256Hex(extracted)).toBe(KIWI_WASM_SHA256);
+    await expect(
+      extractKiwiWasm(createWasmArchive('package/dist/not-kiwi.wasm', Buffer.from('wrong'))),
+    ).rejects.toThrow(KIWI_WASM_TAR_ENTRY);
+    await expect(extractKiwiWasm(archive, 1024)).rejects.toThrow(/exceeds maximum decompressed size/);
+  });
+
+  it('distinguishes absent, non-regular, and wrong-size payload states', () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      expect(inspectKiwiWasmArtifact(runtime)).toMatchObject({
+        installed: false,
+        reason: 'file_missing',
+      });
+
+      mkdirSync(kiwiWasmPath(runtime), { recursive: true });
+      expect(inspectKiwiWasmArtifact(runtime)).toMatchObject({
+        installed: false,
+        reason: 'file_not_regular',
+      });
+
+      rmSync(kiwiWasmPath(runtime), { recursive: true, force: true });
+      writeFileSync(kiwiWasmPath(runtime), Buffer.alloc(1));
+      expect(inspectKiwiWasmArtifact(runtime)).toMatchObject({
+        installed: false,
+        reason: 'file_size_mismatch',
+      });
+
+      writeFileSync(kiwiWasmPath(runtime), Buffer.alloc(KIWI_WASM_SIZE_BYTES + 1));
+      expect(inspectKiwiWasmArtifact(runtime)).toMatchObject({
+        installed: false,
+        reason: 'file_size_mismatch',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('publishes a strongly validated payload and manifest', () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      const state = publishKiwiWasmArtifact(runtime, wasmFixture);
+
+      expect(state.installed).toBe(true);
+      expect(state.payloadSha256).toBe(KIWI_WASM_SHA256);
+      expect(sha256Hex(readFileSync(kiwiWasmPath(runtime)))).toBe(KIWI_WASM_SHA256);
+      expect(JSON.parse(readFileSync(kiwiWasmManifestPath(runtime), 'utf-8'))).toMatchObject({
+        schemaVersion: 1,
+        artifact: 'kiwi-wasm',
+        kiwiNlpVersion: KIWI_NLP_VERSION,
+        wasmSha256: KIWI_WASM_SHA256,
+      });
+      expect(readdirSync(kiwiWasmDir(runtime)).some((name) => name.endsWith('.tmp'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a same-size replacement whose digest changed', () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      publishKiwiWasmArtifact(runtime, wasmFixture);
+      const corrupt = Buffer.from(wasmFixture);
+      corrupt[corrupt.length - 1] ^= 0xff;
+      expect(runtime.storage.writeAtomicDurableSync(kiwiWasmPath(runtime), corrupt)).toBe(true);
+
+      expect(inspectKiwiWasmArtifact(runtime)).toMatchObject({
+        installed: false,
+        payloadValid: false,
+        reason: 'file_digest_mismatch',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rehashes a same-size in-place mutation even when its mtime is restored', () => {
+    const { root, runtime } = createTestRuntime();
+    const fixedTime = new Date('2026-01-01T00:00:00.000Z');
+    try {
+      publishKiwiWasmArtifact(runtime, wasmFixture);
+      const path = kiwiWasmPath(runtime);
+      utimesSync(path, fixedTime, fixedTime);
+      expect(inspectKiwiWasmArtifact(runtime).installed).toBe(true);
+
+      const descriptor = openSync(path, 'r+');
+      try {
+        writeSync(descriptor, Buffer.from([wasmFixture[0] ^ 0xff]), 0, 1, 0);
+      } finally {
+        closeSync(descriptor);
+      }
+      utimesSync(path, fixedTime, fixedTime);
+
+      expect(statSync(path).mtimeMs).toBe(fixedTime.getTime());
+      expect(inspectKiwiWasmArtifact(runtime)).toMatchObject({
+        installed: false,
+        payloadValid: false,
+        reason: 'file_digest_mismatch',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'does not reuse readiness after the payload becomes unreadable',
+    () => {
+      const { root, runtime } = createTestRuntime();
+      const path = kiwiWasmPath(runtime);
+      try {
+        publishKiwiWasmArtifact(runtime, wasmFixture);
+        chmodSync(path, 0o000);
+
+        expect(inspectKiwiWasmArtifact(runtime)).toMatchObject({
+          installed: false,
+          payloadValid: false,
+          reason: 'file_unreadable',
+        });
+
+        chmodSync(path, 0o644);
+        expect(inspectKiwiWasmArtifact(runtime).installed).toBe(true);
+      } finally {
+        try {
+          chmodSync(path, 0o644);
+        } catch {
+          // The fixture may already have been removed after an assertion failure.
+        }
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it('passes the pinned archive byte limit to the downloader before buffering', async () => {
+    const { root, runtime } = createTestRuntime();
+    const download = vi.fn(async (_runtime, url: string, options: { readonly maxBytes: number }) => {
+      expect(url).toBe(KIWI_NLP_PACKAGE_URL);
+      expect(options.maxBytes).toBe(KIWI_NLP_PACKAGE_SIZE_BYTES);
+      throw new Error('stop after bound assertion');
+    });
+    try {
+      await expect(ensureKiwiWasmArtifactLocked(runtime, { download })).rejects.toThrow('stop after bound assertion');
+      expect(download).toHaveBeenCalledTimes(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('repairs a directory occupying the canonical WASM file path', () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      mkdirSync(kiwiWasmPath(runtime), { recursive: true });
+
+      const state = publishKiwiWasmArtifact(runtime, wasmFixture);
+
+      expect(state.installed).toBe(true);
+      expect(statSync(kiwiWasmPath(runtime)).isFile()).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('repairs a directory occupying the manifest path without downloading again', async () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      publishKiwiWasmArtifact(runtime, wasmFixture);
+      rmSync(kiwiWasmManifestPath(runtime), { force: true });
+      mkdirSync(kiwiWasmManifestPath(runtime), { recursive: true });
+      const download = vi.fn();
+
+      const state = await ensureKiwiWasmArtifactLocked(runtime, { download });
+
+      expect(state.installed).toBe(true);
+      expect(statSync(kiwiWasmManifestPath(runtime)).isFile()).toBe(true);
+      expect(download).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when durable payload publication fails and leaves no manifest or temp file', () => {
+    const { root, runtime } = createTestRuntime();
+    const writeAtomicDurableSync = runtime.storage.writeAtomicDurableSync;
+    const writeSpy = vi.spyOn(runtime.storage, 'writeAtomicDurableSync');
+    try {
+      writeSpy.mockImplementation((path, data, options) =>
+        path === kiwiWasmPath(runtime) ? false : writeAtomicDurableSync(path, data, options),
+      );
+
+      expect(() => publishKiwiWasmArtifact(runtime, wasmFixture)).toThrow(/could not be published durably/);
+      expect(runtime.storage.existsSync(kiwiWasmManifestPath(runtime))).toBe(false);
+      expect(readdirSync(kiwiWasmDir(runtime)).some((name) => name.endsWith('.tmp'))).toBe(false);
+    } finally {
+      writeSpy.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers a file-before-manifest interruption without downloading again', async () => {
+    const { root, runtime } = createTestRuntime();
+    const writeAtomicDurableSync = runtime.storage.writeAtomicDurableSync;
+    const writeSpy = vi.spyOn(runtime.storage, 'writeAtomicDurableSync');
+    try {
+      writeSpy.mockImplementation((path, data, options) => {
+        if (path === kiwiWasmManifestPath(runtime)) {
+          return false;
+        }
+        return writeAtomicDurableSync(path, data, options);
+      });
+
+      expect(() => publishKiwiWasmArtifact(runtime, wasmFixture)).toThrow(/manifest could not be published/);
+      expect(inspectKiwiWasmArtifact(runtime)).toMatchObject({
+        installed: false,
+        payloadValid: true,
+        reason: 'manifest_missing_or_invalid',
+      });
+      expect(readdirSync(kiwiWasmDir(runtime)).some((name) => name.endsWith('.tmp'))).toBe(false);
+
+      writeSpy.mockRestore();
+      const download = vi.fn();
+      const recovered = await ensureKiwiWasmArtifactLocked(runtime, { download });
+
+      expect(recovered.installed).toBe(true);
+      expect(download).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/engines/kiwi/wasm-artifact.test.ts
+++ b/tests/unit/engines/kiwi/wasm-artifact.test.ts
@@ -163,6 +163,39 @@ describe('Kiwi WASM artifact', () => {
     }
   });
 
+  it('given a wrong-size payload, when publishing, then rejects before writing artifact files', () => {
+    const { root, runtime } = createTestRuntime();
+    try {
+      expect(() => publishKiwiWasmArtifact(runtime, Buffer.alloc(1))).toThrow(/WASM size mismatch/);
+      expect(runtime.storage.existsSync(kiwiWasmPath(runtime))).toBe(false);
+      expect(runtime.storage.existsSync(kiwiWasmManifestPath(runtime))).toBe(false);
+      expect(
+        runtime.storage.existsSync(kiwiWasmDir(runtime)) &&
+          readdirSync(kiwiWasmDir(runtime)).some((name) => name.endsWith('.tmp')),
+      ).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('given a wrong-digest payload, when publishing, then rejects before writing artifact files', () => {
+    const { root, runtime } = createTestRuntime();
+    const corrupt = Buffer.from(wasmFixture);
+    corrupt[corrupt.length - 1] ^= 0xff;
+    try {
+      expect(corrupt).toHaveLength(KIWI_WASM_SIZE_BYTES);
+      expect(() => publishKiwiWasmArtifact(runtime, corrupt)).toThrow(/WASM digest mismatch/);
+      expect(runtime.storage.existsSync(kiwiWasmPath(runtime))).toBe(false);
+      expect(runtime.storage.existsSync(kiwiWasmManifestPath(runtime))).toBe(false);
+      expect(
+        runtime.storage.existsSync(kiwiWasmDir(runtime)) &&
+          readdirSync(kiwiWasmDir(runtime)).some((name) => name.endsWith('.tmp')),
+      ).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('publishes a strongly validated payload and manifest', () => {
     const { root, runtime } = createTestRuntime();
     try {

--- a/tests/unit/engines/orama/analyzer-manager-ac14.test.ts
+++ b/tests/unit/engines/orama/analyzer-manager-ac14.test.ts
@@ -13,8 +13,8 @@ import type { OramaAnalyzerManager } from '#src/engines/orama/analyzer.js';
 import type { OramaTokenizerAnalyzer } from '#src/engines/orama/document-builder.js';
 import { oramaIndexMetadataPath } from '#src/engines/orama/paths.js';
 import { OramaSnapshotStore } from '#src/engines/orama/snapshot.js';
+import { kiwiArtifactStateKey } from '#src/engines/kiwi/artifact.js';
 import { KiwiAnalyzerManager } from '#src/engines/kiwi/analyzer-manager.js';
-import type { KiwiModelArtifactState } from '#src/engines/kiwi/model-artifact.js';
 import { createScope } from '#src/expansion/scope.js';
 import type { KbEngineRuntime, KbRuntime } from '#src/kb/contract.js';
 import { buildNoteIndexEntry } from '#src/kb/corpus/index/records.js';
@@ -24,6 +24,7 @@ import { createKbProjectionInput } from '#src/kb/projection-input.js';
 import { createRealRuntime } from '#src/runtime/real.js';
 import type { Runtime } from '#src/runtime/ports.js';
 import { createTestKbRuntime } from '#tests/fixtures/test-runtime.js';
+import { missingKiwiArtifactState } from '#tests/helpers/kiwi-artifact-state.js';
 import { createKbTestDb } from '#tests/unit/kb/runtime-test-helpers.js';
 
 const tempRoots: string[] = [];
@@ -49,16 +50,6 @@ function withKoEnv(runtime: Runtime): Runtime {
       fullSnapshot: () => ({ ...runtime.env.fullSnapshot(), CORAL_KB_EXTRA_LANGS: 'ko' }),
       coralSnapshot: () => ({ ...runtime.env.coralSnapshot(), CORAL_KB_EXTRA_LANGS: 'ko' }),
     },
-  };
-}
-
-function missingKiwiState(): KiwiModelArtifactState {
-  return {
-    targetDir: '/tmp/kiwi',
-    manifestPath: '/tmp/kiwi/manifest.json',
-    installed: false,
-    manifest: null,
-    missingFiles: ['cong.mdl'],
   };
 }
 
@@ -155,7 +146,7 @@ describe('Orama AC14 analyzer manager integration', () => {
       isTerminalLoadError: () => false,
     };
     const failingManager = new KiwiAnalyzerManager({
-      inspectModelArtifact: () => missingKiwiState(),
+      inspectArtifact: () => missingKiwiArtifactState(),
       loadAnalyzer: async () => {
         throw new Error('Kiwi model deleted');
       },
@@ -163,7 +154,7 @@ describe('Orama AC14 analyzer manager integration', () => {
     });
     const degradedEvents: string[] = [];
     failingManager.observeDegraded(createScope(), (event) => {
-      degradedEvents.push(event.modelStateKey);
+      degradedEvents.push(event.artifactStateKey);
     });
 
     const initialProjection = new OramaBaseProjection(kb, snapshotStore, {
@@ -193,7 +184,7 @@ describe('Orama AC14 analyzer manager integration', () => {
 
     expect(result.hits).toEqual([]);
     expect(failingManager.effectiveDeclaredAnalyzers(kb.declaredAnalyzers, runtime)).toEqual([]);
-    expect(degradedEvents).toEqual(['missing:cong.mdl']);
+    expect(degradedEvents).toEqual([kiwiArtifactStateKey(missingKiwiArtifactState())]);
     expect(requestedReasons).toEqual(['terminal-analyzer-failure', 'incompatible']);
     expect(searchingProjection.warnings()).toContain('fts_index_uninitialized');
     const persistedMetadata = readMetadata(kb);

--- a/tests/unit/engines/orama/script-router-ac12.test.ts
+++ b/tests/unit/engines/orama/script-router-ac12.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 
 import { KiwiAnalyzerManager } from '#src/engines/kiwi/analyzer-manager.js';
 import type { KiwiAnalyzer } from '#src/engines/kiwi/loader.js';
-import type { KiwiModelArtifactState } from '#src/engines/kiwi/model-artifact.js';
 import {
   createOramaDb,
   createOramaTokenizer,
@@ -13,6 +12,7 @@ import {
 } from '#src/engines/orama/document-builder.js';
 import { buildOramaSearchChannelFields } from '#src/engines/orama/search-channels.js';
 import type { Runtime } from '#src/runtime/ports.js';
+import { installedKiwiArtifactState } from '#tests/helpers/kiwi-artifact-state.js';
 
 function createRuntime(): Runtime {
   return {
@@ -34,26 +34,6 @@ function createRuntime(): Runtime {
   } as unknown as Runtime;
 }
 
-function installedKiwiState(): KiwiModelArtifactState {
-  return {
-    targetDir: '/tmp/kiwi',
-    manifestPath: '/tmp/kiwi/manifest.json',
-    installed: true,
-    missingFiles: [],
-    manifest: {
-      packageId: 'kiwi',
-      kiwiNlpVersion: '0.23.0',
-      modelVersion: '0.23.0',
-      modelType: 'cong-global',
-      sourceUrl: 'https://example.invalid/kiwi.tgz',
-      archiveSha256: 'digest',
-      archiveSizeBytes: 1,
-      files: [],
-      installedAt: '2026-06-19T00:00:00.000Z',
-    },
-  };
-}
-
 function createKiwiAnalyzer(): KiwiAnalyzer {
   return {
     identity: {
@@ -73,7 +53,7 @@ function createKiwiAnalyzer(): KiwiAnalyzer {
 
 function createManager(): KiwiAnalyzerManager {
   return new KiwiAnalyzerManager({
-    inspectModelArtifact: () => installedKiwiState(),
+    inspectArtifact: () => installedKiwiArtifactState(),
     loadAnalyzer: async () => createKiwiAnalyzer(),
     logger: () => {},
   });

--- a/tests/unit/expansion/activate.test.ts
+++ b/tests/unit/expansion/activate.test.ts
@@ -140,6 +140,31 @@ describe('expansion activation', () => {
     expect(request).toHaveBeenCalledWith('coordinator.equipExpansion', { name: 'onnx' }, undefined);
   });
 
+  it('exposes the complete Kiwi download disclosure through expansion info', async () => {
+    const activation = createCliExpansionActivation();
+
+    const result = await activation.info('kiwi');
+    expect(result).toMatchObject({
+      status: 'info',
+      package: {
+        id: 'kiwi',
+        activation: 'none',
+      },
+    });
+    expect(result.status).toBe('info');
+    if (result.status !== 'info') {
+      throw new Error('expected Kiwi info result');
+    }
+    if (!('confirmDownload' in result.package) || typeof result.package.confirmDownload !== 'string') {
+      throw new Error('expected Kiwi confirmDownload disclosure');
+    }
+    const message = result.package.confirmDownload;
+    expect(message).toContain('missing or invalid Kiwi artifacts');
+    expect(message).toContain('~88 MB CoNg base model from GitHub Releases');
+    expect(message).toContain('~0.9 MB pinned kiwi-nlp archive from npm');
+    expect(message).toContain('A valid existing model is preserved');
+  });
+
   it('surfaces activation failures instead of collapsing them to unavailable', async () => {
     const activation = createCliExpansionActivation();
     const error = Object.assign(new Error('coordinator.equipExpansion failed'), { code: 'boom' });

--- a/tests/unit/expansion/contracts-parity.test.ts
+++ b/tests/unit/expansion/contracts-parity.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   catalogEntrySchema,
   catalogEntryStatusSchema,
+  installMethodSchema,
   installResultSchema,
   removeExpansionCatalogResultSchema,
 } from '#src/expansion/rpc-contract.js';
@@ -71,7 +72,7 @@ describe('expansion contracts parity', () => {
     }
   });
 
-  it('keeps install-only consent and runtime-download routing inside the update protocol', () => {
+  it('keeps install-only consent and schema methods routed through the shared protocol', () => {
     expect(
       catalogEntrySchema.parse({
         id: 'kiwi',
@@ -85,35 +86,39 @@ describe('expansion contracts parity', () => {
     ).toMatchObject({
       confirmDownload: 'Download the pinned runtime artifacts?',
     });
+
     const equipSection = skillSection('### `<package>`', '### `--update <package>`');
     expect(equipSection).toContain('the current entry includes `confirmDownload`');
     expect(equipSection).toContain('show that message exactly');
-    expect(equipSection).toContain("`method: 'runtime-download'`");
-    expect(equipSection).toContain('`targetDir`');
-    expect(equipSection).toContain('`command`');
-    expect(equipSection).toContain('`installed`');
-    expect(equipSection).toContain('`updated`');
-    expect(equipSection).toContain('no coding-agent restart is required');
-    expect(equipSection).toContain('When `ko` is enabled and the backend is active');
-    expect(equipSection).toContain('this command started neither a download nor a reindex');
-    expect(equipSection).toContain('Do not promise an analyzer upgrade');
-    expect(equipSection).toContain('`coral-cli backend shutdown`');
+    expect(equipSection).toContain('shared install-only result routing');
 
-    const updateSection = skillSection('### `--update <package>`', '### `info <package>`');
+    const updateSection = skillSection('### `--update <package>`', '#### Shared install-only result routing');
     expect(updateSection).toContain('`confirmDownload`');
     expect(updateSection).toContain('show that message exactly');
-    expect(updateSection).toContain("`method: 'runtime-download'`");
-    expect(updateSection).toContain('`targetDir`');
-    expect(updateSection).toContain('`command`');
-    expect(updateSection).toContain('no coding-agent restart is required');
-    expect(updateSection).toContain('only when `ko` is enabled and the backend is active');
-    expect(updateSection).toContain('`installed`');
-    expect(updateSection).toContain('`updated`');
-    expect(updateSection).toContain('`already_installed`');
-    expect(updateSection).toContain('`already_up_to_date`');
-    expect(updateSection).toContain('For `installed` and `updated`');
-    expect(updateSection).toContain('this command started neither a download nor a reindex');
-    expect(updateSection).toContain('do not promise an analyzer upgrade');
+    expect(updateSection).toContain('shared install-only result routing');
+
+    const sharedRoutingSection = skillSection('#### Shared install-only result routing', '### `info <package>`');
+    const explicitlyRoutedMethods = [...sharedRoutingSection.matchAll(/`method: '([^']+)'`/g)].map((match) => match[1]);
+    const schemaMethods = new Set<string>(installMethodSchema.options);
+
+    expect(explicitlyRoutedMethods.length).toBeGreaterThan(0);
+    for (const method of explicitlyRoutedMethods) {
+      expect(schemaMethods.has(method)).toBe(true);
+    }
+    for (const method of installMethodSchema.options) {
+      if (!explicitlyRoutedMethods.includes(method)) {
+        expect(updateSection).toContain(method);
+      }
+    }
+
+    expect(sharedRoutingSection).toContain('- Other methods:');
+    expect(sharedRoutingSection).toContain('`targetDir`');
+    expect(sharedRoutingSection).toContain('`command`');
+    expect(sharedRoutingSection).toContain('no coding-agent restart is required');
+    expect(sharedRoutingSection).toContain('When `ko` is enabled and the backend is active');
+    expect(sharedRoutingSection).toContain('this command started neither a download nor a reindex');
+    expect(sharedRoutingSection).toContain('Do not promise an analyzer upgrade');
+    expect(sharedRoutingSection).toContain('`coral-cli backend shutdown`');
 
     const infoSection = skillSection('### `info <package>`', '### `uninstall <equipment-name>`');
     expect(infoSection).toContain('`confirmDownload`');

--- a/tests/unit/expansion/contracts-parity.test.ts
+++ b/tests/unit/expansion/contracts-parity.test.ts
@@ -105,10 +105,11 @@ describe('expansion contracts parity', () => {
     for (const method of explicitlyRoutedMethods) {
       expect(schemaMethods.has(method)).toBe(true);
     }
-    for (const method of installMethodSchema.options) {
-      if (!explicitlyRoutedMethods.includes(method)) {
-        expect(updateSection).toContain(method);
-      }
+    const hasImplicitlyRoutedMethods = installMethodSchema.options.some(
+      (method) => !explicitlyRoutedMethods.includes(method),
+    );
+    if (hasImplicitlyRoutedMethods) {
+      expect(sharedRoutingSection).toContain('- Other methods:');
     }
 
     expect(sharedRoutingSection).toContain('- Other methods:');

--- a/tests/unit/expansion/contracts-parity.test.ts
+++ b/tests/unit/expansion/contracts-parity.test.ts
@@ -15,6 +15,14 @@ function sort(values: readonly string[]): string[] {
   return [...values].sort();
 }
 
+function skillSection(heading: string, nextHeading: string): string {
+  const start = SKILL_MD.indexOf(heading);
+  const end = SKILL_MD.indexOf(nextHeading, start + heading.length);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return SKILL_MD.slice(start, end);
+}
+
 describe('expansion contracts parity', () => {
   it('keeps every install result status routed in skills/equip/SKILL.md', () => {
     const statuses = sort(installResultSchema.options.map((option) => option.shape.status.value));
@@ -61,6 +69,54 @@ describe('expansion contracts parity', () => {
     for (const status of statuses) {
       expect(SKILL_MD).toContain(`\`${status}\``);
     }
+  });
+
+  it('keeps install-only consent and runtime-download routing inside the update protocol', () => {
+    expect(
+      catalogEntrySchema.parse({
+        id: 'kiwi',
+        name: 'kiwi',
+        description: 'Korean analyzer',
+        activation: 'none',
+        status: 'not_installed',
+        version: '0.23.0',
+        confirmDownload: 'Download the pinned runtime artifacts?',
+      }),
+    ).toMatchObject({
+      confirmDownload: 'Download the pinned runtime artifacts?',
+    });
+    const equipSection = skillSection('### `<package>`', '### `--update <package>`');
+    expect(equipSection).toContain('the current entry includes `confirmDownload`');
+    expect(equipSection).toContain('show that message exactly');
+    expect(equipSection).toContain("`method: 'runtime-download'`");
+    expect(equipSection).toContain('`targetDir`');
+    expect(equipSection).toContain('`command`');
+    expect(equipSection).toContain('`installed`');
+    expect(equipSection).toContain('`updated`');
+    expect(equipSection).toContain('no coding-agent restart is required');
+    expect(equipSection).toContain('When `ko` is enabled and the backend is active');
+    expect(equipSection).toContain('this command started neither a download nor a reindex');
+    expect(equipSection).toContain('Do not promise an analyzer upgrade');
+    expect(equipSection).toContain('`coral-cli backend shutdown`');
+
+    const updateSection = skillSection('### `--update <package>`', '### `info <package>`');
+    expect(updateSection).toContain('`confirmDownload`');
+    expect(updateSection).toContain('show that message exactly');
+    expect(updateSection).toContain("`method: 'runtime-download'`");
+    expect(updateSection).toContain('`targetDir`');
+    expect(updateSection).toContain('`command`');
+    expect(updateSection).toContain('no coding-agent restart is required');
+    expect(updateSection).toContain('only when `ko` is enabled and the backend is active');
+    expect(updateSection).toContain('`installed`');
+    expect(updateSection).toContain('`updated`');
+    expect(updateSection).toContain('`already_installed`');
+    expect(updateSection).toContain('`already_up_to_date`');
+    expect(updateSection).toContain('For `installed` and `updated`');
+    expect(updateSection).toContain('this command started neither a download nor a reindex');
+    expect(updateSection).toContain('do not promise an analyzer upgrade');
+
+    const infoSection = skillSection('### `info <package>`', '### `uninstall <equipment-name>`');
+    expect(infoSection).toContain('`confirmDownload`');
   });
 
   it('keeps capability descriptors and runtime status as separate catalog entry siblings', () => {

--- a/tests/unit/expansion/install.test.ts
+++ b/tests/unit/expansion/install.test.ts
@@ -1,11 +1,14 @@
-import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { inspectKiwiArtifact } from '#src/engines/kiwi/artifact.js';
 import { kiwiInstaller } from '#src/engines/kiwi/install.js';
 import { writeKiwiModelFilesAtomicInWorker } from '#src/engines/kiwi/model-artifact.js';
+import { kiwiWasmManifestPath } from '#src/engines/kiwi/paths.js';
+import { publishKiwiWasmArtifact } from '#src/engines/kiwi/wasm-artifact.js';
 import { KIWI_MODEL_FILES, type KiwiModelFileName } from '#src/engines/kiwi/constants.js';
 import { installResponseSchema } from '#src/expansion/rpc-contract.js';
 import { enginePaths } from '#src/infra/path/engine.js';
@@ -80,10 +83,21 @@ describe('installExpansion', () => {
       KIWI_MODEL_FILES.map((fileName) => [fileName, Buffer.from(`installed:${fileName}`, 'utf-8')]),
     );
     await writeKiwiModelFilesAtomicInWorker(runtime, files);
+    publishKiwiWasmArtifact(
+      runtime,
+      readFileSync(join(process.cwd(), 'node_modules', 'kiwi-nlp', 'dist', 'kiwi-wasm.wasm')),
+    );
+    rmSync(kiwiWasmManifestPath(runtime));
+    expect(inspectKiwiArtifact(runtime)).toMatchObject({
+      ready: false,
+      model: { installed: true },
+      wasm: { installed: false, payloadValid: true },
+    });
 
     await expect(installExpansion('kiwi', { runtime })).resolves.toMatchObject({
-      status: 'already_installed',
+      status: 'installed',
     });
+    expect(inspectKiwiArtifact(runtime).ready).toBe(true);
   });
 
   it.each([
@@ -131,6 +145,33 @@ describe('installExpansion', () => {
 });
 
 describe('Kiwi direct installer boundary', () => {
+  it('reports legacy model-only durable state separately from composite readiness', async () => {
+    const fixture = createFixture();
+    const runtime = createRuntimeForFixture(fixture);
+    const files = new Map<KiwiModelFileName, Buffer>(
+      KIWI_MODEL_FILES.map((fileName) => [fileName, Buffer.from(`installed:${fileName}`, 'utf-8')]),
+    );
+    await writeKiwiModelFilesAtomicInWorker(runtime, files);
+
+    expect(kiwiInstaller.inspect(runtime, 'kiwi')).toMatchObject({
+      installed: false,
+      version: null,
+      method: null,
+      durableState: true,
+    });
+
+    publishKiwiWasmArtifact(
+      runtime,
+      readFileSync(join(process.cwd(), 'node_modules', 'kiwi-nlp', 'dist', 'kiwi-wasm.wasm')),
+    );
+    expect(kiwiInstaller.inspect(runtime, 'kiwi')).toMatchObject({
+      installed: true,
+      version: '0.23.0',
+      method: 'runtime-download',
+      durableState: true,
+    });
+  });
+
   it('rejects a foreign package identity before touching Kiwi data', async () => {
     const fixture = createFixture();
     const runtime = createRuntimeForFixture(fixture);

--- a/tests/unit/expansion/install.test.ts
+++ b/tests/unit/expansion/install.test.ts
@@ -10,7 +10,7 @@ import { writeKiwiModelFilesAtomicInWorker } from '#src/engines/kiwi/model-artif
 import { kiwiWasmManifestPath } from '#src/engines/kiwi/paths.js';
 import { publishKiwiWasmArtifact } from '#src/engines/kiwi/wasm-artifact.js';
 import { KIWI_MODEL_FILES, type KiwiModelFileName } from '#src/engines/kiwi/constants.js';
-import { installResponseSchema } from '#src/expansion/rpc-contract.js';
+import { installResponseSchema, type InstallMethod } from '#src/expansion/rpc-contract.js';
 import { enginePaths } from '#src/infra/path/engine.js';
 import { acquirePackageOperationLockAtPath } from '#src/infra/package-operation-lock.js';
 import { createRealRuntime } from '#src/runtime/real.js';
@@ -18,6 +18,7 @@ import type { Runtime } from '#src/runtime/ports.js';
 import { installExpansion } from '#src/cli/expansion/install.js';
 
 const createdRoots: string[] = [];
+const kiwiInstallMethod = 'runtime-download' satisfies InstallMethod;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -105,7 +106,7 @@ describe('installExpansion', () => {
       label: 'non-canonical target directory',
       result: (runtime: Runtime) => ({
         status: 'installed' as const,
-        method: 'fixture',
+        method: kiwiInstallMethod,
         targetDir: join(runtime.paths.coral.engine.dataDir('kiwi'), '..', 'other'),
       }),
       message: /non-canonical target directory/u,
@@ -114,7 +115,7 @@ describe('installExpansion', () => {
       label: 'absolute manifest path',
       result: (runtime: Runtime) => ({
         status: 'installed' as const,
-        method: 'fixture',
+        method: kiwiInstallMethod,
         targetDir: runtime.paths.coral.engine.dataDir('kiwi'),
         postInstall: [
           { action: 'register_expansion' as const, manifestPath: join(fixtureAbsoluteRoot(), 'manifest.json') },
@@ -135,7 +136,7 @@ describe('installExpansion', () => {
     const runtime = createRuntimeForFixture(fixture);
     vi.spyOn(kiwiInstaller, 'install').mockResolvedValue({
       status: 'installed',
-      method: 'fixture',
+      method: kiwiInstallMethod,
       targetDir: runtime.paths.coral.engine.dataDir('kiwi'),
       postInstall: ['register_expansion'],
     });

--- a/tests/unit/kb-daemon/expansion/retirement.test.ts
+++ b/tests/unit/kb-daemon/expansion/retirement.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createExpansionManifestCatalog } from '#src/expansion/manifest/catalog.js';
 import { installExpansion } from '#src/cli/expansion/install.js';
 import { kiwiInstaller } from '#src/engines/kiwi/install.js';
+import type { InstallMethod } from '#src/expansion/rpc-contract.js';
 import { cleanupRetiredExpansion } from '#src/kb-daemon/expansion/retirement.js';
 import { ExpansionStateStore } from '#src/kb-daemon/expansion/state.js';
 import { ConsumerDriver } from '#src/projection-consumers/index.js';
@@ -18,6 +19,7 @@ import { newRawDatabase } from '#tests/helpers/test-db.js';
 
 const roots: string[] = [];
 const databases: Database[] = [];
+const kiwiInstallMethod = 'runtime-download' satisfies InstallMethod;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -170,7 +172,7 @@ describe('retired expansion cleanup', () => {
       expect(options.operationLockHeld).toBe(true);
       enteredInstall();
       await installFinished;
-      return { status: 'already_installed', method: 'fixture', version: '1.0.0' };
+      return { status: 'already_installed', method: kiwiInstallMethod, version: '1.0.0' };
     });
 
     const installing = installExpansion('kiwi', { runtime: fixture.runtime, lockTimeoutMs: 50 });

--- a/tests/unit/kb-daemon/runtime-host.test.ts
+++ b/tests/unit/kb-daemon/runtime-host.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createKbDaemonWriteRuntimeHost } from '#src/kb-daemon/runtime-host.js';
+import type { KiwiSearchAnalyzerPort } from '#src/kb-daemon/expansion/bundled-loaders.js';
 import { ORAMA_BASE_CONSUMER_ID } from '#src/engines/orama/constants.js';
 import { oramaIndexMetadataPath, oramaIndexPath } from '#src/engines/orama/paths.js';
 import { KB_FTS_CAPABILITY } from '#src/kb/capability/constants.js';
@@ -99,7 +100,7 @@ function readImportPath(value: unknown): string {
 describe('KB daemon runtime host', () => {
   beforeEach(() => {
     // Neutralize an ambient CORAL_KB_EXTRA_LANGS=ko so build()'s background Kiwi
-    // boot fetch can never reach a real 88MB network download from a unit test,
+    // boot fetch can never reach real ~89MB artifact downloads from a unit test,
     // regardless of the runner's shell.
     vi.stubEnv('CORAL_KB_EXTRA_LANGS', '');
   });
@@ -136,6 +137,82 @@ describe('KB daemon runtime host', () => {
 
       expect(runtime.storage.existsSync(stagedDir)).toBe(false);
       expect(runtime.storage.existsSync(pdfDir)).toBe(false);
+    } finally {
+      await host.dispose().catch(() => undefined);
+      db.close();
+      rmSync(runtimeDir, { recursive: true, force: true });
+      while (tempRoots.length > 0) {
+        rmSync(tempRoots.pop()!, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('admits search while Kiwi is degraded to the Intl baseline', async () => {
+    const root = createTempRoot();
+    vi.stubEnv('CLAUDE_CONFIG_DIR', join(root, '.claude'));
+    const runtime = createRealRuntime('prod', { baseDir: root });
+    const db = openTestStoreDb(runtime, ':memory:');
+    const pluginRoot = join(root, 'plugin');
+    const runtimeDir = kbRuntimeDir(runtime.flavor);
+    const kiwiAnalyzer = {
+      leaseReadiness: () => ({
+        ready: true as const,
+        state: 'degraded' as const,
+        reason: 'Kiwi WASM artifact is still downloading',
+      }),
+      withAnalyzerLease: async (_runtime, declaredAnalyzers, run) =>
+        run({ analyzer: null, activeAnalyzers: declaredAnalyzers.filter((analyzer) => analyzer !== 'ko') }),
+    } satisfies KiwiSearchAnalyzerPort;
+    const host = createKbDaemonWriteRuntimeHost({
+      pluginRoot,
+      backendNamespace: 'test-namespace',
+      bundleHash: 'test-bundle',
+      curateUsageBudget: { isExhausted: async () => false },
+      runtime,
+      db,
+      kiwiAnalyzer,
+    });
+
+    try {
+      await host.withKb(() => undefined);
+
+      expect(host.searchReadiness()).toEqual({ ready: true });
+    } finally {
+      await host.dispose().catch(() => undefined);
+      db.close();
+      rmSync(runtimeDir, { recursive: true, force: true });
+      while (tempRoots.length > 0) {
+        rmSync(tempRoots.pop()!, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('aborts Kiwi boot recovery when disposal begins during initialization', async () => {
+    const root = createTempRoot();
+    vi.stubEnv('CLAUDE_CONFIG_DIR', join(root, '.claude'));
+    vi.stubEnv('CORAL_KB_EXTRA_LANGS', 'ko');
+    const runtime = createRealRuntime('prod', { baseDir: root });
+    const db = openTestStoreDb(runtime, ':memory:');
+    const pluginRoot = join(root, 'plugin');
+    const runtimeDir = kbRuntimeDir(runtime.flavor);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('unexpected Kiwi download'));
+    const host = createKbDaemonWriteRuntimeHost({
+      pluginRoot,
+      backendNamespace: 'test-namespace',
+      bundleHash: 'test-bundle',
+      curateUsageBudget: { isExhausted: async () => false },
+      runtime,
+      db,
+    });
+
+    try {
+      const initialization = host.withKb(() => undefined);
+      const disposal = host.dispose();
+
+      await expect(initialization).resolves.toBeUndefined();
+      await expect(disposal).resolves.toBeUndefined();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(host.health()).toEqual({ phase: 'disposed', initializedAt: expect.any(Number) });
     } finally {
       await host.dispose().catch(() => undefined);
       db.close();

--- a/tests/unit/kb/search/korean-snippet.test.ts
+++ b/tests/unit/kb/search/korean-snippet.test.ts
@@ -5,7 +5,6 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { KiwiAnalyzerManager } from '#src/engines/kiwi/analyzer-manager.js';
 import type { KiwiAnalyzer } from '#src/engines/kiwi/loader.js';
-import type { KiwiModelArtifactState } from '#src/engines/kiwi/model-artifact.js';
 import { searchKb } from '#src/kb/ops/search.js';
 import { noteEntryId, type KbResult } from '#src/kb/entry-types.js';
 import { buildNoteIndexEntry } from '#src/kb/corpus/index/records.js';
@@ -15,6 +14,7 @@ import type { Runtime } from '#src/runtime/ports.js';
 import { bindOramaFtsForTest } from '#tests/unit/kb/expansion-test-helpers.js';
 import { createKbTestDb } from '#tests/unit/kb/runtime-test-helpers.js';
 import { applyBoundCorpusConsumerForTest, createKbTestRuntime } from '#tests/helpers/kb-test-runtime.js';
+import { installedKiwiArtifactState } from '#tests/helpers/kiwi-artifact-state.js';
 
 const tempRoots: string[] = [];
 
@@ -42,26 +42,6 @@ function withKoEnv(runtime: Runtime): Runtime {
   };
 }
 
-function installedKiwiState(): KiwiModelArtifactState {
-  return {
-    targetDir: '/tmp/kiwi',
-    manifestPath: '/tmp/kiwi/manifest.json',
-    installed: true,
-    missingFiles: [],
-    manifest: {
-      packageId: 'kiwi',
-      kiwiNlpVersion: '0.23.0',
-      modelVersion: '0.23.0',
-      modelType: 'cong-global',
-      sourceUrl: 'https://example.invalid/kiwi.tgz',
-      archiveSha256: 'digest',
-      archiveSizeBytes: 1,
-      files: [],
-      installedAt: '2026-06-19T00:00:00.000Z',
-    },
-  };
-}
-
 function createLemmaKiwiAnalyzer(): KiwiAnalyzer {
   return {
     identity: {
@@ -84,7 +64,7 @@ function createLemmaKiwiAnalyzer(): KiwiAnalyzer {
 
 function createLemmaKiwiManager(): KiwiAnalyzerManager {
   return new KiwiAnalyzerManager({
-    inspectModelArtifact: () => installedKiwiState(),
+    inspectArtifact: () => installedKiwiArtifactState(),
     loadAnalyzer: async () => createLemmaKiwiAnalyzer(),
     logger: () => {},
   });

--- a/tests/unit/runtime/errors.test.ts
+++ b/tests/unit/runtime/errors.test.ts
@@ -50,6 +50,12 @@ describe('CoralSetupError', () => {
       'Wait for the in-flight operation to complete, then retry. If this persists after ten minutes with no Coral process running, report the JSON error code and context; do not delete a live lock.',
     ],
     [
+      'expansion_install_artifact_failed',
+      { name: 'kiwi', detail: 'archive digest mismatch' },
+      'Coral could not install the runtime artifacts for kiwi.',
+      "archive digest mismatch\nCheck network access, filesystem permissions, and free space, then retry 'coral-cli expansion equip kiwi'.",
+    ],
+    [
       'expansion_binary_corrupt',
       { name: 'vector' },
       'The installed binary for vector could not be activated.',

--- a/vitest/default.ts
+++ b/vitest/default.ts
@@ -17,6 +17,12 @@ export default defineConfig({
     exclude: ['ref/**', 'node_modules/**'],
     setupFiles: ['vitest/setup.ts'],
     globalSetup: ['vitest/no-real-coral-leak.ts'],
+    // Deliberate budget, not vitest's 5s default. This suite is I/O-bound with workers oversubscribed (see
+    // below), and cases that reset the module registry to swap module doubles re-execute a large graph inside
+    // their own budget — measured ~0.7-1.5s idle and roughly 2x that under contention. 5s left as little as a
+    // 1.6x margin, which surfaced as intermittent "timed out in 5000ms" failures in tests/unit/cli. Still
+    // short enough to fail a genuinely hung test promptly.
+    testTimeout: 15_000,
     // This suite is I/O-bound (IPC sockets, subprocess spawns, timers), so on a
     // 2-core CI runner it is worker-bound rather than core-bound: oversubscribing
     // workers overlaps the I/O waits (measured ~1m11s @2 → ~38s @4). Applied only


### PR DESCRIPTION
## Summary

- download the pinned `kiwi-nlp` archive at runtime, validate its integrity and expected WASM entry, and publish the payload and manifest durably without rewriting a valid CoNg model
- treat the model and WASM as one Kiwi runtime artifact under a shared package lock, wire Emscripten to the runtime path, and recover terminal analyzer degradation with bounded boot retry and lifecycle-safe reindexing
- expose structured install remediation and accurate equip/info consent, including changed versus no-change outcomes and conditional live-reindex behavior
- share production esbuild options with an isolated initializer verifier while preserving the exact four-file staging/release inventory

## Validation

- `npm test` — default tier: 438 files / 4,309 tests; simulation tier passed
- focused Kiwi regression suite — 10 files / 88 tests
- `npm run typecheck:tests`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run verify:store-reset-build`
- `npm run verify:kiwi-runtime-build`
- `CORAL_TEST_NETWORK=1 npx vitest run --config vitest/integration.ts tests/integration/engines/kiwi-runtime-download.integration.test.ts`

`clients/bridge` is intentionally unchanged on this feature branch; the Release workflow owns regeneration and byte/package verification.
