### PR TITLE
fix: restore Claude subscription execution

### DIFF
--- a/docs/plans/claude-print-session-regression.md
+++ b/docs/plans/claude-print-session-regression.md
@@ -1,0 +1,82 @@
+# Claude Print-Mode New Session Regression
+
+## Status
+
+Implemented and verified on `fix/claude-subscription-auth` on 2026-07-31.
+
+## Reproduction
+
+The development bundle was built from the working tree and invoked directly:
+
+```bash
+npm run build:dev
+node clients/build/coral-cli.cjs claude -i "hello"
+```
+
+The environment had no `ANTHROPIC_API_KEY`; `claude auth status --json`
+reported a logged-in Claude.ai subscription. Authentication preflight passed,
+then Claude Code 2.1.220 rejected session initialization:
+
+```text
+No conversation found with session ID: <new-provider-session-id>
+```
+
+## Root Cause
+
+An `exec` request intentionally uses its new Coral provider session ID as the
+requested Claude conversation reference and marks `resumeExisting` false.
+
+The TUI child argument builder already preserves that distinction:
+
+- new reference: `--session-id <id>`
+- existing reference: `--resume <id>`
+
+The default print transport did not. Its spawn contract carried the reference
+but not the new-versus-resume intent, and its argument builder interpreted every
+reference as `--resume`. A fresh `exec` therefore asked Claude to resume a
+conversation that could not yet exist.
+
+This is separate from authentication-status parsing. The subscription profile
+was authenticated successfully before the failing session bootstrap.
+
+## Fix
+
+1. Add an explicit `resume` boolean to the print child spawn contract.
+2. Forward `SessionEnsureParams.resumeExisting` through
+   `PrintSessionController`.
+3. Build print child arguments as follows:
+   - no conversation reference: no session-selection flag
+   - reference with `resume: false`: `--session-id <id>`
+   - reference with `resume: true`: `--resume <id>`
+4. Test both argument generation and controller-to-spawn intent propagation.
+
+## Verification
+
+```bash
+npx vitest run --config vitest/default.ts \
+  tests/unit/providers/claude/appserver/server.test.ts \
+  tests/unit/providers/claude/appserver/print-controller.test.ts \
+  tests/unit/providers/claude/request-mapping.test.ts \
+  tests/unit/providers/claude/cli-detection.test.ts \
+  tests/unit/providers/claude/provider-facets.test.ts
+
+npx vitest run --config vitest/default.ts \
+  tests/unit/providers/claude/appserver \
+  tests/unit/providers/claude/one-shot.test.ts \
+  tests/unit/providers/claude/session-kernel.diagnostic.test.ts \
+  tests/unit/providers/claude/request-mapping.test.ts
+
+npm run typecheck:tests
+npm run build:dev
+node clients/build/coral-cli.cjs claude -i "hello"
+```
+
+Results:
+
+- focused regression group: 81 tests passed
+- Claude appserver regression group: 101 tests passed
+- changed-file ESLint, Prettier, and `git diff --check`: passed
+- TypeScript test typecheck: passed
+- development bundle build: passed
+- repository standard test suite: 428 files and 4,147 tests passed
+- live bundled command: completed successfully and returned a Claude response

--- a/docs/plans/claude-subscription-auth-regression.md
+++ b/docs/plans/claude-subscription-auth-regression.md
@@ -1,0 +1,287 @@
+# Claude Subscription Authentication Status Fix
+
+## Status
+
+Implemented and verified on `fix/claude-subscription-auth`. Three independent
+pre-implementation reviews covered authentication semantics, regression tests,
+and architecture. See [Incident Relationship](#incident-relationship) for the
+limit on causal claims.
+
+## Problem
+
+Claude.ai subscription users authenticate Claude Code without
+`ANTHROPIC_API_KEY`. The sanitized output supplied for this investigation is
+shaped like:
+
+```json
+{ "loggedIn": true, "authMethod": "claude.ai" }
+```
+
+Coral's Claude auth parser does not recognize `loggedIn`. It recognizes only
+`authenticated`, `status`, and `auth_status`, so both `loggedIn: true` and
+`loggedIn: false` become `unknown`.
+
+The string fallback also uses positive substring matching before negative
+matching. It therefore classifies `unauthenticated` as authenticated because it
+contains `authenticated`, and `inactive` as authenticated because it contains
+`active`.
+
+These are confirmed authentication-status correctness bugs.
+
+## Incident Relationship
+
+- The `.claude/.gitignore` migration is unrelated.
+- The v0.10 provider-binding work made authentication and profile routing more
+  prominent, but the parser flaw itself existed in v0.9.
+- At the time of this parser correction, no target stderr or target environment
+  was available, so this implementation alone was not a confirmed fix for the
+  original command failure.
+- A subsequent bundled live reproduction established the separate runtime root
+  cause: the default print transport treated a fresh conversation reference as
+  `--resume` instead of `--session-id`. See
+  [Claude Print-Mode New Session Regression](./claude-print-session-regression.md).
+
+## Goals
+
+- Recognize current Claude Code `loggedIn` boolean output.
+- Preserve API-key-free Claude.ai subscription operation.
+- Eliminate positive-substring collisions in legacy string statuses.
+- Treat contradictory recognized fields as unknown rather than selecting one by
+  arbitrary precedence.
+- Preserve current preflight compatibility for unknown output.
+- Add realistic, sanitized regression fixtures through both detector and
+  preflight boundaries.
+
+## Non-goals
+
+- Changing `unknown` from fail-open to fail-closed.
+- Adding typed unknown reasons or new preflight error policy.
+- Making the generic detector's `authEnvVar` optional.
+- Supporting or changing API-key, gateway, Bedrock, Vertex, Foundry, or OAuth
+  environment-variable routing.
+- Changing provider binding, execution plans, profile routing, or
+  `.claude/.gitignore`.
+- Adding a live Claude request to automated CI.
+
+## Compatibility Decisions
+
+### Unknown remains compatible
+
+`unknown` currently combines unrecognized JSON, malformed output, unsupported
+commands, timeouts, process errors, and unrelated nonzero exits. Rejecting the
+entire category would be a separate compatibility and policy change.
+
+This fix retains the existing behavior: only explicit unauthenticated evidence
+is rejected by preflight.
+
+### The generic API-key shortcut remains unchanged
+
+The generic detector supports `authEnvVar`, but Claude's v0.10 preflight gives
+the detector only profile-routing environment (`HOME` or
+`CLAUDE_CONFIG_DIR`). Raw credential selectors are rejected earlier by the
+binding layer. The Claude API-key shortcut is therefore unreachable on the
+normal execution path and cannot explain API-key-free subscription failure.
+
+Changing the generic detector would broaden this patch without changing the
+runtime path, so it is deferred.
+
+### `authMethod` remains metadata
+
+This parser determines only whether the selected Claude profile reports a
+logged-in state. It does not use `authMethod` to choose or route credentials.
+Credential-mode policy remains in the binding and settings validation layers.
+
+## Design
+
+### 1. Collect recognized boolean evidence
+
+Recognize boolean values from:
+
+- `loggedIn`, emitted by current Claude Code
+- `authenticated`, retained for compatibility
+
+Do not use precedence. Collect all recognized evidence and return `unknown` if
+the fields conflict.
+
+### 2. Parse string statuses with normalized exact membership
+
+Read string values from both `status` and `auth_status`. Normalize by trimming,
+lowercasing, and replacing runs of whitespace or hyphens with `_`.
+
+Retain the intended compatibility vocabulary of the existing parser without
+substring matching.
+
+Authenticated:
+
+- `authenticated`
+- `logged_in`
+- `loggedin`
+- `active`
+
+Unauthenticated:
+
+- `unauthenticated`
+- `logged_out`
+- `loggedout`
+- `not_authenticated`
+- `missing`
+- `expired`
+- `inactive`
+
+Unrecognized strings add no evidence. For parseable JSON, conflicting or absent
+recognized evidence returns an explicit `unknown` result so the generic
+plain-text error fallback cannot reinterpret JSON contents. Multiple fields that
+agree return that shared state. Non-JSON output remains eligible for the
+existing plain-text fallback.
+
+### 3. Keep existing preflight policy
+
+- `authenticated` proceeds.
+- `unauthenticated` keeps the existing login recovery error.
+- `unknown` proceeds as it did before this patch.
+
+Route-aware recovery wording is useful but not necessary to repair auth-state
+parsing; it is deferred to avoid mixing message policy into the focused change.
+
+## Implementation
+
+1. Update `src/providers/claude/cli-detection.ts`.
+   - Parse `loggedIn`.
+   - Collect evidence from all supported boolean and string fields.
+   - Replace substring regular expressions with normalized exact sets.
+   - Resolve conflicting or absent evidence in parseable JSON to an explicit
+     `unknown` result.
+   - Reserve `null` for non-JSON output so the generic plain-text fallback
+     remains available.
+2. Update `tests/unit/providers/claude/cli-detection.test.ts`.
+   - Replace synthetic-only fixtures with a compact realistic matrix.
+   - Keep legacy compatibility coverage.
+   - Remove the Claude test's reliance on API-key evidence when testing detector
+     isolation.
+   - Assert the exact `claude --version` and
+     `claude auth status --json` calls for the no-key path.
+3. Update `tests/unit/providers/claude/provider-facets.test.ts`.
+   - Make the default successful fixture use sanitized subscription output.
+   - Add a vertical no-key `loggedIn: true` preflight test.
+   - Add a `loggedIn: false` rejection test.
+   - Retain current settings-selector rejection coverage.
+4. Do not change `src/providers/cli-detection.ts`,
+   `src/providers/claude/provider-facets.ts`, binding, or execution-plan code
+   unless implementation reveals a contradiction with this reviewed design.
+
+## Test Matrix
+
+| Auth command output, exit 0                           | Expected detector state |
+| ----------------------------------------------------- | ----------------------- |
+| `{"loggedIn":true,"authMethod":"claude.ai"}`          | authenticated           |
+| `{"loggedIn":false}`                                  | unauthenticated         |
+| `{"authenticated":true}`                              | authenticated           |
+| `{"authenticated":false}`                             | unauthenticated         |
+| `{"loggedIn":true,"authenticated":false}`             | unknown                 |
+| `{"status":" LOGGED-IN "}`                            | authenticated           |
+| `{"status":"unauthenticated"}`                        | unauthenticated         |
+| `{"status":"inactive"}`                               | unauthenticated         |
+| `{"status":"not-authenticated"}`                      | unauthenticated         |
+| `{"auth_status":"expired"}`                           | unauthenticated         |
+| conflicting recognized fields with an error token     | unknown                 |
+| unknown valid JSON containing an error token          | unknown                 |
+| non-JSON output without a recognized plain-text error | unknown                 |
+| array, `null`, or empty JSON output                   | unknown                 |
+
+Preflight boundary:
+
+| Condition                                               | Expected result                              |
+| ------------------------------------------------------- | -------------------------------------------- |
+| No API key, `loggedIn: true`                            | success after version and auth-status probes |
+| No API key, `loggedIn: false`                           | existing `claude auth login` recovery error  |
+| Unknown auth result                                     | current compatibility behavior: proceed      |
+| Unsupported credential selector in environment/settings | existing rejection                           |
+
+Existing execution-plan tests remain the source of truth for default `HOME` and
+explicit `CLAUDE_CONFIG_DIR` routing; this patch does not duplicate them.
+
+## Verification
+
+Run, in order:
+
+```bash
+npx vitest run --config vitest/default.ts \
+  tests/unit/providers/claude/cli-detection.test.ts \
+  tests/unit/providers/claude/provider-facets.test.ts \
+  tests/unit/providers/cli-detection.test.ts
+
+npx vitest run --config vitest/default.ts \
+  tests/unit/providers/claude/provider-facets.test.ts \
+  tests/unit/providers/binding-lifecycle.test.ts \
+  tests/unit/providers/binding-registry.test.ts \
+  tests/unit/providers/execution-plan.test.ts \
+  tests/unit/runtime/binding.test.ts \
+  tests/unit/expansion/require-binding-validation.test.ts \
+  tests/invariants/principal-binding.test.ts \
+  tests/invariants/provider-binding-ownership.test.ts
+
+npx eslint \
+  src/providers/claude/cli-detection.ts \
+  tests/unit/providers/claude/cli-detection.test.ts \
+  tests/unit/providers/claude/provider-facets.test.ts
+npm run typecheck:tests
+npx prettier --check \
+  src/providers/claude/cli-detection.ts \
+  tests/unit/providers/claude/cli-detection.test.ts \
+  tests/unit/providers/claude/provider-facets.test.ts \
+  docs/plans/claude-subscription-auth-regression.md
+git diff --check
+npm test
+```
+
+This parser-focused verification originally excluded the reported live command.
+The later bundled reproduction and runtime fix are recorded in
+[Claude Print-Mode New Session Regression](./claude-print-session-regression.md).
+
+## Risks and Mitigations
+
+- **A future Claude version changes schema again.** Unknown compatibility is
+  retained; realistic fixtures make currently supported evidence explicit.
+- **Conflicting fields appear during a transition.** They resolve to unknown
+  rather than trusting arbitrary field order.
+- **Exact status matching drops accidental regex compatibility.** The explicit
+  sets retain the intended values from the previous positive and negative
+  patterns while removing substring collisions.
+
+## Acceptance Criteria
+
+- A sanitized Claude.ai subscription fixture with `loggedIn: true` is reported
+  authenticated without API-key evidence.
+- `loggedIn: false`, `unauthenticated`, `inactive`, and `not-authenticated` are
+  reported unauthenticated.
+- Contradictory recognized fields are reported unknown.
+- Unknown output retains current preflight compatibility.
+- Raw credential-selector policy and profile routing are unchanged.
+- Focused tests, provider binding/execution-plan tests, typecheck, lint,
+  formatting, and the standard test suite pass.
+
+## Implementation Outcome
+
+Completed:
+
+- `loggedIn` boolean output is recognized without API-key evidence.
+- Legacy boolean and string output remains supported.
+- Negative substring collisions are removed through exact normalized matching.
+- Contradictory recognized fields resolve to unknown.
+- Unknown preflight compatibility, binding policy, and execution-plan routing
+  remain unchanged.
+
+Verification snapshot recorded on 2026-07-31 against the uncommitted working
+tree on `fix/claude-subscription-auth`:
+
+- focused Claude and generic detector tests: 58 passed
+- provider binding and execution-plan regression tests: 131 passed
+- changed-file ESLint: passed
+- TypeScript test typecheck: passed
+- Prettier and `git diff --check`: passed
+- repository standard test suite: 428 files and 4,147 tests passed
+
+The parser fix remains independently valid, but it was not the cause of the
+externally observed command failure. A later bundled reproduction identified
+and fixed the print transport's fresh-session `--resume` bug; see
+[Claude Print-Mode New Session Regression](./claude-print-session-regression.md).

--- a/src/providers/claude/appserver/print-controller.ts
+++ b/src/providers/claude/appserver/print-controller.ts
@@ -351,6 +351,7 @@ export class PrintSessionController implements BrokerSessionController {
     const child = await this.spawnChild({
       cwd: signature.cwd,
       ...(conversationRef === undefined ? {} : { conversationRef }),
+      resume: params.resumeExisting === true,
       systemPrompt: params.systemPrompt,
       permissionMode: params.permissionMode,
       model: params.model,

--- a/src/providers/claude/appserver/server.ts
+++ b/src/providers/claude/appserver/server.ts
@@ -413,7 +413,7 @@ export function buildClaudeChildArgs(options: SpawnClaudeChildOptions): string[]
 export function buildClaudePrintChildArgs(options: SpawnClaudePrintChildOptions): string[] {
   const args = ['-p', '--verbose', '--input-format', 'stream-json', '--output-format', 'stream-json'];
   if (options.conversationRef !== undefined) {
-    args.push('--resume', options.conversationRef);
+    args.push(options.resume ? '--resume' : '--session-id', options.conversationRef);
   }
   if (options.systemPrompt) {
     args.push('--append-system-prompt', options.systemPrompt);

--- a/src/providers/claude/appserver/session-contract.ts
+++ b/src/providers/claude/appserver/session-contract.ts
@@ -84,6 +84,7 @@ export interface ClaudePrintChild {
 export interface SpawnClaudePrintChildOptions {
   cwd: string;
   conversationRef?: string;
+  resume: boolean;
   systemPrompt?: string;
   permissionMode: PermissionMode;
   model?: string;

--- a/src/providers/claude/cli-detection.ts
+++ b/src/providers/claude/cli-detection.ts
@@ -10,27 +10,55 @@ import {
 const AUTH_ERROR_MESSAGE =
   'Claude CLI is not authenticated. Run "claude auth login" with the same CLAUDE_CONFIG_DIR, then retry.';
 
+type AuthEvidence = 'authenticated' | 'unauthenticated';
+
+const AUTHENTICATED_STATUSES: ReadonlySet<string> = new Set(['authenticated', 'logged_in', 'loggedin', 'active']);
+const UNAUTHENTICATED_STATUSES: ReadonlySet<string> = new Set([
+  'unauthenticated',
+  'logged_out',
+  'loggedout',
+  'not_authenticated',
+  'missing',
+  'expired',
+  'inactive',
+]);
+
+function statusEvidence(value: unknown): AuthEvidence | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/gu, '_');
+  if (AUTHENTICATED_STATUSES.has(normalized)) return 'authenticated';
+  if (UNAUTHENTICATED_STATUSES.has(normalized)) return 'unauthenticated';
+  return null;
+}
+
 function parseAuthStatus(stdout: string): AuthProbeResult | null {
   try {
-    const parsed = JSON.parse(stdout) as Record<string, unknown>;
-    if (typeof parsed.authenticated === 'boolean') {
-      return parsed.authenticated
-        ? { authState: 'authenticated' }
-        : { authState: 'unauthenticated', authError: AUTH_ERROR_MESSAGE };
+    const parsed = JSON.parse(stdout) as unknown;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { authState: 'unknown' };
     }
-    const status =
-      typeof parsed.status === 'string'
-        ? parsed.status
-        : typeof parsed.auth_status === 'string'
-          ? parsed.auth_status
-          : null;
-    if (status === null) return null;
-    if (/authenticated|logged.?in|active/i.test(status)) return { authState: 'authenticated' };
-    if (/unauthenticated|logged.?out|not.?authenticated|missing|expired/i.test(status)) {
-      return { authState: 'unauthenticated', authError: AUTH_ERROR_MESSAGE };
+
+    const record = parsed as Record<string, unknown>;
+    const evidence = new Set<AuthEvidence>();
+    if (typeof record.loggedIn === 'boolean') {
+      evidence.add(record.loggedIn ? 'authenticated' : 'unauthenticated');
     }
+    if (typeof record.authenticated === 'boolean') {
+      evidence.add(record.authenticated ? 'authenticated' : 'unauthenticated');
+    }
+    for (const value of [record.status, record.auth_status]) {
+      const state = statusEvidence(value);
+      if (state !== null) evidence.add(state);
+    }
+
+    if (evidence.size !== 1) return { authState: 'unknown' };
+    if (evidence.has('authenticated')) return { authState: 'authenticated' };
+    return { authState: 'unauthenticated', authError: AUTH_ERROR_MESSAGE };
   } catch {
-    // Malformed JSON is not authenticated evidence.
+    // Non-JSON output remains eligible for the generic auth-error fallback.
   }
   return null;
 }

--- a/tests/unit/providers/claude/appserver/print-controller.test.ts
+++ b/tests/unit/providers/claude/appserver/print-controller.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { PrintSessionController } from '#src/providers/claude/appserver/print-controller.js';
-import type { ControllerNotification, ClaudePrintChild } from '#src/providers/claude/appserver/session-contract.js';
+import type {
+  ControllerNotification,
+  ClaudePrintChild,
+  SpawnClaudePrintChildOptions,
+} from '#src/providers/claude/appserver/session-contract.js';
 
 const TEST_SESSION_ID = '00000000-0000-4000-8000-000000000001';
 const testControlRequestTimer = {
@@ -95,7 +99,10 @@ async function waitForWrite(child: FakeClaudePrintChild, index: number): Promise
 function createController(
   child: FakeClaudePrintChild,
   notifications: ControllerNotification[] = [],
-  options: { controlRequestTimeoutMs?: number } = {},
+  options: {
+    controlRequestTimeoutMs?: number;
+    onSpawn?: (spawnOptions: SpawnClaudePrintChildOptions) => void;
+  } = {},
 ) {
   return createControllerFromChildren([child], notifications, options);
 }
@@ -103,12 +110,17 @@ function createController(
 function createControllerFromChildren(
   children: FakeClaudePrintChild[],
   notifications: ControllerNotification[] = [],
-  options: { controlRequestTimeoutMs?: number } = {},
+  options: {
+    controlRequestTimeoutMs?: number;
+    onSpawn?: (spawnOptions: SpawnClaudePrintChildOptions) => void;
+  } = {},
 ) {
   let spawnIndex = 0;
   let requestIndex = 0;
+  const { onSpawn, ...controllerOptions } = options;
   const controller = new PrintSessionController({
-    spawnChild: () => {
+    spawnChild: (spawnOptions) => {
+      onSpawn?.(spawnOptions);
       const child = children[spawnIndex];
       spawnIndex += 1;
       if (!child) {
@@ -124,7 +136,7 @@ function createControllerFromChildren(
     },
     now: () => 1_000,
     controlRequestTimer: testControlRequestTimer,
-    ...options,
+    ...controllerOptions,
   });
   controller.subscribeNotifications((notification) => {
     notifications.push(notification);
@@ -136,6 +148,7 @@ async function ensureController(
   controller: PrintSessionController,
   child: FakeClaudePrintChild,
   permissionMode: 'default' | 'bypassPermissions' = 'default',
+  overrides: { conversationRef?: string; resumeExisting?: boolean } = {},
 ) {
   const ensure = controller.sessionEnsure({
     cwd: '/workspace',
@@ -147,6 +160,7 @@ async function ensureController(
     systemPrompt: 'system',
     model: 'claude-sonnet-test',
     effort: 'high',
+    ...overrides,
   });
   await waitForWrite(child, 0);
 
@@ -160,7 +174,7 @@ async function ensureController(
   child.emitStdout({
     type: 'system',
     subtype: 'init',
-    session_id: TEST_SESSION_ID,
+    session_id: overrides.conversationRef ?? TEST_SESSION_ID,
     model: 'claude-sonnet-test',
   });
   child.emitStdout({
@@ -176,6 +190,31 @@ async function ensureController(
 }
 
 describe('PrintSessionController', () => {
+  it.each([
+    ['new', false],
+    ['resumed', true],
+  ] as const)('passes %s-session intent to the print child', async (_label, resumeExisting) => {
+    const child = new FakeClaudePrintChild();
+    const spawnOptions: SpawnClaudePrintChildOptions[] = [];
+    const controller = createController(child, [], {
+      onSpawn: (options) => spawnOptions.push(options),
+    });
+
+    await expect(
+      ensureController(controller, child, 'default', {
+        conversationRef: TEST_SESSION_ID,
+        resumeExisting,
+      }),
+    ).resolves.toMatchObject({ conversationRef: TEST_SESSION_ID });
+    expect(spawnOptions).toHaveLength(1);
+    expect(spawnOptions[0]).toMatchObject({
+      conversationRef: TEST_SESSION_ID,
+      resume: resumeExisting,
+    });
+
+    await controller.shutdown();
+  });
+
   it('bootstraps with a control request, sends user JSONL, and completes from result output', async () => {
     const child = new FakeClaudePrintChild();
     const notifications: ControllerNotification[] = [];

--- a/tests/unit/providers/claude/appserver/server.test.ts
+++ b/tests/unit/providers/claude/appserver/server.test.ts
@@ -25,6 +25,7 @@ function spawnOptions(overrides: Partial<SpawnClaudeChildOptions> = {}): SpawnCl
 function printSpawnOptions(overrides: Partial<SpawnClaudePrintChildOptions> = {}): SpawnClaudePrintChildOptions {
   return {
     cwd: '/workspace',
+    resume: false,
     permissionMode: 'default',
     ...overrides,
   };
@@ -105,11 +106,25 @@ describe('claude appserver print child args', () => {
     ]);
   });
 
+  it('starts a new print-mode session with the requested session id', () => {
+    expect(buildClaudePrintChildArgs(printSpawnOptions({ conversationRef: TEST_SESSION_ID }))).toEqual([
+      '-p',
+      '--verbose',
+      '--input-format',
+      'stream-json',
+      '--output-format',
+      'stream-json',
+      '--session-id',
+      TEST_SESSION_ID,
+    ]);
+  });
+
   it('resumes existing print-mode sessions and carries bootstrap options', () => {
     expect(
       buildClaudePrintChildArgs(
         printSpawnOptions({
           conversationRef: 'session-existing',
+          resume: true,
           systemPrompt: 'Stay concise.',
           model: 'claude-sonnet-4-6',
           effort: 'high',

--- a/tests/unit/providers/claude/cli-detection.test.ts
+++ b/tests/unit/providers/claude/cli-detection.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { detectClaudeCli } from '#src/providers/claude/cli-detection.js';
 
+const AUTH_ERROR_MESSAGE =
+  'Claude CLI is not authenticated. Run "claude auth login" with the same CLAUDE_CONFIG_DIR, then retry.';
+
 function probe(authOutput: string) {
   const exec = vi
     .fn()
@@ -15,30 +18,101 @@ function probe(authOutput: string) {
 
 describe('Claude CLI detection', () => {
   it.each([
-    ['{"authenticated":true}', 'authenticated'],
-    ['{"authenticated":false}', 'unauthenticated'],
-    ['{"status":"logged_in"}', 'authenticated'],
-    ['{"auth_status":"expired"}', 'unauthenticated'],
-    ['not-json', 'unknown'],
-  ])('interprets Claude auth/status output %s', async (output, authState) => {
+    [
+      JSON.stringify({ loggedIn: true, authMethod: 'claude.ai', subscriptionType: 'team' }),
+      { authState: 'authenticated' },
+    ],
+    [JSON.stringify({ loggedIn: false }), { authState: 'unauthenticated', authError: AUTH_ERROR_MESSAGE }],
+    [JSON.stringify({ authenticated: true }), { authState: 'authenticated' }],
+    [JSON.stringify({ authenticated: false }), { authState: 'unauthenticated', authError: AUTH_ERROR_MESSAGE }],
+    [JSON.stringify({ loggedIn: true, authenticated: false }), { authState: 'unknown' }],
+    [JSON.stringify({ loggedIn: true, authenticated: true }), { authState: 'authenticated' }],
+    [JSON.stringify({ loggedIn: true, status: 'unauthenticated' }), { authState: 'unknown' }],
+    [JSON.stringify({ status: ' LOGGED-IN ' }), { authState: 'authenticated' }],
+    [JSON.stringify({ status: 'not-authenticated' }), { authState: 'unauthenticated', authError: AUTH_ERROR_MESSAGE }],
+    [JSON.stringify({ status: 'active', auth_status: 'expired' }), { authState: 'unknown' }],
+    [JSON.stringify({ futureAuthState: 'unauthenticated' }), { authState: 'unknown' }],
+    ['not-json', { authState: 'unknown' }],
+    ['[]', { authState: 'unknown' }],
+    ['null', { authState: 'unknown' }],
+    ['', { authState: 'unknown' }],
+  ])('interprets Claude auth/status output %s', async (output, auth) => {
     const subject = probe(output);
-    await expect(subject.detect()).resolves.toMatchObject({
+    await expect(subject.detect()).resolves.toEqual({
       available: true,
       version: 'claude 2.0',
-      authState,
+      ...auth,
     });
   });
 
-  it('keeps detector caches isolated by process and environment ports', async () => {
-    const missingExec = vi.fn().mockResolvedValue({ stdout: '', stderr: 'missing', status: 1 });
-    const availableExec = vi.fn().mockResolvedValue({ stdout: 'claude 2.0', stderr: '', status: 0 });
+  it.each(['authenticated', 'logged_in', 'loggedin', 'active'])(
+    'accepts the legacy authenticated status %s',
+    async (status) => {
+      await expect(probe(JSON.stringify({ status })).detect()).resolves.toMatchObject({
+        authState: 'authenticated',
+      });
+    },
+  );
 
-    await expect(detectClaudeCli({ exec: missingExec } as never, { get: () => undefined })).resolves.toMatchObject({
+  it.each(['unauthenticated', 'logged_out', 'loggedout', 'not_authenticated', 'missing', 'expired', 'inactive'])(
+    'rejects the legacy unauthenticated status %s',
+    async (status) => {
+      await expect(probe(JSON.stringify({ auth_status: status })).detect()).resolves.toMatchObject({
+        authState: 'unauthenticated',
+        authError: AUTH_ERROR_MESSAGE,
+      });
+    },
+  );
+
+  it('probes the selected Claude profile without API-key evidence', async () => {
+    const subject = probe(JSON.stringify({ loggedIn: true, authMethod: 'claude.ai' }));
+
+    await expect(subject.detect()).resolves.toEqual({
+      available: true,
+      version: 'claude 2.0',
+      authState: 'authenticated',
+    });
+    expect(subject.exec.mock.calls).toEqual([
+      ['claude', ['--version'], { timeout: 10_000, encoding: 'utf-8' }],
+      ['claude', ['auth', 'status', '--json'], { timeout: 5_000, encoding: 'utf-8' }],
+    ]);
+  });
+
+  it('keeps detector caches isolated by process port', async () => {
+    const envPort = { get: () => undefined };
+    const missingExec = vi.fn().mockResolvedValue({ stdout: '', stderr: 'missing', status: 1 });
+    const availableExec = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: 'claude 2.0', stderr: '', status: 0 })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ loggedIn: true }), stderr: '', status: 0 });
+
+    await expect(detectClaudeCli({ exec: missingExec } as never, envPort)).resolves.toMatchObject({
       available: false,
     });
-    await expect(detectClaudeCli({ exec: availableExec } as never, { get: () => 'token' })).resolves.toMatchObject({
+    await expect(detectClaudeCli({ exec: availableExec } as never, envPort)).resolves.toMatchObject({
       available: true,
       authState: 'authenticated',
     });
+    expect(availableExec).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps detector caches isolated by environment port', async () => {
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: 'claude profile-a', stderr: '', status: 0 })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ loggedIn: false }), stderr: '', status: 0 })
+      .mockResolvedValueOnce({ stdout: 'claude profile-b', stderr: '', status: 0 })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ loggedIn: true }), stderr: '', status: 0 });
+    const processPort = { exec } as never;
+
+    await expect(detectClaudeCli(processPort, { get: () => undefined })).resolves.toMatchObject({
+      version: 'claude profile-a',
+      authState: 'unauthenticated',
+    });
+    await expect(detectClaudeCli(processPort, { get: () => undefined })).resolves.toMatchObject({
+      version: 'claude profile-b',
+      authState: 'authenticated',
+    });
+    expect(exec).toHaveBeenCalledTimes(4);
   });
 });

--- a/tests/unit/providers/claude/provider-facets.test.ts
+++ b/tests/unit/providers/claude/provider-facets.test.ts
@@ -17,7 +17,12 @@ function claudePreflightRuntime(
   const runExact = vi.fn(async (_command: string, args: string[]) =>
     args[0] === '--version'
       ? { stdout: 'claude 1.0.0', stderr: '', status: 0, signal: null }
-      : { stdout: JSON.stringify({ authenticated: true }), stderr: '', status: 0, signal: null },
+      : {
+          stdout: JSON.stringify({ loggedIn: true, authMethod: 'claude.ai', subscriptionType: 'team' }),
+          stderr: '',
+          status: 0,
+          signal: null,
+        },
   );
   return {
     access: TEST_CLAUDE_ACCESS,
@@ -112,13 +117,16 @@ describe('claudePreflight', () => {
     },
   );
 
-  it('probes Claude when selected and project settings contain no unsupported credential mode', async () => {
+  it('accepts a subscription-authenticated profile without API-key evidence', async () => {
     const runtime = claudePreflightRuntime({
       '/home/user/.claude/settings.json': JSON.stringify({ env: { CLAUDE_CODE_MAX_OUTPUT_TOKENS: '8192' } }),
     });
 
     await expect(claudePreflight(runtime)).resolves.toBeUndefined();
-    expect(runtime.runExact).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(runtime.runExact).mock.calls).toEqual([
+      ['claude', ['--version'], { timeout: 10_000, encoding: 'utf-8' }],
+      ['claude', ['auth', 'status', '--json'], { timeout: 5_000, encoding: 'utf-8' }],
+    ]);
   });
 
   it('surfaces the detector authentication recovery message without a redundant prefix', async () => {
@@ -127,7 +135,7 @@ describe('claudePreflight', () => {
       .fn()
       .mockResolvedValueOnce({ stdout: 'claude 1.0.0', stderr: '', status: 0, signal: null })
       .mockResolvedValueOnce({
-        stdout: JSON.stringify({ authenticated: false }),
+        stdout: JSON.stringify({ loggedIn: false }),
         stderr: '',
         status: 0,
         signal: null,
@@ -136,6 +144,24 @@ describe('claudePreflight', () => {
     await expect(claudePreflight(runtime)).rejects.toThrow(
       'Claude CLI is not authenticated. Run "claude auth login" with the same CLAUDE_CONFIG_DIR, then retry.',
     );
+  });
+
+  it.each([
+    ['conflicting recognized evidence', { loggedIn: true, status: 'unauthenticated' }],
+    ['an unknown schema containing an auth-error token', { futureAuthState: 'unauthenticated' }],
+  ])('retains compatibility when Claude returns %s', async (_label, authOutput) => {
+    const runtime = claudePreflightRuntime({});
+    runtime.runExact = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: 'claude 1.0.0', stderr: '', status: 0, signal: null })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify(authOutput),
+        stderr: '',
+        status: 0,
+        signal: null,
+      });
+
+    await expect(claudePreflight(runtime)).resolves.toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Recognize current Claude subscription auth JSON without requiring ANTHROPIC_API_KEY.
- Keep structured unknown auth results from leaking into the legacy raw-text fallback.
- Distinguish fresh print sessions (--session-id) from resumed sessions (--resume).

## Root cause

Coral v0.10 print transport mapped every conversation reference to --resume. Fresh exec requests already carry a newly allocated provider session UUID, so Claude Code attempted to resume a conversation that did not exist. Separately, the auth parser did not recognize loggedIn and used positive substring matching.

## User impact

API-key-free Claude.ai subscription users can pass preflight and start a fresh Claude session from the bundled CLI. Existing resume behavior remains unchanged.

## Validation

- Focused Claude tests: 81 passed.
- Claude appserver regression: 101 passed.
- TypeScript test typecheck, changed-file ESLint, Prettier, and git diff checks passed.
- Development bundle build passed.
- Full suite: 428 files and 4,147 tests passed.
- Live built-bundle command completed successfully: node clients/build/coral-cli.cjs claude -i "hello".