### PR TITLE
feat: block on pioneer before presenting, and budget plan rounds per phase

### DIFF
--- a/clients/skills/pathfind/SKILL.md
+++ b/clients/skills/pathfind/SKILL.md
@@ -152,10 +152,20 @@ argument-hint: "<problem descriptions or symptoms>"
   - **When to choose**: ...
   ```
 
-  ## Step 5 — Pioneer
+  ## Step 5 — Pioneer (blocking barrier)
 
   Pioneer independently generates elegant directions for the same root causes.
   It is not evaluating pathfind's directions — it is finding its own.
+
+  Pioneer's directions are **candidates in** the Step 6 ranking, not a late addition to a
+  ranking already shown. Until pioneer has returned and its directions are in the artifact:
+
+  - Do NOT rank, score, or recommend.
+  - Do NOT ask the user to choose a direction.
+  - Do NOT enter Step 6.
+
+  Run it as a single **foreground blocking call** — never background it, never continue other
+  work while it runs.
 
   ```
   Agent({ subagent_type: "coral:pioneer",
@@ -170,7 +180,9 @@ argument-hint: "<problem descriptions or symptoms>"
       {root cause table from Step 3}" })
   ```
 
-  **If pioneer fails**: proceed with pathfind's directions only, note in artifact.
+  **If pioneer fails, is unreachable, or returns nothing usable**: proceed with pathfind's
+  directions only, note it in the artifact, and say so when presenting — never let a
+  pathfind-only candidate set stand as though pioneer had contributed.
 
   Add pioneer's directions as additional candidates alongside pathfind's directions.
   Tag each direction's origin: `[pathfind]` or `[pioneer]`.
@@ -182,6 +194,9 @@ argument-hint: "<problem descriptions or symptoms>"
   ```
 
   ## Step 6 — Evaluate
+
+  **Precondition**: Step 5 is settled — pioneer has returned and its directions are in the
+  artifact, or it failed and that is recorded. Rank **once**, over the complete candidate set.
 
   **Combine**: If two directions are complementary (each covers different root causes),
   create a composite direction tagged `[combined]`. Evaluate it as a single candidate.
@@ -278,6 +293,7 @@ argument-hint: "<problem descriptions or symptoms>"
   | Use scanner when investigating existing code | Use gap-finder for raw symptom diagnosis |
   | Generate one direction per orthogonal lane | Generate multiple variations of the same mechanism |
   | Let pioneer generate its own elegant directions | Use pioneer as an evaluator of pathfind's directions |
+  | Block on pioneer, then rank the full candidate set once | Rank or recommend while pioneer is still running |
   | Hand off to preplan with direction | Implement or plan directly |
   | Ask clarifying questions when confidence is low | Proceed blindly on vague input |
   | Delegate code bugs to /analyze or debugger | Self-diagnose code-level bugs |

--- a/clients/skills/plan/SKILL.md
+++ b/clients/skills/plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan
-description: 'Use when a task needs structured planning before implementation. Supports --delegate and round=N.'
-argument-hint: '[--delegate] [round=N] [task description]'
+description: 'Use when a task needs structured planning before implementation. Supports --delegate and round=N[,M].'
+argument-hint: '[--delegate] [round=N[,M]] [task description]'
 ---
 
 # Planning
@@ -14,11 +14,20 @@ Execute a multi-round planning session with architect/critic review.
 | -------------- | -------------------------------------------------------------------------------------------------- |
 | `<prompt>`     | Self-execute on current host (default)                                                             |
 | `--delegate`   | Add review pass on the other host (Codex when current is Claude, Claude when current is Codex; from SessionStart `Current host:`) |
-| `round=N`      | Review rounds per phase (default `1`). e.g. `round=3` for deeper iteration. |
+| `round=N`      | Review rounds for every applicable phase (default `1`). e.g. `round=3` for deeper iteration. |
+| `round=N,M`    | Per-phase budget: Phase 1 (`<other-host>`) gets `N` rounds, Phase 2 (`<current-host>`) gets `M`. **Turns `--delegate` on.** |
 | `--no-handoff` | Internal: skip implementation prompt at step 5 (caller controls next step)                         |
 
-Reviewers and the resolver always run — `round=N` only sets how many times each phase iterates.
-Parse `round=N` (default `1`), then strip `--delegate`, `round=N`, and `--no-handoff` tokens before passing the prompt to the execution path.
+Reviewers and the resolver always run — the round budget only sets how many times each phase iterates.
+
+**Parsing the round budget** (`round=…` and `--round=…` are the same token):
+
+- `round=N` → every applicable phase gets `N`. Does not affect `--delegate`.
+- `round=N,M` → `{maxRounds[1]}` = `N`, `{maxRounds[2]}` = `M`, and `--delegate` is on whether or not it was written. Phase 1 exists only under `--delegate`, so naming two budgets IS the request for both phases.
+- Absent → `1` for every phase.
+- Every value must be an integer ≥ 1. More than two values, a `0`, or a non-integer is a usage error: report it and stop. Do not clamp, drop the extras, or fall back to the default.
+
+Strip `--delegate`, the round token, and `--no-handoff` before passing the prompt to the execution path.
 
 <Planning_Protocol>
 <Role>
@@ -71,18 +80,18 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
     ### 4. Review Loop
 
     Phase 0 always runs first. Phase 0b (Complexity Gate) may skip review phases.
-    Phase 1 runs only when `--delegate` flag is set (review on the other host). Phase 2 always runs (unless skipped by Complexity Gate; review on the current host).
+    Phase 1 runs only when `--delegate` is set — explicitly, or implied by a two-value `round=N,M` (review on the other host). Phase 2 always runs (unless skipped by Complexity Gate; review on the current host).
 
-    **Round budget**: `{maxRounds}` = the `round=N` argument value (default `1`). Each phase iterates up to `{maxRounds}` rounds. With the default `round=1`, each phase runs exactly one round and then exits (no iteration). Phase structure is unaffected — Phase 1 (if `--delegate`) and Phase 2 still run regardless of round budget.
+    **Round budget**: `{maxRounds[P]}` is phase P's own budget. `round=N` gives every phase `N`; `round=N,M` gives Phase 1 `N` and Phase 2 `M`; absent gives every phase `1`. Each phase iterates up to its own budget and then exits — a phase at budget `1` runs exactly one round with no iteration. Phase structure is independent of the budget: Phase 1 (if `--delegate`) and Phase 2 still run whatever the numbers are.
 
     **Task registration**: Before starting Phase 0, register one Task per applicable phase:
     - `TaskCreate({ subject: "Phase 0 — Frame Gate" })`
-    - `TaskCreate({ subject: "Phase 1 — <other-host> review" })` (only if `--delegate`)
+    - `TaskCreate({ subject: "Phase 1 — <other-host> review" })` (only if `--delegate`, explicit or implied)
     - `TaskCreate({ subject: "Phase 2 — <current-host> review" })`
     - `TaskCreate({ subject: "Execution Ordering" })`
 
     On phase start: `TaskUpdate({ taskId, status: "in_progress" })`.
-    On each round: `TaskUpdate({ taskId, subject: "Phase N — {label} (round M/{maxRounds})" })`.
+    On each round: `TaskUpdate({ taskId, subject: "Phase P — {label} (round M/{maxRounds[P]})" })`.
     On phase complete: `TaskUpdate({ taskId, status: "completed" })`.
 
     #### Phase 0 — Frame Gate (always)
@@ -117,12 +126,12 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
 
     Let `<current-host>` come from SessionStart `Current host:`. Let `<other-host>` = the other of `codex`/`claude`.
 
-    | Phase | Condition | Provider | Round Label |
-    |-------|-----------|----------|-------------|
-    | 1 | `--delegate` only | `<other-host>` | `(<other-host capitalized>)` |
-    | 2 | always | `<current-host>` | `(<current-host capitalized>)` |
+    | Phase | Condition | Provider | Round Label | Budget |
+    |-------|-----------|----------|-------------|--------|
+    | 1 | `--delegate`, explicit or implied by `round=N,M` | `<other-host>` | `(<other-host capitalized>)` | `{maxRounds[1]}` |
+    | 2 | always | `<current-host>` | `(<current-host capitalized>)` | `{maxRounds[2]}` |
 
-    For each applicable phase, repeat (max `{maxRounds}` rounds; default 1):
+    Run the phases in order. For each applicable phase, repeat up to that phase's own `{maxRounds[P]}` rounds (default 1):
 
     **4a. Workflow Dispatch**
 
@@ -161,15 +170,15 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
 
       **Changes Applied**: [what was edited, with rationale for each change]
 
-      **Continue Decision**: **{Verdict}** — {Rationale} (from resolver). At round `{maxRounds}` the phase exits regardless of the verdict — note the round cap when it forces the exit.
+      **Continue Decision**: **{Verdict}** — {Rationale} (from resolver). At round `{maxRounds[P]}` the phase exits regardless of the verdict — note the round cap when it forces the exit.
 
     **4d. Exit Condition**
 
-    Follow the resolver's **Continue Decision** verdict — do not override or reinterpret it — but `{maxRounds}` is the outer bound:
-    - **Round < `{maxRounds}`**: Continue → 4a. Exit → fix remaining MEDIUM/LOW inline, then exit phase. Hard override: CRITICAL findings always Continue.
-    - **Round == `{maxRounds}`**: always proceed to the next phase (or Execution Order if this is the last phase), regardless of the verdict. Fix surviving MEDIUM inline; defer CRITICAL/HIGH to the next phase.
+    Follow the resolver's **Continue Decision** verdict — do not override or reinterpret it — but this phase's `{maxRounds[P]}` is the outer bound. A budget belongs to one phase: exhausting Phase 1 says nothing about Phase 2's.
+    - **Round < `{maxRounds[P]}`**: Continue → 4a. Exit → fix remaining MEDIUM/LOW inline, then exit phase. Hard override: CRITICAL findings always Continue.
+    - **Round == `{maxRounds[P]}`**: always proceed to the next phase (or Execution Order if this is the last phase), regardless of the verdict. Fix surviving MEDIUM inline; defer CRITICAL/HIGH to the next phase.
 
-    With the default `round=1`, every phase exits after its first round. Severity is never reclassified at exit — only during synthesis (4b). If the Continue Decision is missing, treat it as a protocol violation and re-evaluate from the resolver report's highest severity.
+    A phase at budget `1` exits after its first round. Severity is never reclassified at exit — only during synthesis (4b). If the Continue Decision is missing, treat it as a protocol violation and re-evaluate from the resolver report's highest severity.
 
     ### 4e. Execution Order
 
@@ -241,7 +250,7 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
     | Use workflow for all review phases | Run reviewers sequentially |
     | Delegate synthesis to the resolver every round | Self-synthesize in the orchestrator or skip the resolver |
     | Cite file:line in plans | Write vague plans without references |
-    | Exit when the resolver says Exit, or at round `{maxRounds}` | Continue past the round budget |
+    | Exit when the resolver says Exit, or at that phase's `{maxRounds[P]}` | Continue past a phase's round budget, or spend one phase's budget on another |
     | Return plan file path | Implement within this protocol |
   </Constraints>
   <Output_Format>
@@ -251,7 +260,7 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
 
     ### Review Summary
     - Phases: [0 (Frame Gate) + 1 (<other-host>) + 2 (<current-host>)] or [0 (Frame Gate) + 2 (<current-host>)]
-    - Rounds: N per phase
+    - Rounds: rounds actually run / budget, per phase — e.g. `Phase 1: 2/3, Phase 2: 1/1`
     - Final verdict: [APPROVED / APPROVED WITH CONDITIONS]
     - Key changes from review: [brief list]
     - ⚠️ **Unsatisfied Success Criteria**: [list with reasons] *(omit if all satisfied)*

--- a/clients/skills/preplan/SKILL.md
+++ b/clients/skills/preplan/SKILL.md
@@ -13,7 +13,7 @@ Structured problem-definition conversation with the user before planning begins.
 | Argument     | Mode                                                                                                                                                    |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<prompt>`   | Self-execute on current host (default)                                                                                                                  |
-| `--deep`     | Enable pioneer review for elegant alternatives                                                                                                          |
+| `--deep`     | Enable pioneer review for elegant alternatives. Blocks Step 3 until pioneer returns.                                                                    |
 | `--delegate` | Delegate pioneer to the other host (Codex when current is Claude, Claude when current is Codex; from SessionStart `Current host:`). Activates `--deep`. |
 
 Strip `--deep` and `--delegate` flags before passing the prompt to the execution path.
@@ -108,28 +108,50 @@ items with the "unconfirmed" marker, then seek user feedback.
     **RECOMMENDED**: When filling Assumptions (#4), consider applying
     `CORAL_METHODS/HOW-ELICIT.md` Lens 3 (Assumption Surfacing).
 
-    ### 2. Pioneer (`--deep` or `--delegate`)
+    ### 2. Pioneer (`--deep` or `--delegate`) — blocking barrier
 
     **Skip this step unless `--deep` or `--delegate` is set.** Without either flag, proceed
     directly to Step 3 — the orchestrator fills the three-point spectrum from its own analysis.
 
-    Dispatch pioneer to find the most elegant alternatives. Let `<other-host>` = Codex if current host is Claude; Claude if current host is Codex.
+    When either flag IS set, pioneer's output is an **input to** the Step 3 draft, not a parallel
+    commentary on it. Until pioneer has returned and its findings are written into the agreement file:
+
+    - Do NOT present the draft.
+    - Do NOT ask the user to decide, confirm, or react — no `AskUserQuestion`, no alternatives table,
+      no "silence is consent".
+    - Do NOT enter Step 4.
+
+    A draft shown before pioneer returns is a partial draft, and every decision the user makes on it
+    is made against the alternatives Step 2 was supposed to supply. If it happens anyway: withdraw the
+    request, wait for pioneer, re-present once.
+
+    Run pioneer as a single **foreground blocking call** — never background it, never continue other
+    work while it runs. Let `<other-host>` = Codex if current host is Claude; Claude if current host is Codex.
 
     ```
-    // --deep (without --delegate): self-execute
+    // --deep (without --delegate): self-execute, blocking
     output = Agent({ subagent_type: "coral:pioneer", prompt: <draft file content> })
 
-    // --delegate: dispatch to the other host
+    // --delegate: dispatch to the other host, then block on the wait
     launch = Bash(`coral-cli <other-host> pioneer -i "<draft file content>" --work-dir "<work_dir>" -d`)
     job = parse `Job <job> <launchState> (session <session>)` from launch
-    terminal = Bash(`coral-cli wait jobs ${job} --embed`)
+    terminal = Bash(`coral-cli wait jobs ${job} --embed`)   // foreground; blocks until terminal
     output = Read(<path from the terminal's `Result path:` line>)
     ```
 
-    For items where pioneer identifies a genuinely more elegant form: mark the sub-item
-    unconfirmed and add the three-point spectrum (default, minimal, elegant).
+    Then consume `output`: for items where pioneer identifies a genuinely more elegant form, mark the
+    sub-item unconfirmed and add the three-point spectrum (default, minimal, elegant) with pioneer's
+    form as the elegant tier. Write them into `CORAL_PROJECT/plans/pre-{topic}.md` before Step 3.
+
+    **If pioneer fails, is unreachable, or returns nothing usable**: fill the spectrum from your own
+    analysis and state the miss when presenting. Never let an orchestrator-only spectrum stand as
+    pioneer-reviewed.
 
     ### 3. Present Draft
+
+    **Precondition**: Step 2 is settled — with `--deep`/`--delegate` that means pioneer has returned
+    and its findings are already in the agreement file; without either flag it means Step 2 was
+    skipped by rule. Present **once**, complete. Never an interim draft followed by a revision.
 
     Present complete draft. The user's role is to **correct**, not to fill from scratch.
 
@@ -183,6 +205,8 @@ items with the "unconfirmed" marker, then seek user feedback.
     | Run Q&A gate when any axis fails the gate-criteria check | Skip gate and draft on shaky framing |
     | Print Q&A preview table before AskUserQuestion | Call AskUserQuestion directly without preview table |
     | Fill the 7 agreement items autonomously before asking | Ask item-by-item like a form |
+    | Block on pioneer, fold its findings in, then present once | Present the draft or solicit decisions while pioneer is still running |
+    | Say so when pioneer was skipped, failed, or unreachable | Pass an orchestrator-only spectrum off as pioneer-reviewed |
     | Commit to the best choice per unconfirmed sub-item, offer minimal + elegant alternatives | Leave unconfirmed items blank or offer alternatives per section |
     | Mark uncertain items as "unconfirmed" | Present guesses as confirmed facts |
     | Flag ambiguous items explicitly to the user | Assume the user noticed uncertainty |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -24,7 +24,7 @@ Resolved absolute paths are injected through `inject/tools.md` (`{{CORAL_METHODS
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/coral:analyze`       | Deep analysis and investigation; `--delegate` runs on the other host                                                                                    |
 | `/coral:preplan`       | Structured problem-definition conversation before planning                                                                                              |
-| `/coral:plan`          | Planning with architect/critic review; `round=N` sets the review-round budget per phase (default 1); `--delegate` adds a review round on the other host |
+| `/coral:plan`          | Planning with architect/critic review; `round=N` sets the review-round budget for every phase (default 1); `round=N,M` sets Phase 1 and Phase 2 separately and turns `--delegate` on; `--delegate` adds a review phase on the other host |
 | `/coral:ralph`         | Persistent execution loop with verification; supports `--delegate`, `--team`, and `--red`                                                               |
 | `/coral:code-simplify` | Code simplification and cleanup                                                                                                                         |
 | `/coral:bugfix`        | Diagnosis, planning, and fix execution                                                                                                                  |


### PR DESCRIPTION
## Why

`/coral:preplan --deep` presented its draft and asked the user to choose alternatives **while pioneer was still running**, with "silence is consent" attached. The user's decisions were therefore made against the very alternatives Step 2 was supposed to supply.

The skill text permitted it. Step 2 said "Dispatch pioneer", assigned `output = Agent(...)` and never referenced `output` again, and Step 3 (`Present Draft`) owned the entire default/minimal/elegant construction on its own — so Step 3 executed standalone. With the `--deep` path and the no-flag path converging on identical Step 3 text, nothing signalled that pioneer was a prerequisite. The Constraints table had no ordering row.

`coral:pathfind` Step 5 has the same shape, survivable only because Step 6 structurally scores pioneer's directions.

## What

**Pioneer barriers** (`preplan`, `pathfind`)
- Name the step a blocking barrier and enumerate what must NOT happen while pioneer runs: present, `AskUserQuestion`, "silence is consent", enter the next step.
- Require a single foreground blocking call; never background it.
- Name the consumption of `output` and where it is written — an assignment with no reader reads as fire-and-forget.
- Add a Precondition to the consuming step (`Present Draft` / `Evaluate`): present or rank **once**, complete.
- Require the skipped/failed/unreachable case to be stated, so an orchestrator-only spectrum never stands as pioneer-reviewed.
- One ordering row each in Constraints.

**Per-phase round budget** (`plan`)
- `round=N,M` budgets Phase 1 (`<other-host>`) and Phase 2 (`<current-host>`) separately, and turns `--delegate` on — Phase 1 exists only under `--delegate`, so naming two budgets *is* the request for both phases.
- `round=N` keeps its uniform meaning; existing callers (`bugfix`, `preplan`, `init-project`) are unaffected.
- `--round=` is accepted as the same token.
- `0`, non-integers, and >2 values are a usage error — no clamping, no silent drop.
- `{maxRounds}` → `{maxRounds[P]}` at all 10 references; one phase exhausting its budget says nothing about another's.

## Scope

`clients/skills/` + `docs/skills.md` only — no source, so the lint/build/test gate does not apply. README left as-is; the argument reference lives in `docs/skills.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)