### PR TITLE
fix: a per-job failure is never a process verdict

### DIFF
--- a/src/cli/format/backend.ts
+++ b/src/cli/format/backend.ts
@@ -9,6 +9,13 @@ export function formatBackendStatus(result: BackendStatusFull): string {
       return formatRunningStatus(result.health);
     case 'not_running':
       return 'Backend not running. Any coral-cli mutating command (or a Claude Code session start) relaunches it.';
+    case 'recent_failure':
+      return [
+        'Backend is not running after a recent coordinator failure.',
+        `Phase: ${result.phase}`,
+        `Reason: ${result.reason}`,
+        'Next step: inspect the coordinator log, fix the reported cause, then retry a coral-cli mutating command to relaunch it.',
+      ].join('\n');
     case 'shutting_down':
       return 'Backend shutting down';
     case 'unauthorized':

--- a/src/cli/format/backend.ts
+++ b/src/cli/format/backend.ts
@@ -13,7 +13,6 @@ export function formatBackendStatus(result: BackendStatusFull): string {
       return [
         'Backend is not running after a recent coordinator failure.',
         `Phase: ${result.phase}`,
-        `Reason: ${result.reason}`,
         'Next step: inspect the coordinator log, fix the reported cause, then retry a coral-cli mutating command to relaunch it.',
       ].join('\n');
     case 'shutting_down':

--- a/src/coordinator/bootstrap-diagnostics.ts
+++ b/src/coordinator/bootstrap-diagnostics.ts
@@ -27,6 +27,9 @@ function serializeBootstrapError(error: unknown): Record<string, unknown> {
       name: error.name,
       message: error.message,
       ...(error.stack === undefined ? {} : { stack: error.stack }),
+      // A wrapper that carries the real reason in `cause` is useless without it: the
+      // operator sees a fatal, non-retryable failure and no way to learn why.
+      ...(error.cause === undefined || error.cause === null ? {} : { cause: serializeBootstrapError(error.cause) }),
     };
   }
   return {

--- a/src/coordinator/bootstrap-diagnostics.ts
+++ b/src/coordinator/bootstrap-diagnostics.ts
@@ -11,12 +11,14 @@ import { serializeCoralSetupError } from '../runtime/errors.js';
 
 export type BootstrapDiagnosticPhase = 'startup_failed' | 'fatal_shutdown_error' | 'bootstrap_unhandled_rejection';
 
+const MAX_BOOTSTRAP_ERROR_CAUSE_DEPTH = 8;
+
 function startupStartedAt(): number {
   const startedAt = Number(process.env.CORAL_STARTUP_STARTED_AT);
   return Number.isFinite(startedAt) && startedAt > 0 ? startedAt : Date.now();
 }
 
-function serializeBootstrapError(error: unknown): Record<string, unknown> {
+export function serializeBootstrapError(error: unknown, causeDepth = 0): Record<string, unknown> {
   const setupError = serializeCoralSetupError(error);
   if (setupError) {
     return { kind: 'coral_setup_error', ...setupError };
@@ -29,7 +31,9 @@ function serializeBootstrapError(error: unknown): Record<string, unknown> {
       ...(error.stack === undefined ? {} : { stack: error.stack }),
       // A wrapper that carries the real reason in `cause` is useless without it: the
       // operator sees a fatal, non-retryable failure and no way to learn why.
-      ...(error.cause === undefined || error.cause === null ? {} : { cause: serializeBootstrapError(error.cause) }),
+      ...(error.cause === undefined || error.cause === null || causeDepth >= MAX_BOOTSTRAP_ERROR_CAUSE_DEPTH
+        ? {}
+        : { cause: serializeBootstrapError(error.cause, causeDepth + 1) }),
     };
   }
   return {

--- a/src/coordinator/execution-service.ts
+++ b/src/coordinator/execution-service.ts
@@ -271,8 +271,8 @@ export class ExecutionService implements RecoveryCapableService, ProjectRequestP
   finalizeProviderRecoveryBindingFailure(
     launchRecord: JobLaunch,
     failure: Parameters<RecoveryService['finalizeProviderRecoveryBindingFailure']>[1],
-  ): void {
-    this.recoveryService.finalizeProviderRecoveryBindingFailure(launchRecord, failure);
+  ): ReturnType<RecoveryService['finalizeProviderRecoveryBindingFailure']> {
+    return this.recoveryService.finalizeProviderRecoveryBindingFailure(launchRecord, failure);
   }
 
   adoptRunningJob(
@@ -288,8 +288,8 @@ export class ExecutionService implements RecoveryCapableService, ProjectRequestP
     result: JobTerminalInput,
     phase: JobPhase,
     options: TerminalWriteOptions & { pool: LaunchPool },
-  ): void {
-    this.recoveryService.completeRecoveredJob(jobId, sessionId, result, phase, options);
+  ): ReturnType<RecoveryService['completeRecoveredJob']> {
+    return this.recoveryService.completeRecoveredJob(jobId, sessionId, result, phase, options);
   }
 
   async finalizeInterruptedDurableJob(

--- a/src/coordinator/index.ts
+++ b/src/coordinator/index.ts
@@ -511,6 +511,7 @@ export function createCoordinatorServer(options: CoordinatorServerOptions = {}):
           coordinatorCommit,
           log: identity.log,
         }),
+        log: identity.log,
         time: runtime.time,
         drainDeadlineMs: resolveDrainDeadlineMs(runtime.env),
         staleAbortTimeoutMs: resolveStaleAbortTimeoutMs(runtime.env),

--- a/src/coordinator/index.ts
+++ b/src/coordinator/index.ts
@@ -474,7 +474,7 @@ export function createCoordinatorServer(options: CoordinatorServerOptions = {}):
       ]);
       signal.throwIfAborted();
 
-      await jobsReconcile.runStartup({
+      const recoveryProgressStore = await jobsReconcile.runStartup({
         recoveryCoordinator,
         namespace: identity.namespace,
         bundleHash: identity.bundleHash,
@@ -502,7 +502,7 @@ export function createCoordinatorServer(options: CoordinatorServerOptions = {}):
 
       await workflowRecover.resumeAll({
         db,
-        progressStore,
+        progressStore: recoveryProgressStore,
         loadJobDetails: loadJobProjectionDetails,
         getExecutionService: (ctx) => getExecutionService(ctx) as never,
         createInvocationContext,
@@ -513,14 +513,16 @@ export function createCoordinatorServer(options: CoordinatorServerOptions = {}):
           log: identity.log,
         }),
         releaseFailedWorkflowDescendants: createFailedWorkflowDescendantReleaser({
-          progressStore,
+          progressStore: recoveryProgressStore,
           runtime,
           coordinatorCommit,
           getExecutionService,
           createInvocationContext,
           releaseAdoptedJob: recoveryCoordinator.releaseAdoptedJob,
           emitSessionReleased: (payload) => eventBus.emit('session:released', payload),
+          log: identity.log,
         }),
+        signal,
         log: identity.log,
         time: runtime.time,
         drainDeadlineMs: resolveDrainDeadlineMs(runtime.env),

--- a/src/coordinator/index.ts
+++ b/src/coordinator/index.ts
@@ -39,6 +39,7 @@ import { ConsumerDrainTimeout, ConsumerDriver } from '../projection-consumers/in
 import type { KbCorpusPublication, KbCorpusSnapshot } from '../kb/contract.js';
 import { documentedCoralSetupError } from '../runtime/errors.js';
 import { createWorkflowRecoveryFinalizer } from './services/workflow-recovery-finalizer.js';
+import { createFailedWorkflowDescendantReleaser } from './services/workflow-recovery-descendants.js';
 import { assertDescriberCoverage } from '../read-model/event-describers.js';
 import { aggregateWorkflowUsage } from '../jobs/workflow-usage.js';
 import { JobStore } from '../jobs/store.js';
@@ -510,6 +511,15 @@ export function createCoordinatorServer(options: CoordinatorServerOptions = {}):
           progressStore,
           coordinatorCommit,
           log: identity.log,
+        }),
+        releaseFailedWorkflowDescendants: createFailedWorkflowDescendantReleaser({
+          progressStore,
+          runtime,
+          coordinatorCommit,
+          getExecutionService,
+          createInvocationContext,
+          releaseAdoptedJob: recoveryCoordinator.releaseAdoptedJob,
+          emitSessionReleased: (payload) => eventBus.emit('session:released', payload),
         }),
         log: identity.log,
         time: runtime.time,

--- a/src/coordinator/services/recovery/actions.ts
+++ b/src/coordinator/services/recovery/actions.ts
@@ -10,7 +10,7 @@ import type { RecoveryAction } from '../../../jobs/reconcile/plan.js';
 import type { RecoveryRegistry } from '../../../jobs/reconcile/registry.js';
 import type { Runtime } from '../../../runtime/ports.js';
 import type { SessionLookup } from '../../../sessions/lookup.js';
-import { releaseSessionJobClaim } from '../../../sessions/job-release.js';
+import { describeSessionJobClaimReleaseResult, releaseSessionJobClaim } from '../../../sessions/job-release.js';
 import type { ProviderRecoveryAuthority, RecoveryCapableService } from '../../../jobs/reconcile/contracts.js';
 import type { RecoveryCommitFence } from '../../../jobs/reconcile/contracts.js';
 import { markJobAsError } from '../../../jobs/reconcile/recovery-effects.js';
@@ -100,9 +100,11 @@ export async function applyRecoveryAction(action: RecoveryAction, ctx: RecoveryA
       const captured = await service.captureProviderRecoveryAuthority(action.launchRecord);
       signal.throwIfAborted();
       if (!captured.ok) {
-        service.finalizeProviderRecoveryBindingFailure(action.launchRecord, captured.failure);
+        const releaseResult = service.finalizeProviderRecoveryBindingFailure(action.launchRecord, captured.failure);
         recoveryRegistry.remove(action.jobId);
-        log(`Rejected queued recovery with invalid provider authority: ${action.jobId}\n`);
+        log(
+          `Rejected queued recovery with invalid provider authority: ${action.jobId}; session claim disposition: ${describeSessionJobClaimReleaseResult(releaseResult)}.\n`,
+        );
         return;
       }
       const { authority } = captured;
@@ -122,19 +124,15 @@ export async function applyRecoveryAction(action: RecoveryAction, ctx: RecoveryA
           try {
             gracefulKillByPid(runtime, action.runtimeRecord.pid);
           } catch (error: unknown) {
-            // RealRuntime.kill swallows signal errors, so only a mocked port reaches
-            // this catch. An EPERM-alive PID was recycled into a process that was never
-            // ours; a failed kill of our own child means it is already gone. Either way,
-            // no owned live process is abandoned.
             log(
-              `Failed to stop rejected recovery process ${action.runtimeRecord.pid} for job ${action.jobId}; no owned live process was abandoned and recovery finalization will continue: ${errorMessage(error)}\n`,
+              `Failed to send SIGTERM to rejected recovery process ${action.runtimeRecord.pid} for job ${action.jobId}; recovery finalization will continue: ${errorMessage(error)}\n`,
             );
           }
         }
-        service.finalizeProviderRecoveryBindingFailure(action.launchRecord, captured.failure);
+        const releaseResult = service.finalizeProviderRecoveryBindingFailure(action.launchRecord, captured.failure);
         recoveryRegistry.remove(action.jobId);
         log(
-          `Rejected running recovery with invalid provider authority: terminalized ${action.jobId}, released its session claim, and recorded the reason. Run coral-cli jobs detail ${action.jobId} for details.\n`,
+          `Rejected running recovery with invalid provider authority: terminalized ${action.jobId}; session claim disposition: ${describeSessionJobClaimReleaseResult(releaseResult)}. Run coral-cli jobs detail ${action.jobId} for the recorded reason.\n`,
         );
         return;
       }
@@ -163,7 +161,7 @@ export async function applyRecoveryAction(action: RecoveryAction, ctx: RecoveryA
         return;
       }
 
-      releaseSessionJobClaim({
+      const releaseResult = releaseSessionJobClaim({
         projectRoot: session.projectRoot,
         runtime,
         emitSessionReleased,
@@ -174,9 +172,13 @@ export async function applyRecoveryAction(action: RecoveryAction, ctx: RecoveryA
       });
       const status = progressStore.readStatus(action.jobId);
       if (status && isTerminalPhase(status.phase)) {
-        log(`Released terminal session claim: ${action.sessionId}\n`);
+        log(
+          `Terminal session claim ${action.sessionId} disposition: ${describeSessionJobClaimReleaseResult(releaseResult)}.\n`,
+        );
       } else {
-        log(`Released orphaned session claim: ${action.sessionId}\n`);
+        log(
+          `Orphaned session claim ${action.sessionId} disposition: ${describeSessionJobClaimReleaseResult(releaseResult)}.\n`,
+        );
       }
       return;
     }

--- a/src/coordinator/services/recovery/actions.ts
+++ b/src/coordinator/services/recovery/actions.ts
@@ -1,4 +1,4 @@
-import { formatError } from '../../../infra/error-format.js';
+import { errorMessage, formatError } from '../../../infra/error-format.js';
 import { isTerminalPhase } from '../../../jobs/phase.js';
 import { isAppServerRuntime, type JobRuntime } from '../../../jobs/records.js';
 import type { DurableCliRuntimeRecord } from '../../../runtime/durable-runtime.js';
@@ -17,6 +17,7 @@ import { markJobAsError } from '../../../jobs/reconcile/recovery-effects.js';
 import { writeResultArtifact } from '../../../jobs/terminal/export.js';
 import type { CommitEventsFn } from '../../../store/append.js';
 import { elapsedDurationMs } from '../../../jobs/duration.js';
+import { gracefulKillByPid } from '../../live/process-supervision.js';
 
 export type QueuedRecoverableJob = { jobId: string; authority: ProviderRecoveryAuthority };
 export type RunningRecoverableJob = {
@@ -119,16 +120,22 @@ export async function applyRecoveryAction(action: RecoveryAction, ctx: RecoveryA
         // try/catch, which would abandon every other job's recovery too.
         if (isDurableCliRuntime(action.runtimeRecord) && runtime.process.isAlive(action.runtimeRecord.pid)) {
           try {
-            runtime.process.kill(action.runtimeRecord.pid, 'SIGTERM');
+            gracefulKillByPid(runtime, action.runtimeRecord.pid);
           } catch (error: unknown) {
-            // A failed stop is not a reason to refuse the whole daemon. The next boot
-            // observes the pid as dead and takes the dead-process path.
-            log(`Failed to stop rejected recovery process ${action.runtimeRecord.pid}: ${formatError(error)}\n`);
+            // RealRuntime.kill swallows signal errors, so only a mocked port reaches
+            // this catch. An EPERM-alive PID was recycled into a process that was never
+            // ours; a failed kill of our own child means it is already gone. Either way,
+            // no owned live process is abandoned.
+            log(
+              `Failed to stop rejected recovery process ${action.runtimeRecord.pid} for job ${action.jobId}; no owned live process was abandoned and recovery finalization will continue: ${errorMessage(error)}\n`,
+            );
           }
         }
         service.finalizeProviderRecoveryBindingFailure(action.launchRecord, captured.failure);
         recoveryRegistry.remove(action.jobId);
-        log(`Rejected running recovery with invalid provider authority: ${action.jobId}\n`);
+        log(
+          `Rejected running recovery with invalid provider authority: terminalized ${action.jobId}, released its session claim, and recorded the reason. Run coral-cli jobs detail ${action.jobId} for details.\n`,
+        );
         return;
       }
       const { authority } = captured;

--- a/src/coordinator/services/recovery/actions.ts
+++ b/src/coordinator/services/recovery/actions.ts
@@ -114,23 +114,17 @@ export async function applyRecoveryAction(action: RecoveryAction, ctx: RecoveryA
       const captured = await service.captureProviderRecoveryAuthority(action.launchRecord);
       signal.throwIfAborted();
       if (!captured.ok) {
+        // A rejected authority is a per-job fault, never a process verdict: throwing
+        // here is fatal to startup because the register loop runs outside the adoption
+        // try/catch, which would abandon every other job's recovery too.
         if (isDurableCliRuntime(action.runtimeRecord) && runtime.process.isAlive(action.runtimeRecord.pid)) {
           try {
             runtime.process.kill(action.runtimeRecord.pid, 'SIGTERM');
           } catch (error: unknown) {
-            throw new Error(
-              `Failed to stop rejected recovery process ${action.runtimeRecord.pid}: ${formatError(error)}`,
-              { cause: error },
-            );
+            // A failed stop is not a reason to refuse the whole daemon. The next boot
+            // observes the pid as dead and takes the dead-process path.
+            log(`Failed to stop rejected recovery process ${action.runtimeRecord.pid}: ${formatError(error)}\n`);
           }
-          throw new Error(
-            `Recovery authority rejected for live durable job ${action.jobId}; process stop requested and launch fence retained.`,
-          );
-        }
-        if (isAppServerRuntime(action.runtimeRecord)) {
-          throw new Error(
-            `Recovery authority rejected for app-server job ${action.jobId}; provider work cannot be stopped without the persisted binding.`,
-          );
         }
         service.finalizeProviderRecoveryBindingFailure(action.launchRecord, captured.failure);
         recoveryRegistry.remove(action.jobId);

--- a/src/coordinator/services/recovery/index.ts
+++ b/src/coordinator/services/recovery/index.ts
@@ -1,4 +1,5 @@
-import { formatError } from '../../../infra/error-format.js';
+import { errorMessage, formatError } from '../../../infra/error-format.js';
+import { isTerminalPhase } from '../../../jobs/phase.js';
 import { isAppServerRuntime } from '../../../jobs/records.js';
 import { isDurableCliRuntime } from '../../../runtime/durable-runtime.js';
 import type { InvocationContext } from '../../../runtime/invocation-context.js';
@@ -23,6 +24,7 @@ import {
   type RunningRecoverableJob,
 } from './actions.js';
 import { buildRecoverySnapshot } from './snapshot.js';
+import { releaseSessionJobClaim } from '../../../sessions/job-release.js';
 import type { SessionLookup } from '../../../sessions/lookup.js';
 
 const RECOVERY_POLL_MS = 500;
@@ -80,6 +82,7 @@ type RecoveryAdoptionContext = {
   queuedJobs: QueuedRecoverableJob[];
   runningJobs: RunningRecoverableJob[];
   signal: AbortSignal;
+  coordinatorCommit: CommitEventsFn;
   interruptedAppServerReason: InterruptedAppServerReason;
 };
 
@@ -210,28 +213,69 @@ export function createRecoveryCoordinator({
     queuedJobs,
     runningJobs,
     signal,
+    coordinatorCommit,
     interruptedAppServerReason,
   }: RecoveryAdoptionContext): Promise<void> {
     /**
-     * A job whose recovery cannot be resolved is a per-job fault, never a process
-     * verdict. Terminalizing with the thrown reason keeps the cause queryable through
-     * the job's own cause chain instead of leaving the job at `running` forever, and
-     * `releaseJob` preserves `conversationRef`/`providerContinuity`, so the session
-     * stays resumable.
+     * Persist an unresolvable recovery as a per-job terminal fault, release any
+     * matching session claim, and remove registry ownership so startup can continue.
      */
     const recordUnresolvedRecovery = (jobId: string, summary: string, error: unknown): void => {
       const status = progressStore.readStatus(jobId);
-      if (status !== null) {
+      if (status === null) {
+        state.recoveryRegistry?.remove(jobId);
+        log(
+          `${summary} for ${jobId}: ${errorMessage(error)}; job status was unavailable, so no terminal or session claim could be updated.\n`,
+        );
+        return;
+      }
+
+      const alreadyTerminal = isTerminalPhase(status.phase);
+      if (!alreadyTerminal) {
         markJobAsError(
           progressStore,
           status,
-          { kind: 'recovery_parse_failed', cause: { message: `${summary}: ${formatError(error)}` } },
+          {
+            kind: 'recovery_parse_failed',
+            cause: {
+              message: `${summary}: ${errorMessage(error)}`,
+              ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+            },
+          },
           runtime.time.now(),
           log,
         );
       }
-      state.recoveryRegistry?.remove(jobId);
-      log(`${summary} for ${jobId}: ${formatError(error)}\n`);
+
+      let releasedSessionClaim = status.sessionId === null;
+      try {
+        if (status.sessionId !== null) {
+          releaseSessionJobClaim({
+            projectRoot: status.projectRoot,
+            runtime,
+            emitSessionReleased: (payload) => eventBus.emit('session:released', payload),
+            db: progressStore.getDb(),
+            commitEvents: coordinatorCommit,
+            sessionId: status.sessionId,
+            jobId,
+          });
+          releasedSessionClaim = true;
+        }
+      } finally {
+        state.recoveryRegistry?.remove(jobId);
+        const terminalDisposition = alreadyTerminal
+          ? 'job was already terminal'
+          : 'terminalized as recovery_parse_failed';
+        const sessionDisposition =
+          status.sessionId === null
+            ? 'no session claim was present'
+            : releasedSessionClaim
+              ? 'released its session claim'
+              : 'could not release its session claim';
+        log(
+          `${summary} for ${jobId}: ${errorMessage(error)}; ${terminalDisposition}; ${sessionDisposition}. Run coral-cli jobs detail ${jobId} for the recorded reason.\n`,
+        );
+      }
     };
 
     queuedJobs.sort((a, b) => a.authority.launchRecord.enqueueSequence - b.authority.launchRecord.enqueueSequence);
@@ -523,6 +567,7 @@ export function createRecoveryCoordinator({
           queuedJobs: queuedRecoverable,
           runningJobs: runningRecoverable,
           signal,
+          coordinatorCommit: ctx.coordinatorCommit,
           interruptedAppServerReason,
         });
       } catch (error: unknown) {

--- a/src/coordinator/services/recovery/index.ts
+++ b/src/coordinator/services/recovery/index.ts
@@ -1,6 +1,13 @@
 import { errorMessage, formatError } from '../../../infra/error-format.js';
 import { isTerminalPhase } from '../../../jobs/phase.js';
-import { isAppServerRuntime } from '../../../jobs/records.js';
+import { isAppServerRuntime, type JobLaunch, type JobStatus } from '../../../jobs/records.js';
+import {
+  decodeProjectionJobExecutionOwner,
+  decodeProjectionJobStoredRow,
+  decodeProjectionJobTerminal,
+  PROJECTION_JOB_COLUMNS,
+  type ProjectionJobStoredRow,
+} from '../../../jobs/projection-row.js';
 import { isDurableCliRuntime } from '../../../runtime/durable-runtime.js';
 import type { InvocationContext } from '../../../runtime/invocation-context.js';
 import type { JobStore } from '../../../jobs/store.js';
@@ -49,6 +56,7 @@ type RecoveryCoordinatorState = {
 
 export interface RecoveryCoordinator {
   runStartupRecovery(ctx: StartupRecoveryContext): Promise<void>;
+  releaseAdoptedJob(jobId: string): void;
   getRecoveryRegistry(): RecoveryRegistry | null;
   isIdleBlocked(): boolean;
   teardown(): Promise<void>;
@@ -86,6 +94,36 @@ type RecoveryAdoptionContext = {
   coordinatorCommit: CommitEventsFn;
   interruptedAppServerReason: InterruptedAppServerReason;
 };
+
+type RecoveryHydrationFallback = {
+  status: JobStatus;
+  launchCreatedAt: string;
+};
+
+function candidateJobId(raw: unknown): string | null {
+  if (typeof raw !== 'object' || raw === null || !('job_id' in raw)) {
+    return null;
+  }
+  return typeof raw.job_id === 'string' && raw.job_id.length > 0 ? raw.job_id : null;
+}
+
+function recoveryStatusFromProjectionRow(row: ProjectionJobStoredRow): JobStatus {
+  const result = decodeProjectionJobTerminal(row);
+  return {
+    jobId: row.job_id,
+    owner: decodeProjectionJobExecutionOwner(row),
+    sessionId: row.session_id,
+    provider: row.provider,
+    projectRoot: row.project_root,
+    backendNamespace: row.backend_namespace,
+    ...(row.bundle_hash === null ? {} : { bundleHash: row.bundle_hash }),
+    jobKind: row.job_kind,
+    phase: row.phase,
+    updatedAt: row.created_at,
+    lastSeq: row.last_seq,
+    ...(result === null ? {} : { result }),
+  };
+}
 
 export function createRecoveryCoordinator({
   progressStore,
@@ -154,17 +192,18 @@ export function createRecoveryCoordinator({
     return cleanup;
   };
 
+  const maybeReleaseRecoveryRegistry = (): void => {
+    if (state.adoptedRunningPids.size === 0 && state.recoveryRegistry?.size === 0) {
+      state.recoveryRegistry = null;
+    }
+  };
+
   const releaseAdoptedJob = (jobId: string): void => {
     clearRecoveryPoller(jobId);
     state.adoptedRunningPids.delete(jobId);
     state.recoveryRegistry?.clearCancelled(jobId);
     takeAdoptedJobCleanup(jobId)?.();
-  };
-
-  const maybeReleaseRecoveryRegistry = (): void => {
-    if (state.adoptedRunningPids.size === 0 && state.recoveryRegistry?.size === 0) {
-      state.recoveryRegistry = null;
-    }
+    maybeReleaseRecoveryRegistry();
   };
 
   const resetRecoveryState = (options: { forceRegistryRelease?: boolean } = {}): void => {
@@ -215,8 +254,9 @@ export function createRecoveryCoordinator({
     summary: string,
     error: unknown,
     coordinatorCommit: CommitEventsFn,
+    hydrationFallback?: RecoveryHydrationFallback,
   ): void => {
-    const status = progressStore.readStatus(jobId);
+    const status = hydrationFallback?.status ?? progressStore.readStatus(jobId);
     if (status === null) {
       try {
         state.recoveryRegistry?.remove(jobId);
@@ -234,8 +274,15 @@ export function createRecoveryCoordinator({
     let recoveryUpdateError: unknown = null;
     try {
       if (!alreadyTerminal) {
+        const terminalStore =
+          hydrationFallback === undefined
+            ? progressStore
+            : ({
+                commit: (cb) => [...(coordinatorCommit(cb) ?? [])],
+                readLaunchProjection: () => ({ createdAt: hydrationFallback.launchCreatedAt }) as JobLaunch,
+              } satisfies Pick<JobStore, 'commit' | 'readLaunchProjection'>);
         markJobAsError(
-          progressStore,
+          terminalStore,
           status,
           {
             kind: 'recovery_parse_failed',
@@ -280,7 +327,9 @@ export function createRecoveryCoordinator({
               : 'session claim release failed';
       const nextStep =
         recoveryUpdateError === null
-          ? `Run coral-cli jobs detail ${jobId} for the recorded reason.`
+          ? hydrationFallback === undefined
+            ? `Run coral-cli jobs detail ${jobId} for the recorded reason.`
+            : 'The persisted-detail decode failure is included in this log.'
           : `Recovery state update failed: ${errorMessage(recoveryUpdateError)}. Resolve the store write failure and restart the coordinator.`;
       try {
         state.recoveryRegistry?.remove(jobId);
@@ -290,6 +339,70 @@ export function createRecoveryCoordinator({
         );
       }
     }
+  };
+
+  const hydrateRecoveryJobDetails = (
+    coordinatorCommit: CommitEventsFn,
+    excludedJobIds: ReadonlySet<string> = new Set(),
+  ): {
+    detailsByJob: Map<string, ReturnType<JobStore['loadJobProjectionDetail']>>;
+    excludedJobIds: Set<string>;
+  } => {
+    const detailsByJob = new Map<string, ReturnType<JobStore['loadJobProjectionDetail']>>();
+    const excluded = new Set(excludedJobIds);
+    const rawRows = progressStore
+      .getDb()
+      .prepare(`SELECT ${PROJECTION_JOB_COLUMNS} FROM projection_jobs ORDER BY job_id ASC`)
+      .all();
+    const rows: ProjectionJobStoredRow[] = [];
+    let sawUndecodableProjection = false;
+
+    for (const raw of rawRows) {
+      const possibleJobId = candidateJobId(raw);
+      if (possibleJobId !== null && excluded.has(possibleJobId)) {
+        continue;
+      }
+
+      let row: ProjectionJobStoredRow;
+      try {
+        row = decodeProjectionJobStoredRow(raw);
+      } catch (error: unknown) {
+        sawUndecodableProjection = true;
+        if (possibleJobId === null) {
+          log(`Skipped malformed persisted job projection with no decodable job id: ${errorMessage(error)}\n`);
+        } else {
+          log(
+            `Skipped malformed persisted job projection with unverified job id ${possibleJobId}: ${errorMessage(error)}; recovery authority could not be decoded, so no terminal or session claim was updated.\n`,
+          );
+          excluded.add(possibleJobId);
+        }
+        continue;
+      }
+
+      rows.push(row);
+    }
+
+    for (const row of rows) {
+      if (sawUndecodableProjection && row.job_kind === 'workflow') {
+        excluded.add(row.job_id);
+        log(
+          `Skipped hydrating workflow job ${row.job_id} after another persisted job projection could not be decoded; no terminal or session claim was updated for ${row.job_id}.\n`,
+        );
+        continue;
+      }
+
+      try {
+        detailsByJob.set(row.job_id, progressStore.loadJobProjectionDetail(row.job_id));
+      } catch (error: unknown) {
+        excluded.add(row.job_id);
+        recordUnresolvedRecovery(row.job_id, 'Persisted job recovery hydration failed', error, coordinatorCommit, {
+          status: recoveryStatusFromProjectionRow(row),
+          launchCreatedAt: row.created_at,
+        });
+      }
+    }
+
+    return { detailsByJob, excludedJobIds: excluded };
   };
 
   async function runRecoveryAdoption({
@@ -561,12 +674,30 @@ export function createRecoveryCoordinator({
       const queuedRecoverable: QueuedRecoverableJob[] = [];
       const runningRecoverable: RunningRecoverableJob[] = [];
 
-      const adoptedCount = adoptOrphanedCrossNamespaceJobs(namespace, progressStore, runtime.time.now(), log);
+      const initialHydration = hydrateRecoveryJobDetails(ctx.coordinatorCommit);
+      let adoptedCount = 0;
+      try {
+        adoptedCount = adoptOrphanedCrossNamespaceJobs(namespace, progressStore, runtime.time.now(), log);
+      } catch (error: unknown) {
+        log(
+          `Cross-namespace adoption could not inspect every persisted job projection: ${errorMessage(error)}; startup recovery will continue with the individually hydrated jobs.\n`,
+        );
+      }
       if (adoptedCount > 0) {
         log(`Adopted ${adoptedCount} orphaned cross-namespace job(s)\n`);
       }
 
-      const snapshot = buildRecoverySnapshot(progressStore, namespace, log, ctx.sessionLookup, runtime.process);
+      const { detailsByJob } = hydrateRecoveryJobDetails(ctx.coordinatorCommit, initialHydration.excludedJobIds);
+      const hydratedProgressStore = Object.create(progressStore) as JobStore;
+      hydratedProgressStore.listJobIds = () => [...detailsByJob.keys()];
+      hydratedProgressStore.loadJobProjectionDetail = (jobId) => {
+        const detail = detailsByJob.get(jobId);
+        if (detail === undefined) {
+          throw new Error(`Recovery snapshot requested job ${jobId} outside the hydrated job set.`);
+        }
+        return detail;
+      };
+      const snapshot = buildRecoverySnapshot(hydratedProgressStore, namespace, log, ctx.sessionLookup, runtime.process);
       const plan = planRecovery(snapshot);
 
       const applyPlanAction = async (action: Parameters<typeof applyRecoveryAction>[0]): Promise<void> => {
@@ -612,7 +743,11 @@ export function createRecoveryCoordinator({
         await applyPlanAction(action);
       }
 
-      cleanupStaleJobs(bundleHash);
+      try {
+        cleanupStaleJobs(bundleHash);
+      } catch (error: unknown) {
+        log(`Stale job artifact cleanup did not complete: ${errorMessage(error)}; startup recovery will continue.\n`);
+      }
 
       if (queuedRecoverable.length === 0 && runningRecoverable.length === 0) {
         resetRecoveryState();
@@ -667,6 +802,7 @@ export function createRecoveryCoordinator({
         resetRecoveryState({ forceRegistryRelease: true });
       }
     },
+    releaseAdoptedJob,
     getRecoveryRegistry: () => state.recoveryRegistry,
     isIdleBlocked: () => state.adoptedRunningPids.size > 0 || (state.recoveryRegistry?.size ?? 0) > 0,
     teardown,

--- a/src/coordinator/services/recovery/index.ts
+++ b/src/coordinator/services/recovery/index.ts
@@ -24,7 +24,8 @@ import {
   type RunningRecoverableJob,
 } from './actions.js';
 import { buildRecoverySnapshot } from './snapshot.js';
-import { releaseSessionJobClaim } from '../../../sessions/job-release.js';
+import { describeSessionJobClaimReleaseResult, releaseSessionJobClaim } from '../../../sessions/job-release.js';
+import type { SessionJobClaimReleaseResult } from '../../../sessions/contracts.js';
 import type { SessionLookup } from '../../../sessions/lookup.js';
 
 const RECOVERY_POLL_MS = 500;
@@ -209,28 +210,29 @@ export function createRecoveryCoordinator({
     resetRecoveryState({ forceRegistryRelease: true });
   };
 
-  async function runRecoveryAdoption({
-    queuedJobs,
-    runningJobs,
-    signal,
-    coordinatorCommit,
-    interruptedAppServerReason,
-  }: RecoveryAdoptionContext): Promise<void> {
-    /**
-     * Persist an unresolvable recovery as a per-job terminal fault, release any
-     * matching session claim, and remove registry ownership so startup can continue.
-     */
-    const recordUnresolvedRecovery = (jobId: string, summary: string, error: unknown): void => {
-      const status = progressStore.readStatus(jobId);
-      if (status === null) {
+  const recordUnresolvedRecovery = (
+    jobId: string,
+    summary: string,
+    error: unknown,
+    coordinatorCommit: CommitEventsFn,
+  ): void => {
+    const status = progressStore.readStatus(jobId);
+    if (status === null) {
+      try {
         state.recoveryRegistry?.remove(jobId);
+      } finally {
         log(
           `${summary} for ${jobId}: ${errorMessage(error)}; job status was unavailable, so no terminal or session claim could be updated.\n`,
         );
-        return;
       }
+      return;
+    }
 
-      const alreadyTerminal = isTerminalPhase(status.phase);
+    const alreadyTerminal = isTerminalPhase(status.phase);
+    let terminalized = alreadyTerminal;
+    let releaseResult: SessionJobClaimReleaseResult | null = null;
+    let recoveryUpdateError: unknown = null;
+    try {
       if (!alreadyTerminal) {
         markJobAsError(
           progressStore,
@@ -245,39 +247,58 @@ export function createRecoveryCoordinator({
           runtime.time.now(),
           log,
         );
+        terminalized = true;
       }
 
-      let releasedSessionClaim = status.sessionId === null;
+      if (status.sessionId !== null) {
+        releaseResult = releaseSessionJobClaim({
+          projectRoot: status.projectRoot,
+          runtime,
+          emitSessionReleased: (payload) => eventBus.emit('session:released', payload),
+          db: progressStore.getDb(),
+          commitEvents: coordinatorCommit,
+          sessionId: status.sessionId,
+          jobId,
+        });
+      }
+    } catch (updateError: unknown) {
+      recoveryUpdateError = updateError;
+      throw updateError;
+    } finally {
+      const terminalDisposition = alreadyTerminal
+        ? 'job was already terminal'
+        : terminalized
+          ? 'terminalized as recovery_parse_failed'
+          : 'could not terminalize as recovery_parse_failed';
+      const sessionDisposition =
+        status.sessionId === null
+          ? 'no session claim was recorded on the job'
+          : !terminalized
+            ? 'session claim release was not attempted because terminalization failed'
+            : releaseResult !== null
+              ? `session claim disposition: ${describeSessionJobClaimReleaseResult(releaseResult)}`
+              : 'session claim release failed';
+      const nextStep =
+        recoveryUpdateError === null
+          ? `Run coral-cli jobs detail ${jobId} for the recorded reason.`
+          : `Recovery state update failed: ${errorMessage(recoveryUpdateError)}. Resolve the store write failure and restart the coordinator.`;
       try {
-        if (status.sessionId !== null) {
-          releaseSessionJobClaim({
-            projectRoot: status.projectRoot,
-            runtime,
-            emitSessionReleased: (payload) => eventBus.emit('session:released', payload),
-            db: progressStore.getDb(),
-            commitEvents: coordinatorCommit,
-            sessionId: status.sessionId,
-            jobId,
-          });
-          releasedSessionClaim = true;
-        }
-      } finally {
         state.recoveryRegistry?.remove(jobId);
-        const terminalDisposition = alreadyTerminal
-          ? 'job was already terminal'
-          : 'terminalized as recovery_parse_failed';
-        const sessionDisposition =
-          status.sessionId === null
-            ? 'no session claim was present'
-            : releasedSessionClaim
-              ? 'released its session claim'
-              : 'could not release its session claim';
+      } finally {
         log(
-          `${summary} for ${jobId}: ${errorMessage(error)}; ${terminalDisposition}; ${sessionDisposition}. Run coral-cli jobs detail ${jobId} for the recorded reason.\n`,
+          `${summary} for ${jobId}: ${errorMessage(error)}; ${terminalDisposition}; ${sessionDisposition}. ${nextStep}\n`,
         );
       }
-    };
+    }
+  };
 
+  async function runRecoveryAdoption({
+    queuedJobs,
+    runningJobs,
+    signal,
+    coordinatorCommit,
+    interruptedAppServerReason,
+  }: RecoveryAdoptionContext): Promise<void> {
     queuedJobs.sort((a, b) => a.authority.launchRecord.enqueueSequence - b.authority.launchRecord.enqueueSequence);
 
     let maxRecoverableSeq: number | null = null;
@@ -324,7 +345,12 @@ export function createRecoveryCoordinator({
             await finalization;
           } catch (error: unknown) {
             if ((error as { name?: string } | null)?.name === 'AbortError') throw error;
-            recordUnresolvedRecovery(jobId, 'Interrupted app-server recovery remains incomplete', error);
+            recordUnresolvedRecovery(
+              jobId,
+              'Interrupted app-server recovery remains incomplete',
+              error,
+              coordinatorCommit,
+            );
             continue;
           }
           signal.throwIfAborted();
@@ -384,7 +410,12 @@ export function createRecoveryCoordinator({
             );
           } catch (error: unknown) {
             if ((error as { name?: string } | null)?.name === 'AbortError') throw error;
-            recordUnresolvedRecovery(jobId, 'Interrupted durable recovery remains incomplete', error);
+            recordUnresolvedRecovery(
+              jobId,
+              'Interrupted durable recovery remains incomplete',
+              error,
+              coordinatorCommit,
+            );
             state.recoveryRegistry?.clearCancelled(jobId);
             continue;
           }
@@ -471,8 +502,8 @@ export function createRecoveryCoordinator({
           cleanup?.();
           throw error;
         }
-        log(`Failed to adopt running job ${jobId}: ${formatError(error)}\n`);
-        state.recoveryRegistry?.remove(jobId);
+        cleanup?.();
+        recordUnresolvedRecovery(jobId, 'Running recovery adoption failed', error, coordinatorCommit);
       }
     }
 
@@ -493,8 +524,7 @@ export function createRecoveryCoordinator({
         log(`Recovered queued job: ${jobId}\n`);
       } catch (error: unknown) {
         if ((error as { name?: string } | null)?.name === 'AbortError') throw error;
-        log(`Failed to recover queued job ${jobId}: ${formatError(error)}\n`);
-        state.recoveryRegistry?.remove(jobId);
+        recordUnresolvedRecovery(jobId, 'Queued recovery adoption failed', error, coordinatorCommit);
       }
     }
 
@@ -543,7 +573,17 @@ export function createRecoveryCoordinator({
         } catch (error: unknown) {
           logRecoveryActionFailure(action, error, log);
           if (action.type === 'registerQueued' || action.type === 'registerRunning') {
-            throw error;
+            if ((error as { name?: string } | null)?.name === 'AbortError') {
+              throw error;
+            }
+            recordUnresolvedRecovery(
+              action.jobId,
+              action.type === 'registerQueued'
+                ? 'Queued recovery registration failed'
+                : 'Running recovery registration failed',
+              error,
+              ctx.coordinatorCommit,
+            );
           }
         }
       };

--- a/src/coordinator/services/recovery/index.ts
+++ b/src/coordinator/services/recovery/index.ts
@@ -55,7 +55,7 @@ type RecoveryCoordinatorState = {
 };
 
 export interface RecoveryCoordinator {
-  runStartupRecovery(ctx: StartupRecoveryContext): Promise<void>;
+  runStartupRecovery(ctx: StartupRecoveryContext): Promise<JobStore>;
   releaseAdoptedJob(jobId: string): void;
   getRecoveryRegistry(): RecoveryRegistry | null;
   isIdleBlocked(): boolean;
@@ -330,7 +330,7 @@ export function createRecoveryCoordinator({
           ? hydrationFallback === undefined
             ? `Run coral-cli jobs detail ${jobId} for the recorded reason.`
             : 'The persisted-detail decode failure is included in this log.'
-          : `Recovery state update failed: ${errorMessage(recoveryUpdateError)}. Resolve the store write failure and restart the coordinator.`;
+          : `Recovery state disposition did not complete: ${errorMessage(recoveryUpdateError)}. Inspect the persisted state and coordinator log before restarting.`;
       try {
         state.recoveryRegistry?.remove(jobId);
       } finally {
@@ -355,7 +355,6 @@ export function createRecoveryCoordinator({
       .prepare(`SELECT ${PROJECTION_JOB_COLUMNS} FROM projection_jobs ORDER BY job_id ASC`)
       .all();
     const rows: ProjectionJobStoredRow[] = [];
-    let sawUndecodableProjection = false;
 
     for (const raw of rawRows) {
       const possibleJobId = candidateJobId(raw);
@@ -367,7 +366,6 @@ export function createRecoveryCoordinator({
       try {
         row = decodeProjectionJobStoredRow(raw);
       } catch (error: unknown) {
-        sawUndecodableProjection = true;
         if (possibleJobId === null) {
           log(`Skipped malformed persisted job projection with no decodable job id: ${errorMessage(error)}\n`);
         } else {
@@ -383,14 +381,6 @@ export function createRecoveryCoordinator({
     }
 
     for (const row of rows) {
-      if (sawUndecodableProjection && row.job_kind === 'workflow') {
-        excluded.add(row.job_id);
-        log(
-          `Skipped hydrating workflow job ${row.job_id} after another persisted job projection could not be decoded; no terminal or session claim was updated for ${row.job_id}.\n`,
-        );
-        continue;
-      }
-
       try {
         detailsByJob.set(row.job_id, progressStore.loadJobProjectionDetail(row.job_id));
       } catch (error: unknown) {
@@ -664,7 +654,7 @@ export function createRecoveryCoordinator({
   }
 
   return {
-    async runStartupRecovery(ctx: StartupRecoveryContext): Promise<void> {
+    async runStartupRecovery(ctx: StartupRecoveryContext): Promise<JobStore> {
       const { namespace, bundleHash, runtime, progressStore, signal, log, cleanupStaleJobs } = ctx;
       const interruptedAppServerReason: InterruptedAppServerReason = ctx.interruptedAppServerReason ?? 'restart';
       state.teardownRequested = false;
@@ -751,7 +741,7 @@ export function createRecoveryCoordinator({
 
       if (queuedRecoverable.length === 0 && runningRecoverable.length === 0) {
         resetRecoveryState();
-        return;
+        return hydratedProgressStore;
       }
 
       try {
@@ -801,6 +791,7 @@ export function createRecoveryCoordinator({
         }
         resetRecoveryState({ forceRegistryRelease: true });
       }
+      return hydratedProgressStore;
     },
     releaseAdoptedJob,
     getRecoveryRegistry: () => state.recoveryRegistry,

--- a/src/coordinator/services/recovery/index.ts
+++ b/src/coordinator/services/recovery/index.ts
@@ -481,12 +481,29 @@ export function createRecoveryCoordinator({
               maybeReleaseRecoveryRegistry();
             })
             .catch((error: unknown) => {
-              if (retainedCleanup !== null) {
-                state.adoptedRunningJobCleanups.set(jobId, retainedCleanup);
+              if ((error as { name?: string } | null)?.name === 'AbortError') {
+                try {
+                  retainedCleanup?.();
+                } finally {
+                  maybeReleaseRecoveryRegistry();
+                }
+                return;
               }
-              state.recoveryRegistry?.register(jobId, launchRecord, adoptedRuntimeRecord);
-              runtimeState.setLaunchFenceActive(true);
-              log(`Failed to finalize adopted job ${jobId}: ${formatError(error)}\n`);
+              try {
+                recordUnresolvedRecovery(
+                  jobId,
+                  'Adopted durable recovery finalization failed',
+                  error,
+                  coordinatorCommit,
+                );
+                state.recoveryRegistry?.clearCancelled(jobId);
+              } finally {
+                try {
+                  retainedCleanup?.();
+                } finally {
+                  maybeReleaseRecoveryRegistry();
+                }
+              }
             });
           void finalization.catch((error: unknown) => {
             log(`Durable finalization cleanup failed for ${jobId}: ${formatError(error)}\n`);

--- a/src/coordinator/services/recovery/index.ts
+++ b/src/coordinator/services/recovery/index.ts
@@ -27,15 +27,6 @@ import type { SessionLookup } from '../../../sessions/lookup.js';
 
 const RECOVERY_POLL_MS = 500;
 
-class InterruptedRecoveryBlockedError extends Error {
-  readonly jobId: string;
-  constructor(jobId: string, message: string, cause: unknown) {
-    super(message, { cause });
-    this.name = 'InterruptedRecoveryBlockedError';
-    this.jobId = jobId;
-  }
-}
-
 type RecoveryCoordinatorState = {
   recoveryRegistry: RecoveryRegistry | null;
   cancelledRecoveryJobIds: Set<string>;
@@ -221,6 +212,28 @@ export function createRecoveryCoordinator({
     signal,
     interruptedAppServerReason,
   }: RecoveryAdoptionContext): Promise<void> {
+    /**
+     * A job whose recovery cannot be resolved is a per-job fault, never a process
+     * verdict. Terminalizing with the thrown reason keeps the cause queryable through
+     * the job's own cause chain instead of leaving the job at `running` forever, and
+     * `releaseJob` preserves `conversationRef`/`providerContinuity`, so the session
+     * stays resumable.
+     */
+    const recordUnresolvedRecovery = (jobId: string, summary: string, error: unknown): void => {
+      const status = progressStore.readStatus(jobId);
+      if (status !== null) {
+        markJobAsError(
+          progressStore,
+          status,
+          { kind: 'recovery_parse_failed', cause: { message: `${summary}: ${formatError(error)}` } },
+          runtime.time.now(),
+          log,
+        );
+      }
+      state.recoveryRegistry?.remove(jobId);
+      log(`${summary} for ${jobId}: ${formatError(error)}\n`);
+    };
+
     queuedJobs.sort((a, b) => a.authority.launchRecord.enqueueSequence - b.authority.launchRecord.enqueueSequence);
 
     let maxRecoverableSeq: number | null = null;
@@ -267,11 +280,8 @@ export function createRecoveryCoordinator({
             await finalization;
           } catch (error: unknown) {
             if ((error as { name?: string } | null)?.name === 'AbortError') throw error;
-            throw new InterruptedRecoveryBlockedError(
-              jobId,
-              `Interrupted app-server recovery remains incomplete for ${jobId}.`,
-              error,
-            );
+            recordUnresolvedRecovery(jobId, 'Interrupted app-server recovery remains incomplete', error);
+            continue;
           }
           signal.throwIfAborted();
           state.recoveryRegistry?.remove(jobId);
@@ -330,11 +340,9 @@ export function createRecoveryCoordinator({
             );
           } catch (error: unknown) {
             if ((error as { name?: string } | null)?.name === 'AbortError') throw error;
-            throw new InterruptedRecoveryBlockedError(
-              jobId,
-              `Interrupted durable recovery remains incomplete for ${jobId}.`,
-              error,
-            );
+            recordUnresolvedRecovery(jobId, 'Interrupted durable recovery remains incomplete', error);
+            state.recoveryRegistry?.clearCancelled(jobId);
+            continue;
           }
           state.recoveryRegistry?.remove(jobId);
           state.recoveryRegistry?.clearCancelled(jobId);
@@ -416,10 +424,6 @@ export function createRecoveryCoordinator({
         log(`Adopted running job: ${jobId} (pid=${runtimeRecord.pid})\n`);
       } catch (error: unknown) {
         if ((error as { name?: string } | null)?.name === 'AbortError') {
-          cleanup?.();
-          throw error;
-        }
-        if (error instanceof InterruptedRecoveryBlockedError) {
           cleanup?.();
           throw error;
         }
@@ -523,10 +527,6 @@ export function createRecoveryCoordinator({
         });
       } catch (error: unknown) {
         if ((error as { name?: string } | null)?.name === 'AbortError') {
-          throw error;
-        }
-        if (error instanceof InterruptedRecoveryBlockedError) {
-          log(`Recovery launch fence retained: ${formatError(error)}\n`);
           throw error;
         }
         log(`Recovery adoption failed: ${formatError(error)}\n`);

--- a/src/coordinator/services/recovery/service.ts
+++ b/src/coordinator/services/recovery/service.ts
@@ -9,9 +9,14 @@ import type { DurableCliRuntimeRecord, DurableProcessExit } from '../../../runti
 import { providerSessionProvider, type ProviderSession } from '../../../sessions/entry.js';
 import type { ProviderBindingCatalog } from '../../../providers/catalog.js';
 import type { ProviderBindingFailure } from '../../../providers/contracts/binding.js';
-import type { JobAdmissionPort, JobLaunchRecoveryPort, LaunchPool } from '../../../jobs/contracts/admission.js';
+import type {
+  JobAdmissionPort,
+  JobLaunchRecoveryPort,
+  LaunchPool,
+  QueuedHandle,
+} from '../../../jobs/contracts/admission.js';
 import type { JobProgressStore, TerminalWriteOptions } from '../../../jobs/contracts/job-store.js';
-import type { SessionRecoveryPort } from '../../../sessions/contracts.js';
+import type { SessionJobClaimReleaseResult, SessionRecoveryPort } from '../../../sessions/contracts.js';
 import type { Runtime } from '../../../runtime/ports.js';
 import type { BoundProvider, BoundProviderHostPreparationInput } from '../../../providers/bound-provider-contract.js';
 import type { JobAbortRegistryPort } from '../../../jobs/contracts/abort-registry.js';
@@ -129,11 +134,13 @@ export class RecoveryService {
     return { ok: true, session, bound: binding.value, continuity: continuity.value };
   }
 
-  finalizeProviderRecoveryBindingFailure(launchRecord: JobLaunch, failure: ProviderBindingFailure): void {
+  finalizeProviderRecoveryBindingFailure(
+    launchRecord: JobLaunch,
+    failure: ProviderBindingFailure,
+  ): SessionJobClaimReleaseResult {
     requireProviderLaunchRecord(launchRecord, 'finalizeProviderRecoveryBindingFailure');
-    if (launchRecord.sessionId === null) return;
     const message = this.deps.providerRegistry.renderBindingFailure(failure);
-    this.completeRecoveredJob(
+    return this.completeRecoveredJob(
       launchRecord.jobId,
       launchRecord.sessionId,
       {
@@ -240,29 +247,34 @@ export class RecoveryService {
     const pool = launchRecord.pool;
     const jobId = launchRecord.jobId;
 
-    this.deps.jobPools.set(jobId, pool);
+    let queuedHandle: QueuedHandle | null = null;
+    try {
+      this.deps.jobPools.set(jobId, pool);
+      queuedHandle = this.deps.launchRecovery.restoreQueuedLaunch(
+        jobId,
+        launchRecord.provider,
+        launchRecord.owner,
+        pool,
+      );
+      this.deps.abortRegistry.register(jobId, () => {
+        queuedHandle?.cancel();
+      });
 
-    const queuedHandle = this.deps.launchRecovery.restoreQueuedLaunch(
-      jobId,
-      launchRecord.provider,
-      launchRecord.owner,
-      pool,
-    );
-    this.deps.abortRegistry.register(jobId, () => {
-      queuedHandle.cancel();
-    });
+      this.deps.progressStore.rebindNamespace(jobId, this.deps.backendNamespace, this.deps.bundleHash);
 
-    this.deps.progressStore.rebindNamespace(jobId, this.deps.backendNamespace, this.deps.bundleHash);
+      this.deps.launchOrchestrator.runRecoveredQueuedJob(
+        boundProvider,
+        launchRecord,
+        queuedHandle,
+        pool,
+        this.queuedRecoveryChildEnv(session, jobId),
+      );
 
-    this.deps.launchOrchestrator.runRecoveredQueuedJob(
-      boundProvider,
-      launchRecord,
-      queuedHandle,
-      pool,
-      this.queuedRecoveryChildEnv(session, jobId),
-    );
-
-    return jobId;
+      return jobId;
+    } catch (error: unknown) {
+      this.cleanupRecoveryRegistration(jobId, pool, queuedHandle);
+      throw error;
+    }
   }
 
   async finalizeInterruptedDurableJob(
@@ -310,15 +322,19 @@ export class RecoveryService {
     if (!isDurableCliRuntime(runtimeRecord)) {
       throw new Error(`Unsupported runtime transport for adoptRunningJob(${jobId}): ${runtimeRecord.transport}`);
     }
-    this.deps.jobPools.set(jobId, pool);
+    try {
+      this.deps.jobPools.set(jobId, pool);
+      this.deps.launchRecovery.restoreActiveLaunch(jobId, launchRecord.provider, launchRecord.owner, pool);
+      this.deps.progressStore.rebindNamespace(jobId, this.deps.backendNamespace, this.deps.bundleHash);
 
-    this.deps.launchRecovery.restoreActiveLaunch(jobId, launchRecord.provider, launchRecord.owner, pool);
-    this.deps.progressStore.rebindNamespace(jobId, this.deps.backendNamespace, this.deps.bundleHash);
-
-    const pid = runtimeRecord.pid;
-    this.deps.abortRegistry.register(jobId, () => {
-      this.deps.runtime.process.kill(pid, 'SIGTERM');
-    });
+      const pid = runtimeRecord.pid;
+      this.deps.abortRegistry.register(jobId, () => {
+        this.deps.runtime.process.kill(pid, 'SIGTERM');
+      });
+    } catch (error: unknown) {
+      this.cleanupRecoveryRegistration(jobId, pool);
+      throw error;
+    }
 
     let cleaned = false;
     return {
@@ -326,12 +342,19 @@ export class RecoveryService {
       cleanup: () => {
         if (cleaned) return;
         cleaned = true;
-        if (!this.deps.jobPools.has(jobId)) return;
-        this.deps.abortRegistry.remove(jobId);
-        this.deps.jobPools.delete(jobId);
-        this.deps.launchAdmission.releaseLaunch(jobId, pool);
+        this.cleanupRecoveryRegistration(jobId, pool);
       },
     };
+  }
+
+  private cleanupRecoveryRegistration(jobId: string, pool: LaunchPool, queuedHandle: QueuedHandle | null = null): void {
+    if (queuedHandle !== null) {
+      void queuedHandle.waitForPermit().catch(() => undefined);
+      queuedHandle.cancel();
+    }
+    this.deps.abortRegistry.remove(jobId);
+    this.deps.jobPools.delete(jobId);
+    this.deps.launchAdmission.releaseLaunch(jobId, pool);
   }
 
   completeRecoveredJob(
@@ -340,7 +363,7 @@ export class RecoveryService {
     result: JobTerminalInput,
     phase: JobPhase,
     options: TerminalWriteOptions & { pool: LaunchPool },
-  ): void {
+  ): SessionJobClaimReleaseResult {
     const currentStatus = this.deps.progressStore.readStatus(jobId);
     if (!currentStatus || !isTerminalPhase(currentStatus.phase)) {
       this.deps.launchOrchestrator.writeJobTerminal(jobId, sessionId, result, phase, {
@@ -357,12 +380,13 @@ export class RecoveryService {
     } catch (error: unknown) {
       backendLog.warn(`Writing terminal artifact failed for ${jobId}: ${String(error)}`);
     }
-    this.deps.sessionManager.releaseJob(sessionId, jobId);
+    const releaseResult = this.deps.sessionManager.releaseJob(sessionId, jobId);
 
     const pool = this.deps.jobPools.get(jobId) ?? options.pool;
     this.deps.abortRegistry.remove(jobId);
     this.deps.jobPools.delete(jobId);
     this.deps.launchAdmission.releaseLaunch(jobId, pool);
+    return releaseResult;
   }
 
   private sessionProviderContinuity(

--- a/src/coordinator/services/recovery/snapshot.ts
+++ b/src/coordinator/services/recovery/snapshot.ts
@@ -34,7 +34,11 @@ export function buildRecoverySnapshot(
   const sessionRefs: Array<{ sessionId: string; provider: string }> = [];
   const sessionsById = new Map<string, RecoverySessionFacts | null>();
 
-  for (const sessionRef of sessionLookup.listSessionRefs()) {
+  const listedSessionRefs = sessionLookup.listSessionRefs((sessionId, error) => {
+    const subject = sessionId === null ? 'with no decodable session id' : `for ${sessionId}`;
+    log(`Skipped malformed session projection ${subject} during recovery snapshot: ${formatError(error)}\n`);
+  });
+  for (const sessionRef of listedSessionRefs) {
     try {
       const entry = sessionLookup.readProviderSession(sessionRef.sessionId);
       let sessionFacts: RecoverySessionFacts | null = null;

--- a/src/coordinator/services/workflow-recovery-descendants.ts
+++ b/src/coordinator/services/workflow-recovery-descendants.ts
@@ -1,0 +1,63 @@
+import type { ProjectRequestPort } from '../contracts.js';
+import type { InvocationContext } from '../../runtime/invocation-context.js';
+import type { JobStore } from '../../jobs/store.js';
+import type { Runtime } from '../../runtime/ports.js';
+import type { CommitEventsFn } from '../../store/append.js';
+import { releaseSessionJobClaim } from '../../sessions/job-release.js';
+import type { WorkflowRecoveryDescendantRelease } from '../../workflow/recover.js';
+
+type FailedWorkflowDescendantReleaserDeps = {
+  progressStore: Pick<JobStore, 'getDb' | 'listJobIds' | 'readStatus'>;
+  runtime: Runtime;
+  coordinatorCommit: CommitEventsFn;
+  getExecutionService: (ctx: InvocationContext) => Pick<ProjectRequestPort, 'abort'>;
+  createInvocationContext: (projectRoot: string) => InvocationContext;
+  releaseAdoptedJob: (jobId: string) => void;
+  emitSessionReleased: (payload: { sessionId: string; jobId: string }) => void;
+};
+
+export function createFailedWorkflowDescendantReleaser(
+  deps: FailedWorkflowDescendantReleaserDeps,
+): (workflowId: string) => readonly WorkflowRecoveryDescendantRelease[] {
+  return (workflowId) => {
+    const releases: WorkflowRecoveryDescendantRelease[] = [];
+    const descendantPrefix = `${workflowId}:`;
+
+    for (const jobId of deps.progressStore.listJobIds()) {
+      if (!jobId.startsWith(descendantPrefix)) {
+        continue;
+      }
+
+      const status = deps.progressStore.readStatus(jobId);
+      if (status === null || status.owner.kind !== 'workflow' || status.owner.id !== workflowId) {
+        continue;
+      }
+
+      try {
+        deps.getExecutionService(deps.createInvocationContext(status.projectRoot)).abort([jobId]);
+      } finally {
+        deps.releaseAdoptedJob(jobId);
+      }
+
+      if (status.sessionId === null) {
+        continue;
+      }
+
+      releases.push({
+        jobId,
+        sessionId: status.sessionId,
+        sessionClaimRelease: releaseSessionJobClaim({
+          projectRoot: status.projectRoot,
+          runtime: deps.runtime,
+          emitSessionReleased: deps.emitSessionReleased,
+          db: deps.progressStore.getDb(),
+          commitEvents: deps.coordinatorCommit,
+          sessionId: status.sessionId,
+          jobId,
+        }),
+      });
+    }
+
+    return releases;
+  };
+}

--- a/src/coordinator/services/workflow-recovery-descendants.ts
+++ b/src/coordinator/services/workflow-recovery-descendants.ts
@@ -5,6 +5,7 @@ import type { Runtime } from '../../runtime/ports.js';
 import type { CommitEventsFn } from '../../store/append.js';
 import { releaseSessionJobClaim } from '../../sessions/job-release.js';
 import type { WorkflowRecoveryDescendantRelease } from '../../workflow/recover.js';
+import { errorMessage } from '../../infra/error-format.js';
 
 type FailedWorkflowDescendantReleaserDeps = {
   progressStore: Pick<JobStore, 'getDb' | 'listJobIds' | 'readStatus'>;
@@ -14,6 +15,7 @@ type FailedWorkflowDescendantReleaserDeps = {
   createInvocationContext: (projectRoot: string) => InvocationContext;
   releaseAdoptedJob: (jobId: string) => void;
   emitSessionReleased: (payload: { sessionId: string; jobId: string }) => void;
+  log: (message: string) => void;
 };
 
 export function createFailedWorkflowDescendantReleaser(
@@ -28,34 +30,61 @@ export function createFailedWorkflowDescendantReleaser(
         continue;
       }
 
-      const status = deps.progressStore.readStatus(jobId);
+      let status: ReturnType<typeof deps.progressStore.readStatus>;
+      try {
+        status = deps.progressStore.readStatus(jobId);
+      } catch (error: unknown) {
+        deps.log(
+          `Workflow recovery could not read child ${jobId}; did not change adopted runtime ownership or any session claim: ${errorMessage(error)}\n`,
+        );
+        continue;
+      }
       if (status === null || status.owner.kind !== 'workflow' || status.owner.id !== workflowId) {
         continue;
       }
 
       try {
         deps.getExecutionService(deps.createInvocationContext(status.projectRoot)).abort([jobId]);
-      } finally {
+      } catch (error: unknown) {
+        const claimDisposition =
+          status.sessionId === null ? 'no session claim was recorded' : `session claim ${status.sessionId}`;
+        deps.log(
+          `Workflow recovery could not confirm child ${jobId} stopped; retained adopted runtime ownership and ${claimDisposition}: ${errorMessage(error)}\n`,
+        );
+        continue;
+      }
+
+      try {
         deps.releaseAdoptedJob(jobId);
+      } catch (error: unknown) {
+        deps.log(
+          `Workflow recovery could not release adopted runtime ownership for stopped child ${jobId}: ${errorMessage(error)}\n`,
+        );
       }
 
       if (status.sessionId === null) {
         continue;
       }
 
-      releases.push({
-        jobId,
-        sessionId: status.sessionId,
-        sessionClaimRelease: releaseSessionJobClaim({
-          projectRoot: status.projectRoot,
-          runtime: deps.runtime,
-          emitSessionReleased: deps.emitSessionReleased,
-          db: deps.progressStore.getDb(),
-          commitEvents: deps.coordinatorCommit,
-          sessionId: status.sessionId,
+      try {
+        releases.push({
           jobId,
-        }),
-      });
+          sessionId: status.sessionId,
+          sessionClaimRelease: releaseSessionJobClaim({
+            projectRoot: status.projectRoot,
+            runtime: deps.runtime,
+            emitSessionReleased: deps.emitSessionReleased,
+            db: deps.progressStore.getDb(),
+            commitEvents: deps.coordinatorCommit,
+            sessionId: status.sessionId,
+            jobId,
+          }),
+        });
+      } catch (error: unknown) {
+        deps.log(
+          `Workflow recovery session claim release did not complete normally for stopped child ${jobId} session ${status.sessionId}: ${errorMessage(error)}\n`,
+        );
+      }
     }
 
     return releases;

--- a/src/infra/time.ts
+++ b/src/infra/time.ts
@@ -13,6 +13,10 @@ export function nowIsoString(timeOrEpoch: TimeNowPort | number): string {
   return new Date(epochMs).toISOString();
 }
 
+export function parseIsoTimestamp(value: string): number {
+  return Date.parse(value);
+}
+
 export function createRealTimePort(): TimePort {
   return {
     now: () => Date.now(),

--- a/src/jobs/outcome.ts
+++ b/src/jobs/outcome.ts
@@ -108,7 +108,7 @@ export function describeJobProgressFault(fault: JobProgressFault): string {
       return 'Job status record is missing its launch record; dropping.';
     case 'recovery_parse_failed':
       return appendCauseStack(
-        `Provider recovery could not parse resumed state: ${fault.cause.message}.`,
+        `Provider recovery could not resolve resumed state: ${fault.cause.message}.`,
         fault.cause.stack,
       );
     default:

--- a/src/jobs/reconcile/contracts.ts
+++ b/src/jobs/reconcile/contracts.ts
@@ -7,6 +7,7 @@ import type { LaunchPool } from '../contracts/admission.js';
 import type { BoundProvider } from '../../providers/bound-provider-contract.js';
 import type { DurableCliRuntimeRecord, DurableProcessExit } from '../../runtime/durable-runtime.js';
 import type { ProviderBindingFailure } from '../../providers/contracts/binding.js';
+import type { SessionJobClaimReleaseResult } from '../../sessions/contracts.js';
 
 export type ProviderRecoveryLaunch = JobLaunch & {
   readonly sessionId: string;
@@ -45,7 +46,10 @@ export type ProviderRecoveryAuthorityCapture =
 
 export interface RecoveryCapableService {
   captureProviderRecoveryAuthority(launchRecord: JobLaunch): Promise<ProviderRecoveryAuthorityCapture>;
-  finalizeProviderRecoveryBindingFailure(launchRecord: JobLaunch, failure: ProviderBindingFailure): void;
+  finalizeProviderRecoveryBindingFailure(
+    launchRecord: JobLaunch,
+    failure: ProviderBindingFailure,
+  ): SessionJobClaimReleaseResult;
   finalizeInterruptedAppServerJob(
     authority: ProviderRecoveryAuthority,
     runtimeRecord: AppServerRuntime,
@@ -73,5 +77,5 @@ export interface RecoveryCapableService {
     result: JobTerminalInput,
     phase: JobPhase,
     options: TerminalWriteOptions & { pool: LaunchPool },
-  ): void;
+  ): SessionJobClaimReleaseResult;
 }

--- a/src/jobs/startup.ts
+++ b/src/jobs/startup.ts
@@ -33,15 +33,15 @@ type JobsStartupContext = {
 };
 
 interface JobsRecoveryCoordinator {
-  runStartupRecovery(ctx: JobsStartupContext): Promise<void>;
+  runStartupRecovery(ctx: JobsStartupContext): Promise<JobStore>;
 }
 
 type JobsStartupDeps = JobsStartupContext & {
   recoveryCoordinator: JobsRecoveryCoordinator;
 };
 
-async function runJobsStartup({ recoveryCoordinator, ...deps }: JobsStartupDeps): Promise<void> {
-  await recoveryCoordinator.runStartupRecovery(deps);
+async function runJobsStartup({ recoveryCoordinator, ...deps }: JobsStartupDeps): Promise<JobStore> {
+  return recoveryCoordinator.runStartupRecovery(deps);
 }
 
 export const jobsReconcile = {

--- a/src/jobs/workflow-usage.ts
+++ b/src/jobs/workflow-usage.ts
@@ -2,7 +2,6 @@ import type { Database } from '../store/db.js';
 
 import { USAGE_TOKEN_FIELDS, type UsageSummary } from '../providers/contract.js';
 import { jobDiagnosticsSchema } from './terminal/result.js';
-import { readProjectionJobRows } from './projection-row.js';
 
 const TOKEN_FIELDS = USAGE_TOKEN_FIELDS;
 
@@ -26,9 +25,14 @@ function hasUsageValue(usage: UsageSummary): boolean {
 export function aggregateWorkflowUsage(db: Database, workflowJobId: string): UsageSummary | undefined {
   // Workflow aggregates intentionally sum direct child jobs only; nested
   // workflow jobs contribute through their own terminal diagnostics.
-  const rows: WorkflowUsageRow[] = readProjectionJobRows(db).filter(
-    (row) => row.parent_workflow_job_id === workflowJobId,
-  );
+  const rows = db
+    .prepare<[string], WorkflowUsageRow>(
+      `SELECT diagnostics
+         FROM projection_jobs
+        WHERE parent_workflow_job_id = ?
+        ORDER BY job_id ASC`,
+    )
+    .all(workflowJobId);
 
   const result: UsageSummary = {};
   let sawUsage = false;

--- a/src/sessions/contracts.ts
+++ b/src/sessions/contracts.ts
@@ -29,6 +29,7 @@ export type SessionAllocateOptions = {
 
 export type SessionJobContinuityCheckpointResult = { ok: true; nextVersion: number } | { ok: false };
 export type SessionArtifactHandleRecordResult = { ok: true; nextVersion: number } | { ok: false };
+export type SessionJobClaimReleaseResult = 'released' | 'already_absent' | 'owned_by_another_job';
 
 export type SessionArtifactHandleRecordOptions = {
   expectedActiveJobId: string;
@@ -43,7 +44,7 @@ export interface SessionJobReadPort {
 }
 
 export interface SessionJobClaimPort extends SessionJobReadPort {
-  releaseJob(sessionId: string, jobId: string): void;
+  releaseJob(sessionId: string, jobId: string): SessionJobClaimReleaseResult;
   checkpointJobContinuityAtomic(
     sessionId: string,
     options: {
@@ -91,7 +92,7 @@ export interface SessionExecutionPort extends SessionInitialLaunchPort {
   allocate(options: SessionAllocateOptions): ProviderSession;
   get(provider: string, sessionId: string): ProviderSession | null;
   list(provider: string): ProviderSession[];
-  releaseJob(sessionId: string, jobId: string): void;
+  releaseJob(sessionId: string, jobId: string): SessionJobClaimReleaseResult;
   recordContinuationLease(input: RecordContinuationLeaseInput): void;
   clearContinuationLease(input: ClearContinuationLeaseInput): Promise<boolean>;
 }
@@ -99,7 +100,7 @@ export interface SessionExecutionPort extends SessionInitialLaunchPort {
 export interface SessionRecoveryPort {
   get(provider: string, sessionId: string): ProviderSession | null;
   readById(sessionId: string, options?: { forceFresh?: boolean }): ProviderSession | null;
-  releaseJob(sessionId: string, jobId: string): void;
+  releaseJob(sessionId: string, jobId: string): SessionJobClaimReleaseResult;
   finalizeJobContinuityAtomic(
     sessionId: string,
     options: {

--- a/src/sessions/job-release.ts
+++ b/src/sessions/job-release.ts
@@ -2,6 +2,7 @@ import type { Database } from '../store/db.js';
 
 import type { Runtime } from '../runtime/ports.js';
 import { SessionManager } from './shell.js';
+import type { SessionJobClaimReleaseResult } from './contracts.js';
 import type { CommitEventsFn } from '../store/append.js';
 
 export type SessionReleasedEmitter = (payload: { sessionId: string; jobId: string }) => void;
@@ -20,8 +21,8 @@ export function releaseSessionJobClaim(options: {
   emitSessionReleased: SessionReleasedEmitter;
   sessionId: string;
   jobId: string;
-}): void {
-  SessionManager.forProduction(
+}): SessionJobClaimReleaseResult {
+  return SessionManager.forProduction(
     options.projectRoot,
     options.runtime,
     options.commitEvents,
@@ -30,4 +31,15 @@ export function releaseSessionJobClaim(options: {
       db: options.db,
     },
   ).releaseJob(options.sessionId, options.jobId);
+}
+
+export function describeSessionJobClaimReleaseResult(result: SessionJobClaimReleaseResult): string {
+  switch (result) {
+    case 'released':
+      return 'released';
+    case 'already_absent':
+      return 'already absent';
+    case 'owned_by_another_job':
+      return 'owned by another job';
+  }
 }

--- a/src/sessions/lifecycle-reactor.ts
+++ b/src/sessions/lifecycle-reactor.ts
@@ -163,7 +163,7 @@ export class LifecycleReactor {
       }),
     );
     this.enqueueWork(
-      readSessionRetentionWorkForEntries(db, this.options.readCtx, listProjectionSessionEntries(db), {
+      readSessionRetentionWorkForEntries(db, this.options.readCtx, this.listLifecycleSessionEntries(db), {
         nowMs: this.options.time.now(),
       }),
     );
@@ -471,10 +471,17 @@ export class LifecycleReactor {
   }
 
   private pendingContinuationLeaseEntries(): Array<ProviderSession & { continuationLease: PendingContinuationLease }> {
-    return listProjectionSessionEntries(this.options.db()).filter(
+    return this.listLifecycleSessionEntries(this.options.db()).filter(
       (entry): entry is ProviderSession & { continuationLease: PendingContinuationLease } =>
         entry.continuationLease?.status === 'pending',
     );
+  }
+
+  private listLifecycleSessionEntries(db: ReadonlyDatabase): ProviderSession[] {
+    return listProjectionSessionEntries(db, undefined, undefined, (sessionId, error) => {
+      const subject = sessionId === null ? 'with no decodable session id' : `for ${sessionId}`;
+      this.log(`Skipped malformed session projection ${subject} during lifecycle processing: ${errorMessage(error)}`);
+    });
   }
 
   private expireOverdueContinuationLeases(): string[] {

--- a/src/sessions/lookup.ts
+++ b/src/sessions/lookup.ts
@@ -8,14 +8,14 @@ type SessionLookupRef = {
 };
 
 export interface SessionLookup {
-  listSessionRefs(): SessionLookupRef[];
+  listSessionRefs(onInvalidRow?: (sessionId: string | null, error: unknown) => void): SessionLookupRef[];
   readProviderSession(sessionId: string): ProviderSession | null;
 }
 
 export function createProjectionSessionLookup(db: ReadonlyDatabase): SessionLookup {
   return {
-    listSessionRefs(): SessionLookupRef[] {
-      return listProjectionSessionEntries(db).map((entry) => ({
+    listSessionRefs(onInvalidRow): SessionLookupRef[] {
+      return listProjectionSessionEntries(db, undefined, undefined, onInvalidRow).map((entry) => ({
         sessionId: entry.sessionId,
         provider: providerSessionProvider(entry),
       }));

--- a/src/sessions/projections.ts
+++ b/src/sessions/projections.ts
@@ -453,6 +453,7 @@ export function listProjectionSessionEntries(
   db: ReadonlyDatabase,
   provider?: string,
   scopeKey?: string,
+  onInvalidRow?: (sessionId: string | null, error: unknown) => void,
 ): ProviderSession[] {
   const rows = db
     .prepare(
@@ -462,7 +463,21 @@ export function listProjectionSessionEntries(
     )
     .all();
 
-  const decoded = rows.map(decodeProjectionSessionAuthorityRow);
+  const decoded = rows.flatMap((raw) => {
+    try {
+      return [decodeProjectionSessionAuthorityRow(raw)];
+    } catch (error: unknown) {
+      if (onInvalidRow === undefined) {
+        throw error;
+      }
+      const sessionId =
+        typeof raw === 'object' && raw !== null && 'session_id' in raw && typeof raw.session_id === 'string'
+          ? raw.session_id
+          : null;
+      onInvalidRow(sessionId, error);
+      return [];
+    }
+  });
   const scoped = scopeKey === undefined ? decoded : decoded.filter(({ row }) => row.scope_key === scopeKey);
   const entries = scoped.map(({ entry }) => entry);
   return provider === undefined ? entries : entries.filter((entry) => providerSessionProvider(entry) === provider);

--- a/src/sessions/shell.ts
+++ b/src/sessions/shell.ts
@@ -34,6 +34,7 @@ import type {
   SessionAllocateOptions,
   SessionArtifactHandleRecordOptions,
   SessionArtifactHandleRecordResult,
+  SessionJobClaimReleaseResult,
 } from './contracts.js';
 import { sessionsRegistry } from './events.js';
 import type {
@@ -810,9 +811,10 @@ export class SessionManager {
   }
 
   /** Release job claim: clear activeJobId. */
-  releaseJob(sessionId: string, jobId: string): void {
+  releaseJob(sessionId: string, jobId: string): SessionJobClaimReleaseResult {
     const entry = this.readEntry(sessionId);
-    if (!entry || entry.activeJobId !== jobId) return;
+    if (!entry || entry.activeJobId === undefined) return 'already_absent';
+    if (entry.activeJobId !== jobId) return 'owned_by_another_job';
     const now = nowIsoString(this.time);
     const clearedLease =
       entry.continuationLease?.status === 'claimed' && entry.continuationLease.resumedJobId === jobId
@@ -839,6 +841,7 @@ export class SessionManager {
       this.populateCache(sessionId, clearedEntry);
     }
     this.releaseEmitter({ sessionId, jobId });
+    return 'released';
   }
 
   /** Provider-scoped lookup. Returns null if sessionId not found or provider mismatch. */

--- a/src/transport/http/backend/status.ts
+++ b/src/transport/http/backend/status.ts
@@ -11,6 +11,8 @@ import { TransientHttpError } from '../../../infra/http-errors.js';
 
 const RECENT_STARTUP_DIAGNOSTIC_MS = 5 * 60_000;
 
+type PublicDiagnosticPhase = 'startup_failed' | 'fatal_shutdown_error' | 'bootstrap_unhandled_rejection';
+
 type BackendStatus =
   | {
       // CLI-level verdict. The daemon-side coarse lifecycle field
@@ -38,23 +40,28 @@ type BackendStatus =
 export type BackendStatusFull =
   | { status: 'ok'; health: Extract<BackendStatus, { status: 'ok' }> }
   | { status: 'shutting_down' | 'unauthorized' | 'not_running' }
-  | { status: 'recent_failure'; phase: string; reason: string };
+  | { status: 'recent_failure'; phase: PublicDiagnosticPhase };
 
 type RecentFailureStatus = Extract<BackendStatusFull, { status: 'recent_failure' }>;
+
+function isPublicDiagnosticPhase(value: unknown): value is PublicDiagnosticPhase {
+  return value === 'startup_failed' || value === 'fatal_shutdown_error' || value === 'bootstrap_unhandled_rejection';
+}
 
 export function statusFromStartupDiagnostic(
   value: unknown,
   now: number,
   earliestRecordedAt = Number.NEGATIVE_INFINITY,
+  expectedPid?: number,
 ): RecentFailureStatus | null {
   if (
     !isRecord(value) ||
     value.schemaVersion !== 1 ||
     value.state !== 'stopped_with_diagnostic' ||
     value.retryable !== false ||
-    typeof value.phase !== 'string' ||
-    value.phase.length === 0 ||
-    typeof value.recordedAt !== 'string'
+    !isPublicDiagnosticPhase(value.phase) ||
+    typeof value.recordedAt !== 'string' ||
+    !isRecord(value.error)
   ) {
     return null;
   }
@@ -68,25 +75,13 @@ export function statusFromStartupDiagnostic(
     !Number.isFinite(recordedAt) ||
     recordedAt < earliestRecordedAt ||
     recordedAt > now ||
-    now - recordedAt > RECENT_STARTUP_DIAGNOSTIC_MS
+    now - recordedAt > RECENT_STARTUP_DIAGNOSTIC_MS ||
+    (expectedPid !== undefined && value.pid !== expectedPid)
   ) {
     return null;
   }
 
-  const reason = deepestDiagnosticErrorMessage(value.error);
-  return reason === null ? null : { status: 'recent_failure', phase: value.phase, reason };
-}
-
-function deepestDiagnosticErrorMessage(error: unknown): string | null {
-  let current = error;
-  let reason: string | null = null;
-  while (isRecord(current)) {
-    if (typeof current.message === 'string' && current.message.trim().length > 0) {
-      reason = current.message.trim().replace(/\s+/g, ' ');
-    }
-    current = current.cause;
-  }
-  return reason;
+  return { status: 'recent_failure', phase: value.phase };
 }
 
 function noDaemonStatus(
@@ -94,10 +89,11 @@ function noDaemonStatus(
   diagnosticFile: string,
   now: number,
   earliestRecordedAt?: number,
+  expectedPid?: number,
 ): BackendStatusFull {
   try {
     const value: unknown = JSON.parse(storage.readFileSync(diagnosticFile, 'utf-8'));
-    return statusFromStartupDiagnostic(value, now, earliestRecordedAt) ?? { status: 'not_running' };
+    return statusFromStartupDiagnostic(value, now, earliestRecordedAt, expectedPid) ?? { status: 'not_running' };
   } catch {
     return { status: 'not_running' };
   }
@@ -116,6 +112,7 @@ export async function getBackendStatusFull(pluginRoot: string): Promise<BackendS
       runtime.paths.coral.coordinator.startupDiagnosticFile,
       runtime.time.now(),
       info?.startedAt,
+      info?.pid,
     );
   }
 
@@ -125,6 +122,7 @@ export async function getBackendStatusFull(pluginRoot: string): Promise<BackendS
       runtime.paths.coral.coordinator.startupDiagnosticFile,
       runtime.time.now(),
       info.startedAt,
+      info.pid,
     );
 
   try {

--- a/src/transport/http/backend/status.ts
+++ b/src/transport/http/backend/status.ts
@@ -1,10 +1,15 @@
 import { readBackendInfo } from '../../../infra/backend-discovery.js';
 import { readBuildFlavor } from '../../../infra/bundle-manifest.js';
+import { isRecord } from '../../../infra/json.js';
 import { isProcessAlive } from '../../../infra/node-process.js';
+import type { StoragePort } from '../../../infra/port-types.js';
+import { parseIsoTimestamp } from '../../../infra/time.js';
 import { createRealRuntime } from '../../../runtime/real.js';
 import { HEALTH_TIMEOUT_MS, parseJsonResponse } from '../sse.js';
 import { isBackendHealth, isBackendPing, type BackendHealth } from './health.js';
 import { TransientHttpError } from '../../../infra/http-errors.js';
+
+const RECENT_STARTUP_DIAGNOSTIC_MS = 5 * 60_000;
 
 type BackendStatus =
   | {
@@ -32,7 +37,71 @@ type BackendStatus =
 
 export type BackendStatusFull =
   | { status: 'ok'; health: Extract<BackendStatus, { status: 'ok' }> }
-  | { status: 'shutting_down' | 'unauthorized' | 'not_running' };
+  | { status: 'shutting_down' | 'unauthorized' | 'not_running' }
+  | { status: 'recent_failure'; phase: string; reason: string };
+
+type RecentFailureStatus = Extract<BackendStatusFull, { status: 'recent_failure' }>;
+
+export function statusFromStartupDiagnostic(
+  value: unknown,
+  now: number,
+  earliestRecordedAt = Number.NEGATIVE_INFINITY,
+): RecentFailureStatus | null {
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== 1 ||
+    value.state !== 'stopped_with_diagnostic' ||
+    value.retryable !== false ||
+    typeof value.phase !== 'string' ||
+    value.phase.length === 0 ||
+    typeof value.recordedAt !== 'string'
+  ) {
+    return null;
+  }
+
+  const recordedAt = parseIsoTimestamp(value.recordedAt);
+  // A status probe has no spawn-attempt ID to compare. Five minutes covers the
+  // 5s bind and 15s readiness budgets plus operator handoff, while proving only
+  // a recent failed attempt, not an ongoing loop. The discovery start time also
+  // prevents a prior attempt's diagnostic from describing a newer daemon.
+  if (
+    !Number.isFinite(recordedAt) ||
+    recordedAt < earliestRecordedAt ||
+    recordedAt > now ||
+    now - recordedAt > RECENT_STARTUP_DIAGNOSTIC_MS
+  ) {
+    return null;
+  }
+
+  const reason = deepestDiagnosticErrorMessage(value.error);
+  return reason === null ? null : { status: 'recent_failure', phase: value.phase, reason };
+}
+
+function deepestDiagnosticErrorMessage(error: unknown): string | null {
+  let current = error;
+  let reason: string | null = null;
+  while (isRecord(current)) {
+    if (typeof current.message === 'string' && current.message.trim().length > 0) {
+      reason = current.message.trim().replace(/\s+/g, ' ');
+    }
+    current = current.cause;
+  }
+  return reason;
+}
+
+function noDaemonStatus(
+  storage: Pick<StoragePort, 'readFileSync'>,
+  diagnosticFile: string,
+  now: number,
+  earliestRecordedAt?: number,
+): BackendStatusFull {
+  try {
+    const value: unknown = JSON.parse(storage.readFileSync(diagnosticFile, 'utf-8'));
+    return statusFromStartupDiagnostic(value, now, earliestRecordedAt) ?? { status: 'not_running' };
+  } catch {
+    return { status: 'not_running' };
+  }
+}
 
 export async function getBackendStatusFull(pluginRoot: string): Promise<BackendStatusFull> {
   const runtime = createRealRuntime(readBuildFlavor(pluginRoot));
@@ -41,7 +110,22 @@ export async function getBackendStatusFull(pluginRoot: string): Promise<BackendS
     env: runtime.env,
     paths: runtime.paths,
   });
-  if (!info || !isProcessAlive(info.pid)) return { status: 'not_running' };
+  if (!info || !isProcessAlive(info.pid)) {
+    return noDaemonStatus(
+      runtime.storage,
+      runtime.paths.coral.coordinator.startupDiagnosticFile,
+      runtime.time.now(),
+      info?.startedAt,
+    );
+  }
+
+  const unreachableStatus = (): BackendStatusFull =>
+    noDaemonStatus(
+      runtime.storage,
+      runtime.paths.coral.coordinator.startupDiagnosticFile,
+      runtime.time.now(),
+      info.startedAt,
+    );
 
   try {
     const pingResponse = await fetch(`http://${info.host}:${info.port}/health`, {
@@ -51,7 +135,7 @@ export async function getBackendStatusFull(pluginRoot: string): Promise<BackendS
     const pingBody = await parseJsonResponse(pingResponse);
     if (pingResponse.status === 200) {
       if (!isBackendPing(pingBody) || pingBody.namespace !== info.namespace || pingBody.flavor !== info.flavor) {
-        return { status: 'not_running' };
+        return unreachableStatus();
       }
       if (pingBody.status === 'draining') {
         return { status: 'shutting_down' };
@@ -59,7 +143,7 @@ export async function getBackendStatusFull(pluginRoot: string): Promise<BackendS
     } else if (pingResponse.status === 503 || TransientHttpError.isTransientStatus(pingResponse.status)) {
       return { status: 'shutting_down' };
     } else {
-      return { status: 'not_running' };
+      return unreachableStatus();
     }
 
     const healthResponse = await fetch(`http://${info.host}:${info.port}/health?detailed=1`, {
@@ -70,7 +154,7 @@ export async function getBackendStatusFull(pluginRoot: string): Promise<BackendS
     const body = await parseJsonResponse(healthResponse);
     if (healthResponse.status === 200) {
       if (!isBackendHealth(body) || body.namespace !== info.namespace || body.flavor !== info.flavor) {
-        return { status: 'not_running' };
+        return unreachableStatus();
       }
       if (body.status === 'draining') {
         return { status: 'shutting_down' };
@@ -82,8 +166,8 @@ export async function getBackendStatusFull(pluginRoot: string): Promise<BackendS
       return { status: 'shutting_down' };
     }
     if (healthResponse.status === 401) return { status: 'unauthorized' };
-    return { status: 'not_running' };
+    return unreachableStatus();
   } catch {
-    return { status: 'not_running' };
+    return unreachableStatus();
   }
 }

--- a/src/workflow/recover.ts
+++ b/src/workflow/recover.ts
@@ -2,6 +2,8 @@ import type { Database } from '../store/db.js';
 
 import { errorMessage } from '../infra/error-format.js';
 import { isAbortError } from '../runtime/abort.js';
+import { describeSessionJobClaimReleaseResult } from '../sessions/job-release.js';
+import type { SessionJobClaimReleaseResult } from '../sessions/contracts.js';
 import type { InvocationContext } from '../runtime/invocation-context.js';
 import type { TimePort } from '../infra/port-types.js';
 import { nowIsoString } from '../infra/time.js';
@@ -46,6 +48,12 @@ type WorkflowSlotJobRow = ProjectionJobStoredRow & { workflow_slot: string };
 type RecoveredWorkflowFinalization = {
   intent: WorkflowFinalizationIntent;
   error?: WorkflowExecutionError;
+};
+
+export type WorkflowRecoveryDescendantRelease = {
+  jobId: string;
+  sessionId: string;
+  sessionClaimRelease: SessionJobClaimReleaseResult;
 };
 
 /**
@@ -820,6 +828,7 @@ export async function resumeAll(options: {
   getExecutionService: (ctx: InvocationContext) => WorkflowExecutionPort;
   createInvocationContext: (projectRoot: string) => InvocationContext;
   finalizeWorkflow: (intent: WorkflowFinalizationIntent) => void;
+  releaseFailedWorkflowDescendants: (workflowId: string) => readonly WorkflowRecoveryDescendantRelease[];
   log?: (message: string) => void;
   onProgress?: (workflowId: string, message: string) => void;
   staleTimeoutMs?: number;
@@ -841,51 +850,42 @@ export async function resumeAll(options: {
     if (!status || status.jobKind !== 'workflow') continue;
     if (status.phase === 'completed' || status.phase === 'error' || status.phase === 'aborted') continue;
 
-    const projection = readWorkflowProjection(options.db, jobId);
-    if (!projection) {
-      options.finalizeWorkflow({
-        outcome: 'failed',
-        workflowJobId: jobId,
-        lifecycleFault: {
-          kind: 'recovery_failed',
-          message: 'Workflow recovery could not find a workflow projection.',
-        },
-        stepDetails: [],
-      });
-      resumedWorkflowIds.push(jobId);
-      continue;
-    }
-
-    const baseCtx = options.createInvocationContext(status.projectRoot);
-    const ctx: InvocationContext = {
-      ...baseCtx,
-      providerScope: projection.providerScope,
-    };
     let recovered: RecoveredWorkflowFinalization | null;
+    let containedFailure: { error: unknown } | null = null;
     try {
-      recovered = await resumeWorkflow({
-        db: options.db,
-        progressStore: options.progressStore,
-        loadJobDetails: options.loadJobDetails,
-        executionSvc: options.getExecutionService(ctx),
-        ctx,
-        workflowId: jobId,
-        plan: projection.plan,
-        onProgress,
-        staleTimeoutMs,
-        staleCheckIntervalMs,
-        staleAbortTimeoutMs,
-        drainDeadlineMs,
-        time,
-      });
+      const projection = readWorkflowProjection(options.db, jobId);
+      if (!projection) {
+        const error = new Error('Workflow recovery could not find a workflow projection.');
+        containedFailure = { error };
+        recovered = { intent: recoveryIntentFromError(jobId, error) };
+      } else {
+        const baseCtx = options.createInvocationContext(status.projectRoot);
+        const ctx: InvocationContext = {
+          ...baseCtx,
+          providerScope: projection.providerScope,
+        };
+        recovered = await resumeWorkflow({
+          db: options.db,
+          progressStore: options.progressStore,
+          loadJobDetails: options.loadJobDetails,
+          executionSvc: options.getExecutionService(ctx),
+          ctx,
+          workflowId: jobId,
+          plan: projection.plan,
+          onProgress,
+          staleTimeoutMs,
+          staleCheckIntervalMs,
+          staleAbortTimeoutMs,
+          drainDeadlineMs,
+          time,
+        });
+      }
     } catch (error: unknown) {
       if (isAbortError(error)) {
         throw error;
       }
-      options.finalizeWorkflow(recoveryIntentFromError(jobId, error));
-      options.log?.(`Workflow recovery finalized ${jobId} after recovery failed: ${errorMessage(error)}\n`);
-      resumedWorkflowIds.push(jobId);
-      continue;
+      containedFailure = { error };
+      recovered = { intent: recoveryIntentFromError(jobId, error) };
     }
 
     if (recovered === null) {
@@ -893,11 +893,25 @@ export async function resumeAll(options: {
     }
 
     options.finalizeWorkflow(recovered.intent);
-    if (recovered.error?.aborted) {
-      throw recovered.error;
+    if (containedFailure !== null) {
+      const releasedDescendants = options.releaseFailedWorkflowDescendants(jobId);
+      for (const released of releasedDescendants) {
+        options.log?.(
+          `Workflow recovery child ${released.jobId} session claim ${released.sessionId} disposition: ${describeSessionJobClaimReleaseResult(released.sessionClaimRelease)}.\n`,
+        );
+      }
+      const outcomeDescription =
+        recovered.intent.outcome === 'failed'
+          ? 'after recovery failed'
+          : `with ${recovered.intent.outcome} outcome after recovery error`;
+      options.log?.(
+        `Workflow recovery finalized ${jobId} ${outcomeDescription}: ${errorMessage(containedFailure.error)}\n`,
+      );
     }
     if (recovered.error) {
-      options.log?.(`Workflow recovery finalized ${jobId} after recovery failed: ${errorMessage(recovered.error)}\n`);
+      options.log?.(
+        `Workflow recovery finalized ${jobId} with ${recovered.intent.outcome} outcome: ${errorMessage(recovered.error)}\n`,
+      );
     }
     resumedWorkflowIds.push(jobId);
   }

--- a/src/workflow/recover.ts
+++ b/src/workflow/recover.ts
@@ -1,6 +1,7 @@
 import type { Database } from '../store/db.js';
 
 import { errorMessage } from '../infra/error-format.js';
+import { isAbortError } from '../runtime/abort.js';
 import type { InvocationContext } from '../runtime/invocation-context.js';
 import type { TimePort } from '../infra/port-types.js';
 import { nowIsoString } from '../infra/time.js';
@@ -819,6 +820,7 @@ export async function resumeAll(options: {
   getExecutionService: (ctx: InvocationContext) => WorkflowExecutionPort;
   createInvocationContext: (projectRoot: string) => InvocationContext;
   finalizeWorkflow: (intent: WorkflowFinalizationIntent) => void;
+  log?: (message: string) => void;
   onProgress?: (workflowId: string, message: string) => void;
   staleTimeoutMs?: number;
   staleCheckIntervalMs?: number;
@@ -877,8 +879,13 @@ export async function resumeAll(options: {
         time,
       });
     } catch (error: unknown) {
+      if (isAbortError(error)) {
+        throw error;
+      }
       options.finalizeWorkflow(recoveryIntentFromError(jobId, error));
-      throw error;
+      options.log?.(`Workflow recovery finalized ${jobId} after recovery failed: ${errorMessage(error)}\n`);
+      resumedWorkflowIds.push(jobId);
+      continue;
     }
 
     if (recovered === null) {
@@ -886,8 +893,11 @@ export async function resumeAll(options: {
     }
 
     options.finalizeWorkflow(recovered.intent);
-    if (recovered.error) {
+    if (recovered.error?.aborted) {
       throw recovered.error;
+    }
+    if (recovered.error) {
+      options.log?.(`Workflow recovery finalized ${jobId} after recovery failed: ${errorMessage(recovered.error)}\n`);
     }
     resumedWorkflowIds.push(jobId);
   }

--- a/src/workflow/recover.ts
+++ b/src/workflow/recover.ts
@@ -1,7 +1,6 @@
 import type { Database } from '../store/db.js';
 
 import { errorMessage } from '../infra/error-format.js';
-import { isAbortError } from '../runtime/abort.js';
 import { describeSessionJobClaimReleaseResult } from '../sessions/job-release.js';
 import type { SessionJobClaimReleaseResult } from '../sessions/contracts.js';
 import type { InvocationContext } from '../runtime/invocation-context.js';
@@ -829,6 +828,7 @@ export async function resumeAll(options: {
   createInvocationContext: (projectRoot: string) => InvocationContext;
   finalizeWorkflow: (intent: WorkflowFinalizationIntent) => void;
   releaseFailedWorkflowDescendants: (workflowId: string) => readonly WorkflowRecoveryDescendantRelease[];
+  signal?: AbortSignal;
   log?: (message: string) => void;
   onProgress?: (workflowId: string, message: string) => void;
   staleTimeoutMs?: number;
@@ -846,6 +846,7 @@ export async function resumeAll(options: {
   const resumedWorkflowIds: string[] = [];
 
   for (const jobId of options.progressStore.listJobIds()) {
+    options.signal?.throwIfAborted();
     const status = options.progressStore.readStatus(jobId);
     if (!status || status.jobKind !== 'workflow') continue;
     if (status.phase === 'completed' || status.phase === 'error' || status.phase === 'aborted') continue;
@@ -881,25 +882,26 @@ export async function resumeAll(options: {
         });
       }
     } catch (error: unknown) {
-      if (isAbortError(error)) {
-        throw error;
-      }
+      options.signal?.throwIfAborted();
       containedFailure = { error };
       recovered = { intent: recoveryIntentFromError(jobId, error) };
     }
 
+    options.signal?.throwIfAborted();
     if (recovered === null) {
       continue;
     }
 
     options.finalizeWorkflow(recovered.intent);
-    if (containedFailure !== null) {
+    if (containedFailure !== null || recovered.error !== undefined) {
       const releasedDescendants = options.releaseFailedWorkflowDescendants(jobId);
       for (const released of releasedDescendants) {
         options.log?.(
           `Workflow recovery child ${released.jobId} session claim ${released.sessionId} disposition: ${describeSessionJobClaimReleaseResult(released.sessionClaimRelease)}.\n`,
         );
       }
+    }
+    if (containedFailure !== null) {
       const outcomeDescription =
         recovered.intent.outcome === 'failed'
           ? 'after recovery failed'

--- a/tests/integration/coordinator/startup-ordering.test.ts
+++ b/tests/integration/coordinator/startup-ordering.test.ts
@@ -59,8 +59,9 @@ describe('coordinator startup ordering', () => {
       await Promise.resolve();
       order.push('waitFreshUntil:resolved');
     });
-    const runStartup = vi.spyOn(jobsReconcile, 'runStartup').mockImplementation(async () => {
+    const runStartup = vi.spyOn(jobsReconcile, 'runStartup').mockImplementation(async (options) => {
       order.push('jobsReconcile.runStartup');
+      return options.progressStore;
     });
     const kbDaemonSupervisor = createMockKbDaemonSupervisor();
 
@@ -135,8 +136,9 @@ describe('coordinator startup ordering', () => {
         const consumerId = typeof args[0] === 'string' ? args[2] : args[1];
         order.push(`waitFreshUntil:${consumerId}`);
       });
-    const runStartup = vi.spyOn(jobsReconcile, 'runStartup').mockImplementation(async () => {
+    const runStartup = vi.spyOn(jobsReconcile, 'runStartup').mockImplementation(async (options) => {
       order.push('jobsReconcile.runStartup');
+      return options.progressStore;
     });
     const resumeAll = vi.spyOn(workflowRecover, 'resumeAll').mockImplementation(async () => {
       order.push('workflowRecover.resumeAll');
@@ -281,6 +283,7 @@ describe('coordinator startup ordering', () => {
         c.append(sessionContinuationLeaseRecordedEvent(pending, lease));
         return undefined;
       });
+      return options.progressStore;
     });
     const resumeAll = vi.spyOn(workflowRecover, 'resumeAll').mockImplementation(async (options) => {
       order.push('workflowRecover.resumeAll');

--- a/tests/integration/coordinator/workflow-handoff.test.ts
+++ b/tests/integration/coordinator/workflow-handoff.test.ts
@@ -212,6 +212,7 @@ describe('workflow handoff (cross-domain integration)', () => {
           getExecutionService: () => stubExecution,
           createInvocationContext,
           finalizeWorkflow,
+          releaseFailedWorkflowDescendants: () => [],
           time: harness.runtime.time,
         });
         resumedIds.push(...resumed);

--- a/tests/invariants/coordinator-topology.test.ts
+++ b/tests/invariants/coordinator-topology.test.ts
@@ -70,6 +70,7 @@ const EXPECTED_COORDINATOR_FILES = new Set([
   'src/coordinator/services/terminal-materializer.ts',
   'src/coordinator/services/workflow-execution.ts',
   'src/coordinator/services/workflow-finalization.ts',
+  'src/coordinator/services/workflow-recovery-descendants.ts',
   'src/coordinator/services/workflow-recovery-finalizer.ts',
   'src/coordinator/shutdown.ts',
 ]);

--- a/tests/invariants/journal-commit-atomicity.test.ts
+++ b/tests/invariants/journal-commit-atomicity.test.ts
@@ -838,7 +838,7 @@ describe('journal commit atomicity invariant', () => {
       const captured = captureWorkflowIntents(realFinalizer);
       const message = "Step 0, atom 'architect' failed: exited with code 1";
 
-      await expect(resumeRecoveryHarness(harness, captured.finalizeWorkflow)).rejects.toThrow(message);
+      await expect(resumeRecoveryHarness(harness, captured.finalizeWorkflow)).resolves.toEqual([harness.workflowId]);
 
       expect(captured.intents).toEqual([
         {

--- a/tests/invariants/journal-commit-atomicity.test.ts
+++ b/tests/invariants/journal-commit-atomicity.test.ts
@@ -546,6 +546,7 @@ async function resumeRecoveryHarness(
     getExecutionService: () => executionSvc,
     createInvocationContext: createRecoveryInvocationContext,
     finalizeWorkflow,
+    releaseFailedWorkflowDescendants: () => [],
     time: harness.runtime.time,
   });
 }

--- a/tests/unit/cli/backend-status.test.ts
+++ b/tests/unit/cli/backend-status.test.ts
@@ -68,7 +68,6 @@ describe('backend status generation readiness', () => {
       getStatus: async () => ({
         status: 'recent_failure',
         phase: 'startup_failed',
-        reason: 'job recovery could not hydrate job-42',
       }),
     };
     const program = new Command();
@@ -82,7 +81,6 @@ describe('backend status generation readiness', () => {
       [
         'Backend is not running after a recent coordinator failure.',
         'Phase: startup_failed',
-        'Reason: job recovery could not hydrate job-42',
         'Next step: inspect the coordinator log, fix the reported cause, then retry a coral-cli mutating command to relaunch it.',
         '',
       ].join('\n'),
@@ -93,7 +91,7 @@ describe('backend status generation readiness', () => {
 describe('backend startup diagnostic classification', () => {
   const now = Date.parse('2026-08-02T12:00:00.000Z');
 
-  it('reports the deepest public-safe cause from a recent failure', () => {
+  it('classifies a recent failure without returning serialized exception text', () => {
     expect(
       statusFromStartupDiagnostic(
         {
@@ -119,8 +117,42 @@ describe('backend startup diagnostic classification', () => {
     ).toEqual({
       status: 'recent_failure',
       phase: 'startup_failed',
-      reason: 'Could not hydrate job-42',
     });
+  });
+
+  it('does not render credentials from a serialized diagnostic cause', async () => {
+    const secret = 'sk-proj-secret-value';
+    const classified = statusFromStartupDiagnostic(
+      {
+        schemaVersion: 1,
+        phase: 'startup_failed',
+        state: 'stopped_with_diagnostic',
+        retryable: false,
+        pid: 4242,
+        recordedAt: '2026-08-02T11:59:30.000Z',
+        attemptId: 'attempt-1',
+        exitCode: 1,
+        error: {
+          message: 'Coordinator startup failed',
+          cause: { message: `Provider rejected credential ${secret}` },
+        },
+      },
+      now,
+    );
+    if (classified === null) throw new Error('expected recent startup failure');
+    const status: BackendStatusCommandOperations = {
+      inspectReadiness: () => ({ kind: 'no-legacy' }),
+      getStatus: async () => classified,
+    };
+    const program = new Command();
+    program.exitOverride();
+    registerBackendCommands(program, storeReset, undefined, undefined, status);
+
+    await program.parseAsync(['node', 'coral-cli', 'backend', 'status']);
+
+    expect(stdout).not.toContain(secret);
+    expect(stdout).not.toContain('Provider rejected credential');
+    expect(stdout).toContain('Next step: inspect the coordinator log');
   });
 
   it('treats a diagnostic left from days ago as a genuine absence', () => {
@@ -152,6 +184,25 @@ describe('backend startup diagnostic classification', () => {
         },
         now,
         Date.parse('2026-08-02T11:59:45.000Z'),
+      ),
+    ).toBeNull();
+  });
+
+  it('rejects a diagnostic whose pid differs from the discovered pid', () => {
+    expect(
+      statusFromStartupDiagnostic(
+        {
+          schemaVersion: 1,
+          phase: 'startup_failed',
+          state: 'stopped_with_diagnostic',
+          retryable: false,
+          pid: 5151,
+          recordedAt: '2026-08-02T11:59:50.000Z',
+          error: { message: 'new contender failed' },
+        },
+        now,
+        Date.parse('2026-08-02T11:59:00.000Z'),
+        4242,
       ),
     ).toBeNull();
   });

--- a/tests/unit/cli/backend-status.test.ts
+++ b/tests/unit/cli/backend-status.test.ts
@@ -6,6 +6,7 @@ import {
   type BackendStatusCommandOperations,
   type StoreResetCommandOperations,
 } from '#src/cli/commands/backend.js';
+import { statusFromStartupDiagnostic } from '#src/transport/http/backend/status.js';
 
 const storeReset: StoreResetCommandOperations = {
   list: () => ({ incidents: [] }),
@@ -59,5 +60,99 @@ describe('backend status generation readiness', () => {
       'Legacy Coral history remains at /state/data; its stored Coral version is 0.9.16. This generation will initialize empty state at /state/gen2/data without changing the legacy tree.\n',
     );
     expect(stdout).toContain('Backend not running.');
+  });
+
+  it('prints a recent startup failure returned by the read-only status probe', async () => {
+    const status: BackendStatusCommandOperations = {
+      inspectReadiness: () => ({ kind: 'no-legacy' }),
+      getStatus: async () => ({
+        status: 'recent_failure',
+        phase: 'startup_failed',
+        reason: 'job recovery could not hydrate job-42',
+      }),
+    };
+    const program = new Command();
+    program.exitOverride();
+    registerBackendCommands(program, storeReset, undefined, undefined, status);
+
+    await program.parseAsync(['node', 'coral-cli', 'backend', 'status']);
+
+    expect(stderr).toBe('');
+    expect(stdout).toBe(
+      [
+        'Backend is not running after a recent coordinator failure.',
+        'Phase: startup_failed',
+        'Reason: job recovery could not hydrate job-42',
+        'Next step: inspect the coordinator log, fix the reported cause, then retry a coral-cli mutating command to relaunch it.',
+        '',
+      ].join('\n'),
+    );
+  });
+});
+
+describe('backend startup diagnostic classification', () => {
+  const now = Date.parse('2026-08-02T12:00:00.000Z');
+
+  it('reports the deepest public-safe cause from a recent failure', () => {
+    expect(
+      statusFromStartupDiagnostic(
+        {
+          schemaVersion: 1,
+          phase: 'startup_failed',
+          state: 'stopped_with_diagnostic',
+          retryable: false,
+          pid: 4242,
+          recordedAt: '2026-08-02T11:59:30.000Z',
+          attemptId: 'attempt-1',
+          exitCode: 1,
+          error: {
+            message: 'Coordinator startup failed',
+            stack: 'not printed',
+            cause: {
+              message: 'Job recovery failed',
+              cause: { message: 'Could not hydrate job-42' },
+            },
+          },
+        },
+        now,
+      ),
+    ).toEqual({
+      status: 'recent_failure',
+      phase: 'startup_failed',
+      reason: 'Could not hydrate job-42',
+    });
+  });
+
+  it('treats a diagnostic left from days ago as a genuine absence', () => {
+    expect(
+      statusFromStartupDiagnostic(
+        {
+          schemaVersion: 1,
+          phase: 'startup_failed',
+          state: 'stopped_with_diagnostic',
+          retryable: false,
+          recordedAt: '2026-07-30T12:00:00.000Z',
+          error: { message: 'old failure' },
+        },
+        now,
+      ),
+    ).toBeNull();
+  });
+
+  it('does not attribute a prior failure to a newer discovered daemon', () => {
+    expect(
+      statusFromStartupDiagnostic(
+        {
+          schemaVersion: 1,
+          phase: 'startup_failed',
+          state: 'stopped_with_diagnostic',
+          retryable: false,
+          recordedAt: '2026-08-02T11:59:30.000Z',
+          error: { message: 'prior failure' },
+        },
+        now,
+        Date.parse('2026-08-02T11:59:45.000Z'),
+      ),
+    ).toBeNull();
   });
 });

--- a/tests/unit/cli/format.test.ts
+++ b/tests/unit/cli/format.test.ts
@@ -717,6 +717,23 @@ describe('cli format', () => {
       );
     });
 
+    it('formats a recent coordinator failure with its phase, reason, and next step', () => {
+      expect(
+        formatBackendStatus({
+          status: 'recent_failure',
+          phase: 'startup_failed',
+          reason: 'Could not hydrate job-42',
+        }),
+      ).toBe(
+        [
+          'Backend is not running after a recent coordinator failure.',
+          'Phase: startup_failed',
+          'Reason: Could not hydrate job-42',
+          'Next step: inspect the coordinator log, fix the reported cause, then retry a coral-cli mutating command to relaunch it.',
+        ].join('\n'),
+      );
+    });
+
     it('formats a shutting-down backend status', () => {
       expect(formatBackendStatus({ status: 'shutting_down' })).toBe('Backend shutting down');
     });

--- a/tests/unit/cli/format.test.ts
+++ b/tests/unit/cli/format.test.ts
@@ -717,18 +717,16 @@ describe('cli format', () => {
       );
     });
 
-    it('formats a recent coordinator failure with its phase, reason, and next step', () => {
+    it('formats a recent coordinator failure with its phase and log guidance', () => {
       expect(
         formatBackendStatus({
           status: 'recent_failure',
           phase: 'startup_failed',
-          reason: 'Could not hydrate job-42',
         }),
       ).toBe(
         [
           'Backend is not running after a recent coordinator failure.',
           'Phase: startup_failed',
-          'Reason: Could not hydrate job-42',
           'Next step: inspect the coordinator log, fix the reported cause, then retry a coral-cli mutating command to relaunch it.',
         ].join('\n'),
       );

--- a/tests/unit/coordinator/bootstrap-diagnostics.test.ts
+++ b/tests/unit/coordinator/bootstrap-diagnostics.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { serializeBootstrapError } from '#src/coordinator/bootstrap-diagnostics.js';
+
+describe('serializeBootstrapError', () => {
+  it('preserves a nested Error cause chain', () => {
+    const error = new Error('coordinator startup failed', {
+      cause: new Error('runtime initialization failed', {
+        cause: new Error('database is locked'),
+      }),
+    });
+
+    expect(serializeBootstrapError(error)).toMatchObject({
+      kind: 'error',
+      message: 'coordinator startup failed',
+      cause: {
+        kind: 'error',
+        message: 'runtime initialization failed',
+        cause: {
+          kind: 'error',
+          message: 'database is locked',
+        },
+      },
+    });
+  });
+
+  it('stops serializing a cyclic cause after eight nested causes', () => {
+    const error = new Error('cyclic failure');
+    error.cause = error;
+
+    let serialized = serializeBootstrapError(error);
+    for (let causeDepth = 0; causeDepth < 8; causeDepth += 1) {
+      expect(serialized).toMatchObject({ kind: 'error', message: 'cyclic failure' });
+      expect(serialized.cause).toBeDefined();
+      serialized = serialized.cause as Record<string, unknown>;
+    }
+    expect(serialized).toMatchObject({ kind: 'error', message: 'cyclic failure' });
+    expect(serialized).not.toHaveProperty('cause');
+  });
+});

--- a/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
+++ b/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
@@ -1456,7 +1456,7 @@ describe('lifecycle recovery', () => {
     }
   });
 
-  it('11b. dead-on-start durable finalization failure retains registry ownership and the launch fence', async () => {
+  it('11b. dead-on-start durable finalization failure is a per-job fault, not a boot failure', async () => {
     const modules = await loadModules();
     const pluginRoot = createProjectRoot('plugin-dead-finalizer-blocked');
     const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
@@ -1491,10 +1491,16 @@ describe('lifecycle recovery', () => {
     });
 
     try {
-      await expect(controller.start()).rejects.toThrow(`Interrupted durable recovery remains incomplete for ${jobId}`);
-      expect(runtimeState.getLaunchFenceActive()).toBe(true);
-      expect(controller.getRecoveryRegistry()?.has(jobId)).toBe(true);
-      expect(progressStore.readStatus(jobId)?.phase).toBe('running');
+      await controller.start();
+      expect(runtimeState.getLaunchFenceActive()).toBe(false);
+      expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
+      // `recovery_parse_failed` is a progress fault, so the terminal is `failed` and the
+      // reason is recorded on the job's own stream and referenced by a causeRef — the job
+      // is terminal with a queryable cause instead of stuck at `running` forever.
+      expect(progressStore.readStatus(jobId)).toMatchObject({
+        phase: 'error',
+        result: { outcome: { kind: 'failed', causeRef: expect.anything() } },
+      });
     } finally {
       await stopLifecycleController(controller);
     }
@@ -1743,7 +1749,7 @@ describe('lifecycle recovery', () => {
     }
   });
 
-  it('14c. interrupted app-server finalization failure retains the recovery registry and launch fence', async () => {
+  it('14c. interrupted app-server finalization failure is a per-job fault, not a boot failure', async () => {
     const modules = await loadModules();
     const pluginRoot = createProjectRoot('plugin-app-server-blocked');
     const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
@@ -1786,18 +1792,84 @@ describe('lifecycle recovery', () => {
     });
 
     try {
-      await expect(controller.start()).rejects.toThrow(
-        `Interrupted app-server recovery remains incomplete for ${jobId}`,
-      );
-      expect(runtimeState.getLaunchFenceActive()).toBe(true);
-      expect(controller.getRecoveryRegistry()?.has(jobId)).toBe(true);
-      expect(progressStore.readStatus(jobId)?.phase).toBe('running');
+      await controller.start();
+      expect(runtimeState.getLaunchFenceActive()).toBe(false);
+      expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
+      // `recovery_parse_failed` is a progress fault, so the terminal is `failed` and the
+      // reason is recorded on the job's own stream and referenced by a causeRef — the job
+      // is terminal with a queryable cause instead of stuck at `running` forever.
+      expect(progressStore.readStatus(jobId)).toMatchObject({
+        phase: 'error',
+        result: { outcome: { kind: 'failed', causeRef: expect.anything() } },
+      });
     } finally {
       await stopLifecycleController(controller);
     }
   });
 
-  it('14d. app-server binding failure retains preregistration and the launch fence without terminalizing', async () => {
+  // Per-job isolation is the invariant `lifecycle.ts` documents ("corrupt sessions should
+  // not abort recovery") and did not have: one unresolvable job used to abandon every other
+  // job's recovery, discuss recovery, workflow recovery, and stale-job cleanup with it.
+  it('14c2. one unresolvable job does not abandon the recovery of another', async () => {
+    const modules = await loadModules();
+    const pluginRoot = createProjectRoot('plugin-app-server-isolation');
+    const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+    const projectRoot = createProjectRoot('project-app-server-isolation');
+    const eventBus = new modules.eventBusModule.TypedEventBus();
+    const progressStore = new modules.progressStoreModule.JobStore(namespace, runtime, createEventBodyCodec(), {
+      db: openTestStoreDb(runtime, ':memory:'),
+      eventBus,
+      providers: permissiveProviderLookupPort,
+    });
+    const blockedJobId = 'isolation-blocked-job';
+    const healthyJobId = 'isolation-healthy-job';
+    const fakeService = createFakeExecutionAndRecoveryService({
+      finalizeInterruptedAppServerJob: vi.fn(async (authority: { launchRecord: { jobId: string } }) => {
+        if (authority.launchRecord.jobId === blockedJobId) {
+          throw new Error('replacement host could not be opened');
+        }
+      }),
+    });
+
+    for (const jobId of [blockedJobId, healthyJobId]) {
+      stubLaunchRecord(progressStore, {
+        jobId,
+        sessionId: `${jobId}-session`,
+        provider: 'codex',
+        projectRoot,
+        backendNamespace: namespace,
+      });
+      progressStore.appendRuntimeStarted(jobId, {
+        transport: 'app-server',
+        startTime: '2026-03-31T00:00:00.000Z',
+        providerMeta: { provider: 'codex', leaseState: 'waiting' },
+      });
+    }
+
+    const { controller, runtimeState } = createLifecycleHarness(modules, {
+      pluginRoot,
+      progressStore,
+      eventBus,
+      servicesByProjectRoot: new Map([[projectRoot, fakeService]]),
+      runtime,
+    });
+
+    try {
+      await controller.start();
+      expect(runtimeState.getLaunchFenceActive()).toBe(false);
+      // The healthy job's recovery ran even though the other one could not be resolved.
+      expect(fakeService.finalizeInterruptedAppServerJob).toHaveBeenCalledTimes(2);
+      expect(progressStore.readStatus(blockedJobId)).toMatchObject({
+        phase: 'error',
+        result: { outcome: { kind: 'failed', causeRef: expect.anything() } },
+      });
+      expect(controller.getRecoveryRegistry()?.has(healthyJobId) ?? false).toBe(false);
+    } finally {
+      await stopLifecycleController(controller);
+    }
+  });
+
+  it('14d. app-server binding failure terminalizes instead of failing the boot', async () => {
     const modules = await loadModules();
     const pluginRoot = createProjectRoot('plugin-provider-authority-blocked');
     const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
@@ -1841,17 +1913,21 @@ describe('lifecycle recovery', () => {
     });
 
     try {
-      await expect(controller.start()).rejects.toThrow(`Recovery authority rejected for app-server job ${jobId}`);
-      expect(runtimeState.getLaunchFenceActive()).toBe(true);
-      expect(controller.getRecoveryRegistry()?.has(jobId)).toBe(true);
-      expect(progressStore.readStatus(jobId)?.phase).toBe('running');
-      expect(fakeService.finalizeProviderRecoveryBindingFailure).not.toHaveBeenCalled();
+      // No process to stop and a structurally unresolvable persisted hostRef, so this
+      // takes the same treatment as the dead-durable case rather than failing the boot.
+      await controller.start();
+      expect(runtimeState.getLaunchFenceActive()).toBe(false);
+      expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
+      expect(fakeService.finalizeProviderRecoveryBindingFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ jobId }),
+        { reason: 'subject-mismatch', provider: 'codex' },
+      );
     } finally {
       await stopLifecycleController(controller);
     }
   });
 
-  it('14e. live durable binding failure requests process stop before retaining the recovery fence', async () => {
+  it('14e. live durable binding failure requests process stop and then terminalizes', async () => {
     const modules = await loadModules();
     const pluginRoot = createProjectRoot('plugin-durable-binding-blocked');
     const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
@@ -1892,20 +1968,17 @@ describe('lifecycle recovery', () => {
 
     try {
       expect(progressStore.readRuntimeProjection(jobId)).toMatchObject({ transport: 'durable-cli', pid });
-      const startError = await controller.start().then(
-        () => null,
-        (error: unknown) => error,
-      );
+      await controller.start();
       expect(fakeService.captureProviderRecoveryAuthority).toHaveBeenCalledTimes(1);
       expect(runtime.process.isAlive).toHaveBeenCalledWith(pid);
-      expect(startError).toEqual(
-        expect.objectContaining({ message: expect.stringContaining(`live durable job ${jobId}`) }),
-      );
+      // The stop request is still the point of this case; only the boot failure is gone.
       expect(kill).toHaveBeenCalledWith(pid, 'SIGTERM');
-      expect(fakeService.finalizeProviderRecoveryBindingFailure).not.toHaveBeenCalled();
-      expect(runtimeState.getLaunchFenceActive()).toBe(true);
-      expect(controller.getRecoveryRegistry()?.has(jobId)).toBe(true);
-      expect(progressStore.readStatus(jobId)?.phase).toBe('running');
+      expect(fakeService.finalizeProviderRecoveryBindingFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ jobId }),
+        { reason: 'subject-mismatch', provider: 'codex' },
+      );
+      expect(runtimeState.getLaunchFenceActive()).toBe(false);
+      expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
     } finally {
       await stopLifecycleController(controller);
     }

--- a/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
+++ b/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
@@ -1910,6 +1910,126 @@ describe('lifecycle recovery', () => {
     }
   });
 
+  it('recovers a valid job while containing attributable and unattributable malformed persisted records', async () => {
+    const modules = await loadModules();
+    const pluginRoot = createProjectRoot('plugin-job-hydration-isolation');
+    const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+    const projectRoot = createProjectRoot('project-job-hydration-isolation');
+    const eventBus = new modules.eventBusModule.TypedEventBus();
+    const db = openTestStoreDb(runtime, ':memory:');
+    const progressStore = new modules.progressStoreModule.JobStore(namespace, runtime, createEventBodyCodec(), {
+      db,
+      eventBus,
+      providers: permissiveProviderLookupPort,
+    });
+    const malformedJobId = 'malformed-runtime-record-job';
+    const healthyJobId = 'healthy-runtime-record-job';
+    const finalizeInterruptedAppServerJob = vi.fn(async () => {});
+    const fakeService = createFakeExecutionAndRecoveryService({ finalizeInterruptedAppServerJob });
+    const log = vi.fn<(message: string) => void>();
+
+    for (const jobId of [malformedJobId, healthyJobId]) {
+      stubLaunchRecord(progressStore, {
+        jobId,
+        sessionId: `${jobId}-session`,
+        provider: 'codex',
+        projectRoot,
+        backendNamespace: namespace,
+      });
+      progressStore.appendRuntimeStarted(jobId, {
+        transport: 'app-server',
+        startTime: '2026-03-31T00:00:00.000Z',
+        providerMeta: { provider: 'codex', leaseState: 'waiting' },
+      });
+    }
+    db.prepare("UPDATE events SET body = ? WHERE stream_id = ? AND type = 'job.runtime.started'").run(
+      Buffer.from('not a stored event body'),
+      malformedJobId,
+    );
+    db.prepare(
+      `INSERT INTO projection_jobs (
+         job_id, execution_owner, phase, terminal, diagnostics, session_id, provider,
+         project_root, backend_namespace, bundle_hash, job_kind, parent_workflow_job_id,
+         workflow_slot, workflow_slot_generation, replaces_workflow_job_id, created_at, last_seq
+       )
+       SELECT
+         '', execution_owner, phase, terminal, diagnostics, session_id, provider,
+         project_root, backend_namespace, bundle_hash, job_kind, parent_workflow_job_id,
+         workflow_slot, workflow_slot_generation, replaces_workflow_job_id, created_at, last_seq
+       FROM projection_jobs
+       WHERE job_id = ?`,
+    ).run(healthyJobId);
+
+    const { controller, runtimeState } = createLifecycleHarness(modules, {
+      pluginRoot,
+      progressStore,
+      eventBus,
+      servicesByProjectRoot: new Map([[projectRoot, fakeService]]),
+      runtime,
+      log,
+    });
+
+    try {
+      await controller.start();
+      expect(runtimeState.getLaunchFenceActive()).toBe(false);
+      expect(controller.getRecoveryRegistry()?.has(malformedJobId) ?? false).toBe(false);
+      expect(finalizeInterruptedAppServerJob).toHaveBeenCalledTimes(1);
+      expect(finalizeInterruptedAppServerJob).toHaveBeenCalledWith(
+        expect.objectContaining({ launchRecord: expect.objectContaining({ jobId: healthyJobId }) }),
+        expect.anything(),
+        expect.anything(),
+      );
+
+      const terminalRow = db
+        .prepare<
+          [string],
+          { seq: number }
+        >("SELECT seq FROM events WHERE stream_id = ? AND type = 'job.terminal.recorded' ORDER BY seq DESC LIMIT 1")
+        .get(malformedJobId);
+      expect(terminalRow).toBeDefined();
+      if (terminalRow === undefined) return;
+      const terminalEvent = getEvent(db, { kind: 'job', id: malformedJobId }, terminalRow.seq, progressStore);
+      const terminalBody = terminalEvent?.body as
+        | {
+            terminal?: { outcome?: { kind?: string; causeRef?: { stream: { kind: 'job'; id: string }; seq: number } } };
+          }
+        | undefined;
+      expect(terminalBody?.terminal?.outcome?.kind).toBe('failed');
+      const causeRef = terminalBody?.terminal?.outcome?.causeRef;
+      expect(causeRef).toBeDefined();
+      if (causeRef === undefined) return;
+      expect(getEvent(db, causeRef.stream, causeRef.seq, progressStore)?.body).toMatchObject({
+        kind: 'recovery_parse_failed',
+        cause: { message: expect.stringContaining('Failed to decode events.body JSON') },
+      });
+
+      const sessionReader = new modules.sessionManagerModule.SessionManager(
+        projectRoot,
+        runtime,
+        undefined,
+        undefined,
+        db,
+        permissiveProviderLookupPort,
+      );
+      expect(sessionReader.get('codex', `${malformedJobId}-session`)?.activeJobId).toBeUndefined();
+      const messages = log.mock.calls.flat().join('');
+      expect(messages).toContain(`Persisted job recovery hydration failed for ${malformedJobId}`);
+      expect(messages).toContain('The persisted-detail decode failure is included in this log.');
+      expect(messages).not.toContain(`Run coral-cli jobs detail ${malformedJobId}`);
+      expect(messages).toContain('Skipped malformed persisted job projection with no decodable job id');
+      expect(
+        db
+          .prepare<
+            [string],
+            { seq: number }
+          >("SELECT seq FROM events WHERE stream_id = ? AND type = 'job.terminal.recorded' LIMIT 1")
+          .get(''),
+      ).toBeUndefined();
+    } finally {
+      await stopLifecycleController(controller);
+    }
+  });
+
   // BLOCKING finding from tier review: terminalizing without releasing the claim left
   // `activeJobId` pointed at a terminal job, so every later launch on that session was
   // rejected `session_busy` ("wait for it to complete or abort it first" — both false)

--- a/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
+++ b/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
@@ -13,6 +13,8 @@ import type { ProviderSession } from '#src/sessions/entry.js';
 import { SessionManager } from '#src/sessions/shell.js';
 import { reduceSessionOpened } from '#src/sessions/projections.js';
 import type { CoralEvent } from '#src/store/envelope.js';
+import { getEvent } from '#src/store/event-queries.js';
+import type { JobStore } from '#src/jobs/store.js';
 import type { SessionOpenedBody } from '#src/sessions/event-bodies.js';
 import { pluginRootNamespace } from '#src/infra/plugin-identity.js';
 import { createRealRuntime } from '#src/runtime/real.js';
@@ -691,6 +693,26 @@ async function stopLifecycleController(controller: {
   } catch {
     /* best effort */
   }
+}
+
+/**
+ * A `recovery_parse_failed` terminal records its reason on the job's own progress
+ * stream and points at it with a causeRef, so asserting the terminal alone proves
+ * nothing about the reason. Resolve the ref the way production does
+ * (`src/workflow/recover.ts` uses the same `getEvent`) and assert the real message.
+ */
+function expectRecordedRecoveryFault(progressStore: JobStore, jobId: string, expectedMessage: string): void {
+  const status = progressStore.readStatus(jobId);
+  expect(status?.phase).toBe('error');
+  const outcome = status?.result?.outcome;
+  expect(outcome?.kind).toBe('failed');
+  if (outcome?.kind !== 'failed') return;
+  const { causeRef } = outcome;
+  const cause = getEvent(progressStore.getDb(), causeRef.stream, causeRef.seq, progressStore);
+  expect(cause?.body).toMatchObject({
+    kind: 'recovery_parse_failed',
+    cause: { message: expect.stringContaining(expectedMessage) },
+  });
 }
 
 describe('lifecycle recovery', () => {
@@ -1494,13 +1516,9 @@ describe('lifecycle recovery', () => {
       await controller.start();
       expect(runtimeState.getLaunchFenceActive()).toBe(false);
       expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
-      // `recovery_parse_failed` is a progress fault, so the terminal is `failed` and the
-      // reason is recorded on the job's own stream and referenced by a causeRef — the job
-      // is terminal with a queryable cause instead of stuck at `running` forever.
-      expect(progressStore.readStatus(jobId)).toMatchObject({
-        phase: 'error',
-        result: { outcome: { kind: 'failed', causeRef: expect.anything() } },
-      });
+      // The terminal is `failed` with the reason on the job's own stream behind a
+      // causeRef; resolve it so a wrong or unresolvable ref cannot pass.
+      expectRecordedRecoveryFault(progressStore, jobId, 'exact session CAS went stale');
     } finally {
       await stopLifecycleController(controller);
     }
@@ -1795,13 +1813,9 @@ describe('lifecycle recovery', () => {
       await controller.start();
       expect(runtimeState.getLaunchFenceActive()).toBe(false);
       expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
-      // `recovery_parse_failed` is a progress fault, so the terminal is `failed` and the
-      // reason is recorded on the job's own stream and referenced by a causeRef — the job
-      // is terminal with a queryable cause instead of stuck at `running` forever.
-      expect(progressStore.readStatus(jobId)).toMatchObject({
-        phase: 'error',
-        result: { outcome: { kind: 'failed', causeRef: expect.anything() } },
-      });
+      // The terminal is `failed` with the reason on the job's own stream behind a
+      // causeRef; resolve it so a wrong or unresolvable ref cannot pass.
+      expectRecordedRecoveryFault(progressStore, jobId, 'session CAS became stale');
     } finally {
       await stopLifecycleController(controller);
     }
@@ -1809,7 +1823,10 @@ describe('lifecycle recovery', () => {
 
   // Per-job isolation is the invariant `lifecycle.ts` documents ("corrupt sessions should
   // not abort recovery") and did not have: one unresolvable job used to abandon every other
-  // job's recovery, discuss recovery, workflow recovery, and stale-job cleanup with it.
+  // job's recovery. Downstream stages are safe for a different reason and are deliberately
+  // not asserted here — `cleanupStaleJobs` already runs before `runRecoveryAdoption`, and
+  // discuss/workflow recovery run after `runStartupRecovery` resolves, which it now always
+  // does. Only the `actions.ts` register-stage throws could ever starve those.
   it('14c2. one unresolvable job does not abandon the recovery of another', async () => {
     const modules = await loadModules();
     const pluginRoot = createProjectRoot('plugin-app-server-isolation');
@@ -1821,6 +1838,11 @@ describe('lifecycle recovery', () => {
       eventBus,
       providers: permissiveProviderLookupPort,
     });
+    // `runningJobs` order comes from `ORDER BY job_id ASC` (src/jobs/read-queries.ts), and
+    // 'isolation-blocked-job' < 'isolation-healthy-job' lexically. That ordering is what makes
+    // this a proof: the failing job must be processed FIRST, or both old and new code would
+    // finalize the healthy job before the throw and the test would assert nothing. Keep the
+    // blocked id sorting first if these are ever renamed.
     const blockedJobId = 'isolation-blocked-job';
     const healthyJobId = 'isolation-healthy-job';
     const fakeService = createFakeExecutionAndRecoveryService({
@@ -1859,11 +1881,94 @@ describe('lifecycle recovery', () => {
       expect(runtimeState.getLaunchFenceActive()).toBe(false);
       // The healthy job's recovery ran even though the other one could not be resolved.
       expect(fakeService.finalizeInterruptedAppServerJob).toHaveBeenCalledTimes(2);
-      expect(progressStore.readStatus(blockedJobId)).toMatchObject({
-        phase: 'error',
-        result: { outcome: { kind: 'failed', causeRef: expect.anything() } },
-      });
+      expectRecordedRecoveryFault(progressStore, blockedJobId, 'replacement host could not be opened');
       expect(controller.getRecoveryRegistry()?.has(healthyJobId) ?? false).toBe(false);
+    } finally {
+      await stopLifecycleController(controller);
+    }
+  });
+
+  // BLOCKING finding from tier review: terminalizing without releasing the claim left
+  // `activeJobId` pointed at a terminal job, so every later launch on that session was
+  // rejected `session_busy` ("wait for it to complete or abort it first" — both false)
+  // until the next boot. 14c cannot catch it: it passes a bare sessionId string with no
+  // session entry, so there is no claim to leak. This one uses a real claimed session.
+  it('14c3. an unresolvable app-server job releases its session claim immediately', async () => {
+    const modules = await loadModules();
+    const pluginRoot = createProjectRoot('plugin-app-server-claim');
+    const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+    const projectRoot = createProjectRoot('project-app-server-claim');
+    const eventBus = new modules.eventBusModule.TypedEventBus();
+    const db = openTestStoreDb(runtime, ':memory:');
+    const progressStore = new modules.progressStoreModule.JobStore(namespace, runtime, createEventBodyCodec(), {
+      db,
+      eventBus,
+      providers: permissiveProviderLookupPort,
+    });
+    const sessionManager = new modules.sessionManagerModule.SessionManager(
+      projectRoot,
+      runtime,
+      undefined,
+      undefined,
+      db,
+      permissiveProviderLookupPort,
+    );
+    const session = allocateTestSession(
+      sessionManager,
+      'codex',
+      'alpha',
+      undefined,
+      projectRoot,
+      projectRoot,
+      namespace,
+    );
+    const jobId = 'app-server-claim-job';
+    expect(sessionManager.claimForJobSync(session.sessionId, jobId)).toBe(true);
+    const fakeService = createFakeExecutionAndRecoveryService({
+      finalizeInterruptedAppServerJob: vi.fn(async () => {
+        throw new Error('replacement host could not be opened');
+      }),
+    });
+
+    stubLaunchRecord(progressStore, {
+      jobId,
+      sessionId: session.sessionId,
+      provider: 'codex',
+      projectRoot,
+      backendNamespace: namespace,
+    });
+    progressStore.appendRuntimeStarted(jobId, {
+      transport: 'app-server',
+      startTime: '2026-03-31T00:00:00.000Z',
+      providerMeta: { provider: 'codex', leaseState: 'waiting' },
+    });
+
+    const { controller } = createLifecycleHarness(modules, {
+      pluginRoot,
+      progressStore,
+      eventBus,
+      servicesByProjectRoot: new Map([[projectRoot, fakeService]]),
+      runtime,
+    });
+
+    try {
+      await controller.start();
+      expectRecordedRecoveryFault(progressStore, jobId, 'replacement host could not be opened');
+      // Released in this boot, not deferred to the next one: the session is immediately
+      // claimable again, which is what keeps the conversation resumable.
+      // Read and re-claim through a fresh manager, matching test 12: the release must be
+      // durable, and `releaseJob` bumps the session version so a handle held from before
+      // the release would fail its CAS for a reason unrelated to the fix.
+      const reader = new modules.sessionManagerModule.SessionManager(
+        projectRoot,
+        runtime,
+        undefined,
+        undefined,
+        db,
+        permissiveProviderLookupPort,
+      );
+      expect(reader.get('codex', session.sessionId)?.activeJobId).toBeUndefined();
+      expect(reader.claimForJobSync(session.sessionId, 'a-later-job')).toBe(true);
     } finally {
       await stopLifecycleController(controller);
     }
@@ -1973,6 +2078,65 @@ describe('lifecycle recovery', () => {
       expect(runtime.process.isAlive).toHaveBeenCalledWith(pid);
       // The stop request is still the point of this case; only the boot failure is gone.
       expect(kill).toHaveBeenCalledWith(pid, 'SIGTERM');
+      expect(fakeService.finalizeProviderRecoveryBindingFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ jobId }),
+        { reason: 'subject-mismatch', provider: 'codex' },
+      );
+      expect(runtimeState.getLaunchFenceActive()).toBe(false);
+      expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
+    } finally {
+      await stopLifecycleController(controller);
+    }
+  });
+
+  // The failed-stop branch is unreachable in production — RealRuntime.kill swallows signal
+  // errors and returns false — so only a mocked port exercises it. It still must not be
+  // fatal: before the fix a failed stop threw and took the whole boot with it.
+  it('14e2. a failed process stop is logged, not fatal', async () => {
+    const modules = await loadModules();
+    const pluginRoot = createProjectRoot('plugin-durable-kill-fails');
+    const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+    const projectRoot = createProjectRoot('project-durable-kill-fails');
+    const eventBus = new modules.eventBusModule.TypedEventBus();
+    const progressStore = new modules.progressStoreModule.JobStore(namespace, runtime, createEventBodyCodec(), {
+      db: openTestStoreDb(runtime, ':memory:'),
+      eventBus,
+      providers: permissiveProviderLookupPort,
+    });
+    const jobId = 'durable-kill-fails-job';
+    const pid = 73_939;
+    const kill = vi.spyOn(runtime.process, 'kill').mockImplementation(() => {
+      throw new Error('EPERM: operation not permitted');
+    });
+    vi.spyOn(runtime.process, 'isAlive').mockImplementation((candidatePid) => candidatePid === pid);
+    const fakeService = createFakeExecutionAndRecoveryService({
+      captureProviderRecoveryAuthority: vi.fn(async () => ({
+        ok: false,
+        failure: { reason: 'subject-mismatch', provider: 'codex' },
+      })),
+    });
+
+    stubLaunchRecord(progressStore, {
+      jobId,
+      sessionId: 'durable-kill-fails-session',
+      provider: 'codex',
+      projectRoot,
+      backendNamespace: namespace,
+    });
+    stubRuntimeRecord(progressStore, { jobId, pid });
+
+    const { controller, runtimeState } = createLifecycleHarness(modules, {
+      pluginRoot,
+      progressStore,
+      eventBus,
+      servicesByProjectRoot: new Map([[projectRoot, fakeService]]),
+      runtime,
+    });
+
+    try {
+      await controller.start();
+      expect(kill).toHaveBeenCalled();
+      // The throw is absorbed and the job still reaches its terminal.
       expect(fakeService.finalizeProviderRecoveryBindingFailure).toHaveBeenCalledWith(
         expect.objectContaining({ jobId }),
         { reason: 'subject-mismatch', provider: 'codex' },

--- a/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
+++ b/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
@@ -73,6 +73,10 @@ async function loadModules() {
     workflowEventsModule,
     jobsEventsModule,
     reducersModule,
+    recoveryCoordinatorModule,
+    jobsStartupModule,
+    workflowRecoverModule,
+    jobsReadQueriesModule,
   ] = await Promise.all([
     import('#src/jobs/store.js'),
     import('#src/sessions/shell.js'),
@@ -90,6 +94,10 @@ async function loadModules() {
     import('#src/workflow/events.js'),
     import('#src/jobs/events.js'),
     import('#src/store/reducers.js'),
+    import('#src/coordinator/services/recovery/index.js'),
+    import('#src/jobs/startup.js'),
+    import('#src/workflow/recover.js'),
+    import('#src/jobs/read-queries.js'),
   ]);
 
   return {
@@ -109,6 +117,10 @@ async function loadModules() {
     workflowEventsModule,
     jobsEventsModule,
     reducersModule,
+    recoveryCoordinatorModule,
+    jobsStartupModule,
+    workflowRecoverModule,
+    jobsReadQueriesModule,
   };
 }
 
@@ -1910,6 +1922,166 @@ describe('lifecycle recovery', () => {
     }
   });
 
+  it('passes safe job enumeration from job recovery into workflow recovery', async () => {
+    const modules = await loadModules();
+    const pluginRoot = createProjectRoot('plugin-safe-workflow-enumeration');
+    const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+    const projectRoot = createProjectRoot('project-safe-workflow-enumeration');
+    const workflowId = 'workflow-safe-enumeration';
+    const eventBus = new modules.eventBusModule.TypedEventBus();
+    const db = openTestStoreDb(runtime, ':memory:');
+    const progressStore = new modules.progressStoreModule.JobStore(namespace, runtime, createEventBodyCodec(), {
+      db,
+      eventBus,
+      providers: permissiveProviderLookupPort,
+      reducers: modules.reducersModule.composeReducers(
+        modules.jobsEventsModule.jobsRegistry,
+        modules.workflowEventsModule.workflowRegistry,
+      ),
+    });
+    stubLaunchRecord(progressStore, {
+      jobId: workflowId,
+      sessionId: 'unused-workflow-session',
+      provider: 'codex',
+      projectRoot,
+      backendNamespace: namespace,
+      jobKind: 'workflow',
+    });
+    db.prepare(
+      `INSERT INTO projection_jobs (
+         job_id, execution_owner, phase, terminal, diagnostics, session_id, provider,
+         project_root, backend_namespace, bundle_hash, job_kind, parent_workflow_job_id,
+         workflow_slot, workflow_slot_generation, replaces_workflow_job_id, created_at, last_seq
+       )
+       SELECT
+         '', execution_owner, phase, terminal, diagnostics, session_id, provider,
+         project_root, backend_namespace, bundle_hash, job_kind, parent_workflow_job_id,
+         workflow_slot, workflow_slot_generation, replaces_workflow_job_id, created_at, last_seq
+       FROM projection_jobs
+       WHERE job_id = ?`,
+    ).run(workflowId);
+    const service = createFakeExecutionAndRecoveryService();
+    const log = vi.fn<(message: string) => void>();
+    const coordinatorCommit = createTestJobJournalDeps(progressStore, runtime).coordinatorCommit;
+    const recoveryCoordinator = modules.recoveryCoordinatorModule.createRecoveryCoordinator({
+      progressStore,
+      runtime,
+      runtimeState: { setLaunchFenceActive: vi.fn() },
+      eventBus,
+      getRecoveryService: () => service as never,
+      createInvocationContext: (root: string) => ({
+        projectRoot: root,
+        pluginRoot,
+        coralEnv: {},
+        principal: testProjectPrincipal(root),
+      }),
+      log,
+    });
+    const signal = new AbortController().signal;
+
+    try {
+      const recoveryProgressStore = await modules.jobsStartupModule.jobsReconcile.runStartup({
+        namespace,
+        bundleHash: 'test-bundle',
+        runtime,
+        progressStore,
+        providerRegistry: createRecoveryProviderRegistry(modules),
+        getRecoveryService: () => service as never,
+        createInvocationContext: (root: string) => ({
+          projectRoot: root,
+          pluginRoot,
+          coralEnv: {},
+          principal: testProjectPrincipal(root),
+        }),
+        signal,
+        log,
+        cleanupStaleJobs: () => {},
+        sessionLookup: modules.sessionLookupModule.createProjectionSessionLookup(db),
+        coordinatorCommit,
+        recoveryCoordinator,
+      });
+      expect(() => progressStore.listJobIds()).toThrow();
+      expect(recoveryProgressStore.listJobIds()).toContain(workflowId);
+      const finalizeWorkflow = vi.fn();
+      await expect(
+        modules.workflowRecoverModule.resumeAll({
+          db,
+          progressStore: recoveryProgressStore,
+          loadJobDetails: modules.jobsReadQueriesModule.loadJobProjectionDetails,
+          getExecutionService: () => service as never,
+          createInvocationContext: (root: string) => ({
+            projectRoot: root,
+            pluginRoot,
+            coralEnv: {},
+            principal: testProjectPrincipal(root),
+          }),
+          finalizeWorkflow,
+          releaseFailedWorkflowDescendants: () => [],
+          signal,
+          time: runtime.time,
+        }),
+      ).resolves.toEqual([workflowId]);
+      expect(finalizeWorkflow).toHaveBeenCalledWith(expect.objectContaining({ workflowJobId: workflowId }));
+      expect(log.mock.calls.flat().join('')).not.toContain(`Skipped hydrating workflow job ${workflowId}`);
+    } finally {
+      await recoveryCoordinator.teardown();
+      db.close();
+    }
+  });
+
+  it('recovers a valid job while a different session projection is malformed', async () => {
+    const modules = await loadModules();
+    const pluginRoot = createProjectRoot('plugin-session-enumeration-isolation');
+    const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+    const projectRoot = createProjectRoot('project-session-enumeration-isolation');
+    const eventBus = new modules.eventBusModule.TypedEventBus();
+    const db = openTestStoreDb(runtime, ':memory:');
+    const progressStore = new modules.progressStoreModule.JobStore(namespace, runtime, createEventBodyCodec(), {
+      db,
+      eventBus,
+      providers: permissiveProviderLookupPort,
+    });
+    const healthyJobId = 'healthy-job-with-malformed-session-row';
+    const healthySessionId = `${healthyJobId}-session`;
+    stubLaunchRecord(progressStore, {
+      jobId: healthyJobId,
+      sessionId: healthySessionId,
+      provider: 'codex',
+      projectRoot,
+      backendNamespace: namespace,
+    });
+    stubAppServerRuntime(progressStore, healthyJobId, 'codex');
+    db.prepare(
+      `INSERT INTO projection_sessions (
+         session_id, controller, resumable, conversation_ref, scope_key, entry, last_seq
+       )
+       SELECT ?, controller, resumable, conversation_ref, scope_key, '{', last_seq
+       FROM projection_sessions
+       WHERE session_id = ?`,
+    ).run('malformed-recovery-session', healthySessionId);
+    const finalizeInterruptedAppServerJob = vi.fn(async () => {});
+    const fakeService = createFakeExecutionAndRecoveryService({ finalizeInterruptedAppServerJob });
+    const log = vi.fn<(message: string) => void>();
+    const { controller } = createLifecycleHarness(modules, {
+      pluginRoot,
+      progressStore,
+      eventBus,
+      servicesByProjectRoot: new Map([[projectRoot, fakeService]]),
+      runtime,
+      log,
+    });
+
+    try {
+      await controller.start();
+      expect(finalizeInterruptedAppServerJob).toHaveBeenCalledOnce();
+      expect(log.mock.calls.flat().join('')).toContain(
+        'Skipped malformed session projection for malformed-recovery-session during recovery snapshot',
+      );
+    } finally {
+      await stopLifecycleController(controller);
+    }
+  });
+
   it('recovers a valid job while containing attributable and unattributable malformed persisted records', async () => {
     const modules = await loadModules();
     const pluginRoot = createProjectRoot('plugin-job-hydration-isolation');
@@ -2318,7 +2490,8 @@ describe('lifecycle recovery', () => {
       const messages = log.mock.calls.flat().join('');
       expect(messages).toContain('could not terminalize as recovery_parse_failed');
       expect(messages).toContain('session claim release was not attempted because terminalization failed');
-      expect(messages).toContain('Resolve the store write failure and restart the coordinator');
+      expect(messages).toContain('Recovery state disposition did not complete');
+      expect(messages).toContain('Inspect the persisted state and coordinator log before restarting');
     } finally {
       await stopLifecycleController(controller);
     }

--- a/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
+++ b/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
@@ -26,6 +26,7 @@ import { createEventBodyCodec } from '#src/store/event-body-codec.js';
 import { openTestStoreDb } from '#tests/helpers/store-db.js';
 import { permissiveProviderLookupPort } from '#tests/helpers/append-context.js';
 import type { RunStartupRecoveryFn } from '#src/coordinator/lifecycle.js';
+import type { TimerHandle } from '#src/infra/port-types.js';
 import { testProjectPrincipal } from '#tests/helpers/principal.js';
 import { ChildPrincipalRegistry } from '#src/coordinator/child-principal-registry.js';
 import { TEST_CODEX_BINDING } from '#tests/helpers/provider-credentials.js';
@@ -235,6 +236,35 @@ function createRuntimeStateMock() {
   return { runtimeState };
 }
 
+function createControllableTimeoutRuntime(baseRuntime: ReturnType<typeof createRealRuntime>) {
+  const scheduled: Array<{ callback: () => void; handle: TimerHandle; ms: number }> = [];
+  const setTimeout = vi.fn((callback: () => void, ms: number): TimerHandle => {
+    const handle: TimerHandle = { unref: vi.fn() };
+    scheduled.push({ callback, handle, ms });
+    return handle;
+  });
+  const clearTimeout = vi.fn((handle: TimerHandle | null): void => {
+    const index = scheduled.findIndex((timer) => timer.handle === handle);
+    if (index !== -1) scheduled.splice(index, 1);
+  });
+
+  return {
+    runtime: {
+      ...baseRuntime,
+      time: { ...baseRuntime.time, setTimeout, clearTimeout },
+    },
+    setTimeout,
+    runNextTimeout(): number {
+      const timer = scheduled.shift();
+      if (!timer) throw new Error('No controlled timeout is scheduled.');
+      timer.callback();
+      return timer.ms;
+    },
+    pendingTimeoutCount: () => scheduled.length,
+    discardScheduledTimeouts: () => scheduled.splice(0),
+  };
+}
+
 function createFakeExecutionAndRecoveryService(overrides: Record<string, unknown> = {}) {
   return {
     start: vi.fn(async () => ({ status: 'running', job: 'started-job', session: 'started-session' })),
@@ -254,7 +284,7 @@ function createFakeExecutionAndRecoveryService(overrides: Record<string, unknown
           },
         }) as never,
     ),
-    finalizeProviderRecoveryBindingFailure: vi.fn(),
+    finalizeProviderRecoveryBindingFailure: vi.fn(() => 'released' as const),
     recoverQueuedJob: vi.fn(async () => 'recovered-job'),
     completeRecoveredJob: vi.fn(),
     finalizeInterruptedAppServerJob: vi.fn(async () => {}),
@@ -523,6 +553,7 @@ function createLifecycleHarness(
     runStartupRecoveryFn?: RunStartupRecoveryFn;
     interruptedAppServerReason?: 'restart' | 'handoff';
     runtime?: ReturnType<typeof createRealRuntime>;
+    log?: (message: string) => void;
   },
 ) {
   const namespace = modules.pathsModule.pluginRootNamespace(options.pluginRoot);
@@ -560,7 +591,7 @@ function createLifecycleHarness(
       bootToken: 'test-boot-token',
       shutdownToken: 'test-shutdown-token',
       now: () => 1,
-      log: () => {},
+      log: options.log ?? (() => {}),
     },
     runtime: options.runtime ?? createRealRuntime('prod'),
     backendPid: 1234,
@@ -1821,12 +1852,8 @@ describe('lifecycle recovery', () => {
     }
   });
 
-  // Per-job isolation is the invariant `lifecycle.ts` documents ("corrupt sessions should
-  // not abort recovery") and did not have: one unresolvable job used to abandon every other
-  // job's recovery. Downstream stages are safe for a different reason and are deliberately
-  // not asserted here — `cleanupStaleJobs` already runs before `runRecoveryAdoption`, and
-  // discuss/workflow recovery run after `runStartupRecovery` resolves, which it now always
-  // does. Only the `actions.ts` register-stage throws could ever starve those.
+  // This case covers isolation inside the adoption loop. Register-stage isolation is
+  // exercised separately because it has a different exception boundary.
   it('14c2. one unresolvable job does not abandon the recovery of another', async () => {
     const modules = await loadModules();
     const pluginRoot = createProjectRoot('plugin-app-server-isolation');
@@ -1838,11 +1865,6 @@ describe('lifecycle recovery', () => {
       eventBus,
       providers: permissiveProviderLookupPort,
     });
-    // `runningJobs` order comes from `ORDER BY job_id ASC` (src/jobs/read-queries.ts), and
-    // 'isolation-blocked-job' < 'isolation-healthy-job' lexically. That ordering is what makes
-    // this a proof: the failing job must be processed FIRST, or both old and new code would
-    // finalize the healthy job before the throw and the test would assert nothing. Keep the
-    // blocked id sorting first if these are ever renamed.
     const blockedJobId = 'isolation-blocked-job';
     const healthyJobId = 'isolation-healthy-job';
     const fakeService = createFakeExecutionAndRecoveryService({
@@ -1974,6 +1996,214 @@ describe('lifecycle recovery', () => {
     }
   });
 
+  it.each(['queued', 'running'] as const)(
+    '14c4. a thrown %s registration failure is terminalized without aborting startup',
+    async (recoveryKind) => {
+      const modules = await loadModules();
+      const pluginRoot = createProjectRoot(`plugin-${recoveryKind}-registration-throws`);
+      const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+      const projectRoot = createProjectRoot(`project-${recoveryKind}-registration-throws`);
+      const eventBus = new modules.eventBusModule.TypedEventBus();
+      const db = openTestStoreDb(runtime, ':memory:');
+      const progressStore = new modules.progressStoreModule.JobStore(namespace, runtime, createEventBodyCodec(), {
+        db,
+        eventBus,
+        providers: permissiveProviderLookupPort,
+      });
+      const jobId = `${recoveryKind}-registration-throws-job`;
+      const sessionId = `${jobId}-session`;
+      const captureError = `${recoveryKind} authority capture rejected`;
+      const fakeService = createFakeExecutionAndRecoveryService({
+        captureProviderRecoveryAuthority: vi.fn(async () => {
+          throw new Error(captureError);
+        }),
+      });
+      const log = vi.fn<(message: string) => void>();
+
+      stubLaunchRecord(progressStore, {
+        jobId,
+        sessionId,
+        provider: 'codex',
+        projectRoot,
+        backendNamespace: namespace,
+      });
+      if (recoveryKind === 'queued') {
+        appendQueuedEvent(progressStore, jobId, sessionId, namespace, projectRoot);
+      } else {
+        stubRuntimeRecord(progressStore, { jobId, pid: process.pid });
+      }
+
+      const { controller, runtimeState } = createLifecycleHarness(modules, {
+        pluginRoot,
+        progressStore,
+        eventBus,
+        servicesByProjectRoot: new Map([[projectRoot, fakeService]]),
+        log,
+      });
+
+      try {
+        await controller.start();
+        expectRecordedRecoveryFault(progressStore, jobId, captureError);
+        expect(runtimeState.getLaunchFenceActive()).toBe(false);
+        expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
+        expect(log.mock.calls.flat().join('')).toContain('session claim disposition: released');
+
+        const reader = new modules.sessionManagerModule.SessionManager(
+          projectRoot,
+          runtime,
+          undefined,
+          undefined,
+          db,
+          permissiveProviderLookupPort,
+        );
+        expect(reader.get('codex', sessionId)?.activeJobId).toBeUndefined();
+        expect(reader.claimForJobSync(sessionId, `${jobId}-later`)).toBe(true);
+      } finally {
+        await stopLifecycleController(controller);
+      }
+    },
+  );
+
+  it.each(['queued', 'running'] as const)(
+    '14c5. a partial %s adoption is unwound before the session is made reusable',
+    async (recoveryKind) => {
+      const modules = await loadModules();
+      const pluginRoot = createProjectRoot(`plugin-${recoveryKind}-adoption-throws`);
+      const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+      const projectRoot = createProjectRoot(`project-${recoveryKind}-adoption-throws`);
+      const eventBus = new modules.eventBusModule.TypedEventBus();
+      const db = openTestStoreDb(runtime, ':memory:');
+      const progressStore = new modules.progressStoreModule.JobStore(namespace, runtime, createEventBodyCodec(), {
+        db,
+        eventBus,
+        providers: permissiveProviderLookupPort,
+      });
+      const launchCoordinator = createLaunchCoordinator(modules);
+      const providerRegistry = createRecoveryProviderRegistry(modules);
+      const service = createActualRecoveryService(modules, {
+        progressStore,
+        eventBus,
+        launchCoordinator,
+        providerRegistry,
+        pluginRoot,
+        projectRoot,
+      });
+      const jobId = `${recoveryKind}-adoption-throws-job`;
+      const sessionId = `${jobId}-session`;
+      const adoptionError = `${recoveryKind} namespace rebind failed`;
+
+      stubLaunchRecord(progressStore, {
+        jobId,
+        sessionId,
+        provider: 'codex',
+        projectRoot,
+        backendNamespace: namespace,
+      });
+      if (recoveryKind === 'queued') {
+        appendQueuedEvent(progressStore, jobId, sessionId, namespace, projectRoot);
+      } else {
+        stubRuntimeRecord(progressStore, { jobId, pid: process.pid });
+      }
+      vi.spyOn(progressStore, 'rebindNamespace').mockImplementationOnce(() => {
+        throw new Error(adoptionError);
+      });
+
+      const { controller, runtimeState } = createLifecycleHarness(modules, {
+        pluginRoot,
+        progressStore,
+        eventBus,
+        launchCoordinator,
+        providerRegistry,
+        servicesByProjectRoot: new Map([[projectRoot, service]]),
+      });
+
+      try {
+        await controller.start();
+        expectRecordedRecoveryFault(progressStore, jobId, adoptionError);
+        expect(runtimeState.getLaunchFenceActive()).toBe(false);
+        expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
+        expect(launchCoordinator.queuePosition(jobId)).toBeNull();
+        expect(launchCoordinator.getActiveJobIds()).not.toContain(jobId);
+
+        const reader = new modules.sessionManagerModule.SessionManager(
+          projectRoot,
+          runtime,
+          undefined,
+          undefined,
+          db,
+          permissiveProviderLookupPort,
+        );
+        expect(reader.get('codex', sessionId)?.activeJobId).toBeUndefined();
+        expect(reader.claimForJobSync(sessionId, `${jobId}-later`)).toBe(true);
+      } finally {
+        await stopLifecycleController(controller);
+      }
+    },
+  );
+
+  it('14c6. a terminal-write failure is logged and leaves the session claim in place', async () => {
+    const modules = await loadModules();
+    const pluginRoot = createProjectRoot('plugin-registration-terminal-write-fails');
+    const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+    const projectRoot = createProjectRoot('project-registration-terminal-write-fails');
+    const eventBus = new modules.eventBusModule.TypedEventBus();
+    const db = openTestStoreDb(runtime, ':memory:');
+    const progressStore = new modules.progressStoreModule.JobStore(namespace, runtime, createEventBodyCodec(), {
+      db,
+      eventBus,
+      providers: permissiveProviderLookupPort,
+    });
+    const jobId = 'registration-terminal-write-fails-job';
+    const sessionId = `${jobId}-session`;
+    const fakeService = createFakeExecutionAndRecoveryService({
+      captureProviderRecoveryAuthority: vi.fn(async () => {
+        throw new Error('authority capture failed first');
+      }),
+    });
+    const log = vi.fn<(message: string) => void>();
+
+    stubLaunchRecord(progressStore, {
+      jobId,
+      sessionId,
+      provider: 'codex',
+      projectRoot,
+      backendNamespace: namespace,
+    });
+    appendQueuedEvent(progressStore, jobId, sessionId, namespace, projectRoot);
+    vi.spyOn(progressStore, 'commit').mockImplementationOnce(() => {
+      throw new Error('terminal journal unavailable');
+    });
+
+    const { controller } = createLifecycleHarness(modules, {
+      pluginRoot,
+      progressStore,
+      eventBus,
+      servicesByProjectRoot: new Map([[projectRoot, fakeService]]),
+      log,
+    });
+
+    try {
+      await expect(controller.start()).rejects.toThrow('terminal journal unavailable');
+      expect(progressStore.readStatus(jobId)?.phase).toBe('queued');
+      expect(
+        new modules.sessionManagerModule.SessionManager(
+          projectRoot,
+          runtime,
+          undefined,
+          undefined,
+          db,
+          permissiveProviderLookupPort,
+        ).get('codex', sessionId)?.activeJobId,
+      ).toBe(jobId);
+      const messages = log.mock.calls.flat().join('');
+      expect(messages).toContain('could not terminalize as recovery_parse_failed');
+      expect(messages).toContain('session claim release was not attempted because terminalization failed');
+      expect(messages).toContain('Resolve the store write failure and restart the coordinator');
+    } finally {
+      await stopLifecycleController(controller);
+    }
+  });
+
   it('14d. app-server binding failure terminalizes instead of failing the boot', async () => {
     const modules = await loadModules();
     const pluginRoot = createProjectRoot('plugin-provider-authority-blocked');
@@ -1991,7 +2221,9 @@ describe('lifecycle recovery', () => {
         ok: false,
         failure: { reason: 'subject-mismatch', provider: 'codex' },
       })),
+      finalizeProviderRecoveryBindingFailure: vi.fn(() => 'owned_by_another_job' as const),
     });
+    const log = vi.fn<(message: string) => void>();
 
     stubLaunchRecord(progressStore, {
       jobId,
@@ -2015,6 +2247,7 @@ describe('lifecycle recovery', () => {
       eventBus,
       servicesByProjectRoot: new Map([[projectRoot, fakeService]]),
       runtime,
+      log,
     });
 
     try {
@@ -2027,6 +2260,7 @@ describe('lifecycle recovery', () => {
         expect.objectContaining({ jobId }),
         { reason: 'subject-mismatch', provider: 'codex' },
       );
+      expect(log.mock.calls.flat().join('')).toContain('session claim disposition: owned by another job');
     } finally {
       await stopLifecycleController(controller);
     }
@@ -2045,6 +2279,7 @@ describe('lifecycle recovery', () => {
     });
     const jobId = 'durable-binding-blocked-job';
     const pid = 73_737;
+    const controlledTime = createControllableTimeoutRuntime(runtime);
     const kill = vi.spyOn(runtime.process, 'kill').mockReturnValue(true);
     vi.spyOn(runtime.process, 'isAlive').mockImplementation((candidatePid) => candidatePid === pid);
     const fakeService = createFakeExecutionAndRecoveryService({
@@ -2053,6 +2288,7 @@ describe('lifecycle recovery', () => {
         failure: { reason: 'subject-mismatch', provider: 'codex' },
       })),
     });
+    const log = vi.fn<(message: string) => void>();
 
     stubLaunchRecord(progressStore, {
       jobId,
@@ -2068,7 +2304,8 @@ describe('lifecycle recovery', () => {
       progressStore,
       eventBus,
       servicesByProjectRoot: new Map([[projectRoot, fakeService]]),
-      runtime,
+      runtime: controlledTime.runtime,
+      log,
     });
 
     try {
@@ -2076,22 +2313,29 @@ describe('lifecycle recovery', () => {
       await controller.start();
       expect(fakeService.captureProviderRecoveryAuthority).toHaveBeenCalledTimes(1);
       expect(runtime.process.isAlive).toHaveBeenCalledWith(pid);
-      // The stop request is still the point of this case; only the boot failure is gone.
-      expect(kill).toHaveBeenCalledWith(pid, 'SIGTERM');
+      expect(kill.mock.calls).toEqual([[pid, 'SIGTERM']]);
+      expect(controlledTime.setTimeout).toHaveBeenCalledTimes(1);
+      expect(controlledTime.runNextTimeout()).toBe(5_000);
+      expect(kill.mock.calls).toEqual([
+        [pid, 'SIGTERM'],
+        [pid, 'SIGKILL'],
+      ]);
+      expect(controlledTime.pendingTimeoutCount()).toBe(0);
       expect(fakeService.finalizeProviderRecoveryBindingFailure).toHaveBeenCalledWith(
         expect.objectContaining({ jobId }),
         { reason: 'subject-mismatch', provider: 'codex' },
       );
+      expect(log.mock.calls.flat().join('')).toContain('session claim disposition: released');
       expect(runtimeState.getLaunchFenceActive()).toBe(false);
       expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
     } finally {
       await stopLifecycleController(controller);
+      controlledTime.discardScheduledTimeouts();
     }
   });
 
-  // The failed-stop branch is unreachable in production — RealRuntime.kill swallows signal
-  // errors and returns false — so only a mocked port exercises it. It still must not be
-  // fatal: before the fix a failed stop threw and took the whole boot with it.
+  // A throwing process port exercises the synchronous failure boundary; the real port
+  // reports signal failures as a false return value.
   it('14e2. a failed process stop is logged, not fatal', async () => {
     const modules = await loadModules();
     const pluginRoot = createProjectRoot('plugin-durable-kill-fails');
@@ -2105,6 +2349,7 @@ describe('lifecycle recovery', () => {
     });
     const jobId = 'durable-kill-fails-job';
     const pid = 73_939;
+    const controlledTime = createControllableTimeoutRuntime(runtime);
     const kill = vi.spyOn(runtime.process, 'kill').mockImplementation(() => {
       throw new Error('EPERM: operation not permitted');
     });
@@ -2130,12 +2375,14 @@ describe('lifecycle recovery', () => {
       progressStore,
       eventBus,
       servicesByProjectRoot: new Map([[projectRoot, fakeService]]),
-      runtime,
+      runtime: controlledTime.runtime,
     });
 
     try {
       await controller.start();
-      expect(kill).toHaveBeenCalled();
+      expect(kill.mock.calls).toEqual([[pid, 'SIGTERM']]);
+      expect(controlledTime.setTimeout).not.toHaveBeenCalled();
+      expect(controlledTime.pendingTimeoutCount()).toBe(0);
       // The throw is absorbed and the job still reaches its terminal.
       expect(fakeService.finalizeProviderRecoveryBindingFailure).toHaveBeenCalledWith(
         expect.objectContaining({ jobId }),
@@ -2145,6 +2392,7 @@ describe('lifecycle recovery', () => {
       expect(controller.getRecoveryRegistry()?.has(jobId) ?? false).toBe(false);
     } finally {
       await stopLifecycleController(controller);
+      controlledTime.discardScheduledTimeouts();
     }
   });
 

--- a/tests/unit/jobs/reconcile/recovery-coordinator-shutdown.test.ts
+++ b/tests/unit/jobs/reconcile/recovery-coordinator-shutdown.test.ts
@@ -18,6 +18,15 @@ import { createEventBodyCodec } from '#src/store/event-body-codec.js';
 import { openTestStoreDb } from '#tests/helpers/store-db.js';
 import { permissiveProviderLookupPort } from '#tests/helpers/append-context.js';
 import { createTestJobJournalDeps } from '#tests/helpers/job-journal-deps.js';
+import { parseExpression } from '#src/workflow/parser.js';
+import { buildWorkflowPlan } from '#src/workflow/plan.js';
+import { commitWorkflowEvents } from '#src/workflow/projections.js';
+import { workflowPlanDeclaredEvent } from '#src/workflow/events.js';
+import { TEST_PROVIDER_SCOPE } from '#tests/helpers/provider-credentials.js';
+import { commitJobTerminal } from '#tests/helpers/job-commits.js';
+import { testProjectPrincipal } from '#tests/helpers/principal.js';
+import type { WorkflowExecutionPort } from '#src/workflow/execution-contract.js';
+import type { WorkflowFinalizationIntent } from '#src/workflow/finalization.js';
 
 const mockState = vi.hoisted(() => ({
   tmpHome: '',
@@ -56,6 +65,8 @@ async function loadModules() {
     pathsModule,
     sessionQueriesModule,
     providerRegistryModule,
+    workflowRecoverModule,
+    jobReadQueriesModule,
   ] = await Promise.all([
     import('#src/jobs/store.js'),
     import('#src/coordinator/lifecycle.js'),
@@ -64,6 +75,8 @@ async function loadModules() {
     import('#src/infra/plugin-identity.js'),
     import('#src/sessions/lookup.js'),
     import('#src/providers/registry.js'),
+    import('#src/workflow/recover.js'),
+    import('#src/jobs/read-queries.js'),
   ]);
 
   return {
@@ -74,6 +87,8 @@ async function loadModules() {
     pathsModule,
     sessionQueriesModule,
     providerRegistryModule,
+    workflowRecoverModule,
+    jobReadQueriesModule,
   };
 }
 
@@ -254,6 +269,98 @@ function stubRuntimeRecord(
     stdoutPath: join(jobsDir(runtime.env), options.jobId, 'stdout'),
     stderrPath: join(jobsDir(runtime.env), options.jobId, 'stderr'),
     startTime: options.startTime ?? '2026-04-17T00:00:00.000Z',
+  });
+}
+
+function stubRecoverableWorkflow(
+  progressStore: InstanceType<LoadedModules['progressStoreModule']['JobStore']>,
+  runtime: Runtime,
+  options: {
+    workflowId: string;
+    projectRoot: string;
+    backendNamespace: string;
+    completedAtom: boolean;
+  },
+): void {
+  const plan = buildWorkflowPlan(options.workflowId, parseExpression('architect'), { defaultProvider: 'codex' });
+  commitWorkflowEvents(
+    progressStore.getDb(),
+    (c) => {
+      c.append(workflowPlanDeclaredEvent(options.workflowId, plan, TEST_PROVIDER_SCOPE));
+      return undefined;
+    },
+    runtime.time,
+    permissiveProviderLookupPort,
+  );
+  progressStore.appendLaunchRequested(options.workflowId, {
+    jobId: options.workflowId,
+    owner: { kind: 'workflow', id: options.workflowId },
+    sessionId: null,
+    provider: null,
+    projectRoot: options.projectRoot,
+    backendNamespace: options.backendNamespace,
+    jobKind: 'workflow',
+    pool: 'default',
+    enqueueSequence: progressStore.nextEnqueueSequence(),
+    request: {
+      prompt: '',
+      cwd: options.projectRoot,
+      bypassPermissions: false,
+      coralEnv: {},
+    },
+    createdAt: new Date(runtime.time.now()).toISOString(),
+  });
+  progressStore.commit((c) => {
+    c.append({
+      type: 'job.runtime.started',
+      stream: { kind: 'job', id: options.workflowId },
+      namespace: options.backendNamespace,
+      project: options.projectRoot,
+      refs: { jobId: options.workflowId, workflowId: options.workflowId },
+      body: { transport: 'workflow', startedAt: new Date(runtime.time.now()).toISOString() },
+    });
+    return undefined;
+  });
+
+  if (!options.completedAtom) {
+    return;
+  }
+
+  const slot = plan.slots[0];
+  const sessionId = `${options.workflowId}-session`;
+  seedTestSessionProjection(progressStore.getDb(), {
+    sessionId,
+    provider: slot.provider,
+    projectRoot: options.projectRoot,
+    backendNamespace: options.backendNamespace,
+    activeJobId: slot.slotId,
+  });
+  progressStore.appendLaunchRequested(slot.slotId, {
+    jobId: slot.slotId,
+    owner: { kind: 'workflow', id: options.workflowId },
+    sessionId,
+    provider: slot.provider,
+    projectRoot: options.projectRoot,
+    backendNamespace: options.backendNamespace,
+    jobKind: 'provider',
+    pool: 'default',
+    enqueueSequence: progressStore.nextEnqueueSequence(),
+    providerAction: 'exec',
+    parentWorkflowJobId: options.workflowId,
+    workflowSlotId: slot.slotId,
+    workflowSlotGeneration: 0,
+    request: {
+      prompt: '',
+      cwd: options.projectRoot,
+      bypassPermissions: false,
+      coralEnv: {},
+    },
+    createdAt: new Date(runtime.time.now()).toISOString(),
+  });
+  commitJobTerminal(progressStore, slot.slotId, sessionId, {
+    content: 'recovered output',
+    outcome: { kind: 'completed' },
+    durationMs: 0,
   });
 }
 
@@ -602,7 +709,79 @@ describe('recovery coordinator shutdown', () => {
     }
   });
 
-  it('re-fences and retains adopted ownership when durable finalization fails', async () => {
+  it('continues to the second workflow and lets start resolve after finalizing the first recovery failure', async () => {
+    const modules = await loadModules();
+    const runtime = createRealRuntime('prod');
+    const pluginRoot = createProjectRoot('plugin-workflow-isolation');
+    const failedProjectRoot = createProjectRoot('project-workflow-failure');
+    const resumedProjectRoot = createProjectRoot('project-workflow-resumed');
+    const backendNamespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+    const finalizeWorkflow = vi.fn<(intent: WorkflowFinalizationIntent) => void>();
+    const recoveryLog = vi.fn<(message: string) => void>();
+    const getExecutionService = vi.fn((ctx: { projectRoot: string }) => {
+      if (ctx.projectRoot === failedProjectRoot) {
+        throw new Error('failed workflow recovery');
+      }
+      return {} as WorkflowExecutionPort;
+    });
+    let resumedWorkflowIds: string[] = [];
+    const harness = createCoordinatorShutdownHarness({
+      modules,
+      runtime,
+      pluginRoot,
+      projectRoot: failedProjectRoot,
+      workflowResumeImpl: async () => {
+        resumedWorkflowIds = await modules.workflowRecoverModule.resumeAll({
+          db: harness.progressStore.getDb(),
+          progressStore: harness.progressStore,
+          loadJobDetails: modules.jobReadQueriesModule.loadJobProjectionDetails,
+          getExecutionService,
+          createInvocationContext: (projectRoot) => ({
+            projectRoot,
+            pluginRoot,
+            coralEnv: {},
+            principal: testProjectPrincipal(projectRoot),
+          }),
+          finalizeWorkflow,
+          log: recoveryLog,
+          time: runtime.time,
+        });
+      },
+    });
+    stubRecoverableWorkflow(harness.progressStore, runtime, {
+      workflowId: 'workflow-fails-recovery',
+      projectRoot: failedProjectRoot,
+      backendNamespace,
+      completedAtom: false,
+    });
+    stubRecoverableWorkflow(harness.progressStore, runtime, {
+      workflowId: 'workflow-resumes-after-failure',
+      projectRoot: resumedProjectRoot,
+      backendNamespace,
+      completedAtom: true,
+    });
+
+    try {
+      await harness.controller.start();
+      expect(resumedWorkflowIds).toEqual(['workflow-fails-recovery', 'workflow-resumes-after-failure']);
+      expect(getExecutionService).toHaveBeenCalledTimes(2);
+      expect(finalizeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: 'failed', workflowJobId: 'workflow-fails-recovery' }),
+      );
+      expect(finalizeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: 'completed', workflowJobId: 'workflow-resumes-after-failure' }),
+      );
+      expect(recoveryLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Workflow recovery finalized workflow-fails-recovery after recovery failed: failed workflow recovery',
+        ),
+      );
+    } finally {
+      await stopLifecycleController(harness.controller);
+    }
+  });
+
+  it('terminalizes the adopted job, releases its claim, cleans up, and leaves the launch fence open when finalization fails', async () => {
     const modules = await loadModules();
     const virtualRuntime = new SimulationRuntime();
     const runtime: Runtime = { ...createRealRuntime('prod'), time: virtualRuntime.time };
@@ -639,11 +818,15 @@ describe('recovery coordinator shutdown', () => {
 
       await vi.waitFor(() => {
         expect(harness.fakeService.finalizeInterruptedDurableJob).toHaveBeenCalledTimes(1);
-        expect(harness.runtimeState.getLaunchFenceActive()).toBe(true);
+        expect(harness.progressStore.readStatus('running-adoption-job')?.phase).toBe('error');
+        expect(cleanupSpy).toHaveBeenCalledTimes(1);
       });
-      expect(cleanupSpy).not.toHaveBeenCalled();
-      expect(harness.controller.getRecoveryRegistry()?.has('running-adoption-job')).toBe(true);
-      expect(harness.progressStore.readStatus('running-adoption-job')?.phase).toBe('running');
+      const recoveredSession = modules.sessionQueriesModule
+        .createProjectionSessionLookup(harness.progressStore.getDb())
+        .readProviderSession('running-adoption-session');
+      expect(recoveredSession?.activeJobId).toBeUndefined();
+      expect(harness.runtimeState.getLaunchFenceActive()).toBe(false);
+      expect(harness.controller.getRecoveryRegistry()).toBeNull();
     } finally {
       await stopLifecycleController(harness.controller);
     }
@@ -787,4 +970,4 @@ describe('recovery coordinator shutdown', () => {
     expect(((await startup) as Error).name).toBe('AbortError');
   });
 });
-import { seedTestJobSession } from '#tests/helpers/session.js';
+import { seedTestJobSession, seedTestSessionProjection } from '#tests/helpers/session.js';

--- a/tests/unit/jobs/reconcile/recovery-coordinator-shutdown.test.ts
+++ b/tests/unit/jobs/reconcile/recovery-coordinator-shutdown.test.ts
@@ -743,6 +743,7 @@ describe('recovery coordinator shutdown', () => {
             principal: testProjectPrincipal(projectRoot),
           }),
           finalizeWorkflow,
+          releaseFailedWorkflowDescendants: () => [],
           log: recoveryLog,
           time: runtime.time,
         });

--- a/tests/unit/jobs/reconcile/recovery-coordinator-shutdown.test.ts
+++ b/tests/unit/jobs/reconcile/recovery-coordinator-shutdown.test.ts
@@ -195,7 +195,7 @@ function createFakeExecutionAndRecoveryService(overrides: Record<string, unknown
         boundProvider: { name: launchRecord.provider },
       },
     })),
-    finalizeProviderRecoveryBindingFailure: vi.fn(),
+    finalizeProviderRecoveryBindingFailure: vi.fn(() => 'released' as const),
     recoverQueuedJob: vi.fn(() => 'recovered-job'),
     completeRecoveredJob: vi.fn(),
     finalizeInterruptedAppServerJob: vi.fn(async () => {}),

--- a/tests/unit/sessions/lifecycle-reactor.test.ts
+++ b/tests/unit/sessions/lifecycle-reactor.test.ts
@@ -1009,6 +1009,43 @@ describe('LifecycleReactor retention enforcement', () => {
     ]);
   });
 
+  it('continues startup retention processing for a valid session when another projection cannot be decoded', async () => {
+    const harness = createHarness({ autoObserveCoordinator: false });
+    const malformedJobId = 'job-startup-scan-malformed-session';
+    const validJobId = 'job-startup-scan-valid-session';
+    const malformedSessionId = await openClaimedSession(harness, malformedJobId);
+    const validSessionId = await openClaimedSession(harness, validJobId);
+
+    for (const [jobId, sessionId] of [
+      [malformedJobId, malformedSessionId],
+      [validJobId, validSessionId],
+    ] as const) {
+      initRunningJob(harness, jobId, sessionId);
+      completeJob(harness, jobId, sessionId);
+      harness.sessionManager.releaseJob(sessionId, jobId);
+    }
+    await harness.reactor.waitForIdle();
+    harness.db
+      .prepare('UPDATE projection_sessions SET entry = ? WHERE session_id = ?')
+      .run('not valid session json', malformedSessionId);
+
+    await harness.reactor.scanStartup();
+
+    await expectRetentionEvents(harness, validSessionId, [
+      { type: 'session.retention.discard.requested', attempt: 1, handles: [] },
+      {
+        type: 'session.retention.discard.completed',
+        attempt: 1,
+        handles: [],
+        outcome: 'skipped_no_handles',
+      },
+    ]);
+    expect(harness.logs.join('\n')).toContain(
+      `Skipped malformed session projection for ${malformedSessionId} during lifecycle processing`,
+    );
+    expect(readRetentionEvents(harness, malformedSessionId)).toEqual([]);
+  });
+
   it('expires a pending continuation lease by timer and discards without later terminal or release events', async () => {
     const harness = createHarness({ autoObserveCoordinator: false });
     const jobId = 'job-lease-timer';

--- a/tests/unit/sessions/shell.test.ts
+++ b/tests/unit/sessions/shell.test.ts
@@ -388,7 +388,7 @@ describe('sessions shell store', () => {
     const entry = allocateTestSession(mgr, 'codex', 'alpha', 'gpt-5', workDir);
     mgr.claimForJobSync(entry.sessionId, 'job-1');
 
-    mgr.releaseJob(entry.sessionId, 'job-1');
+    expect(mgr.releaseJob(entry.sessionId, 'job-1')).toBe('released');
 
     const stored = mgr.get('codex', entry.sessionId);
     expect(stored?.activeJobId).toBeUndefined();
@@ -884,10 +884,19 @@ describe('sessions shell store adversarial', () => {
     const entry = allocateTestSession(mgr, 'codex', 'alpha', 'gpt-5', workDir);
     mgr.claimForJobSync(entry.sessionId, 'job-correct');
 
-    mgr.releaseJob(entry.sessionId, 'job-WRONG');
+    expect(mgr.releaseJob(entry.sessionId, 'job-WRONG')).toBe('owned_by_another_job');
 
     const stored = mgr.get('codex', entry.sessionId);
     expect(stored?.activeJobId).toBe('job-correct');
+  });
+
+  it('releaseJob reports an absent claim without writing a release event', () => {
+    const { mgr, workDir } = setup('release-absent');
+    const entry = allocateTestSession(mgr, 'codex', 'alpha', 'gpt-5', workDir);
+
+    expect(mgr.releaseJob(entry.sessionId, 'job-1')).toBe('already_absent');
+    expect(mgr.releaseJob('missing-session', 'job-1')).toBe('already_absent');
+    expect(mgr.get('codex', entry.sessionId)?.version).toBe(entry.version);
   });
 
   it('list returns only sessions for the requested provider (no cross-provider leakage)', () => {

--- a/tests/unit/workflow/recover-branches.test.ts
+++ b/tests/unit/workflow/recover-branches.test.ts
@@ -440,7 +440,7 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow: vi.fn(),
           time: fixedTime,
         }),
-      ).rejects.toThrow('failed');
+      ).resolves.toEqual(['workflow-1']);
       expect(harness.executionSvc.resume).toHaveBeenCalledWith(
         harness.plan.slots[0].provider,
         expect.objectContaining({
@@ -494,7 +494,7 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow: vi.fn(),
           time: fixedTime,
         }),
-      ).rejects.toThrow('failed');
+      ).resolves.toEqual(['workflow-1']);
       expect(harness.executionSvc.resume).toHaveBeenCalledTimes(1);
     } finally {
       harness.db.close();
@@ -526,7 +526,7 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow: vi.fn(),
           time: fixedTime,
         }),
-      ).rejects.toThrow('failed');
+      ).resolves.toEqual(['workflow-1']);
       expect(harness.executionSvc.recordContinuationLease).toHaveBeenCalledWith(
         expect.objectContaining({
           sessionId: 'session-atom-1',
@@ -578,7 +578,17 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow,
           time: fixedTime,
         }),
-      ).rejects.toThrow(`invalid child chain for slot '${slot.slotId}'`);
+      ).resolves.toEqual(['workflow-1']);
+      expect(finalizeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: 'failed',
+          workflowJobId: 'workflow-1',
+          lifecycleFault: expect.objectContaining({
+            kind: 'recovery_failed',
+            message: `Workflow recovery rejected invalid child chain for slot '${slot.slotId}' at job 'invalid-generation-2'.`,
+          }),
+        }),
+      );
       expect(harness.executionSvc.waitStream).not.toHaveBeenCalled();
     } finally {
       harness.db.close();
@@ -822,10 +832,7 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow,
           time: fixedTime,
         }),
-      ).rejects.toMatchObject({
-        message: "Step 0, atom 'critic' launch failed: launch capacity unavailable",
-        failedSlotId: missingSlot.slotId,
-      });
+      ).resolves.toEqual(['workflow-1']);
 
       expect(harness.executionSvc.coralDispatch).toHaveBeenCalledTimes(1);
       expect(harness.executionSvc.coralDispatch).toHaveBeenCalledWith(
@@ -884,7 +891,7 @@ describe('workflow recovery branch rules', () => {
         },
       },
     });
-    const [completedSlot, missingSlot] = harness.plan.slots;
+    const [completedSlot] = harness.plan.slots;
     const finalizeWorkflow = vi.fn<(intent: WorkflowFinalizationIntent) => void>();
     harness.executionSvc.coralDispatch.mockResolvedValue({
       status: 'rejected',
@@ -911,10 +918,7 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow,
           time: fixedTime,
         }),
-      ).rejects.toMatchObject({
-        message: "Step 0, atom 'critic' launch failed: launch capacity unavailable",
-        failedSlotId: missingSlot.slotId,
-      });
+      ).resolves.toEqual(['workflow-1']);
 
       expect(harness.executionSvc.abort).toHaveBeenCalledWith([completedSlot.slotId]);
       expect(finalizeWorkflow).toHaveBeenCalledTimes(1);
@@ -949,12 +953,7 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow,
           time: fixedTime,
         }),
-      ).rejects.toMatchObject({
-        message: "Step 0, atom 'architect' failed: exited with code 1",
-        aborted: false,
-        failedAtom: 'architect',
-        failedJobId: harness.plan.slots[0].slotId,
-      });
+      ).resolves.toEqual(['workflow-1']);
 
       expect(finalizeWorkflow).toHaveBeenCalledTimes(1);
       expect(finalizeWorkflow.mock.calls[0]?.[0]).toMatchObject({
@@ -996,12 +995,7 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow,
           time: fixedTime,
         }),
-      ).rejects.toMatchObject({
-        message: "Step 0, atom 'critic' failed: exited with code 1",
-        aborted: false,
-        failedAtom: 'critic',
-        failedJobId: harness.plan.slots[1].slotId,
-      });
+      ).resolves.toEqual(['workflow-1']);
 
       expect(finalizeWorkflow).toHaveBeenCalledTimes(1);
       expect(finalizeWorkflow.mock.calls[0]?.[0]).toMatchObject({
@@ -1050,9 +1044,16 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow,
           time: fixedTime,
         }),
-      ).rejects.toThrow(`invalid durable relation for slot '${slot.slotId}'`);
+      ).resolves.toEqual(['workflow-1']);
       expect(finalizeWorkflow).toHaveBeenCalledWith(
-        expect.objectContaining({ outcome: 'failed', workflowJobId: 'workflow-1' }),
+        expect.objectContaining({
+          outcome: 'failed',
+          workflowJobId: 'workflow-1',
+          lifecycleFault: expect.objectContaining({
+            kind: 'recovery_failed',
+            message: `Workflow recovery rejected invalid durable relation for slot '${slot.slotId}' and job '${slot.slotId}'.`,
+          }),
+        }),
       );
       expect(harness.executionSvc.waitStream).not.toHaveBeenCalled();
     } finally {
@@ -1077,9 +1078,16 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow,
           time: fixedTime,
         }),
-      ).rejects.toThrow(`could not find provider session 'session-atom-1' for slot '${slot.slotId}'`);
+      ).resolves.toEqual(['workflow-1']);
       expect(finalizeWorkflow).toHaveBeenCalledWith(
-        expect.objectContaining({ outcome: 'failed', workflowJobId: 'workflow-1' }),
+        expect.objectContaining({
+          outcome: 'failed',
+          workflowJobId: 'workflow-1',
+          lifecycleFault: expect.objectContaining({
+            kind: 'recovery_failed',
+            message: `Workflow recovery could not find provider session 'session-atom-1' for slot '${slot.slotId}'.`,
+          }),
+        }),
       );
       expect(harness.executionSvc.waitStream).not.toHaveBeenCalled();
     } finally {

--- a/tests/unit/workflow/recover-branches.test.ts
+++ b/tests/unit/workflow/recover-branches.test.ts
@@ -273,7 +273,7 @@ function createHarness(options: {
     principal: testProjectPrincipal(projectRoot),
   });
 
-  return { db, plan, progressStore, executionSvc, createInvocationContext, waitRequests };
+  return { db, plan, progressStore, executionSvc, createInvocationContext, waitRequests, runtime };
 }
 
 function appendRecoverableWorkflowRoot(progressStore: JobStore, workflowId: string, projectRoot: string): void {
@@ -1419,6 +1419,7 @@ describe('workflow recovery branch rules', () => {
         createInvocationContext: backend.createInvocationContext,
         releaseAdoptedJob: recoveryCoordinator.releaseAdoptedJob,
         emitSessionReleased,
+        log,
       });
       let workflowServiceCalls = 0;
 
@@ -1469,7 +1470,98 @@ describe('workflow recovery branch rules', () => {
     }
   });
 
-  it('returns after emitting an aborted finalization intent', async () => {
+  it('retains an unconfirmed live descendant claim and continues releasing later descendants', () => {
+    const harness = createHarness({
+      expression: '(architect, reviewer)',
+      atomPhase: 'running',
+      projectionPhase: 'running',
+    });
+    const failedJobId = harness.plan.slots[0].slotId;
+    const failedSessionId = 'session-atom-1';
+    const nextJobId = harness.plan.slots[1].slotId;
+    const nextSessionId = 'session-atom-2';
+    const stopError = new Error('descendant stop failed');
+    const abort = vi.fn((jobIds: string[]) => {
+      if (jobIds[0] === failedJobId) throw stopError;
+      return { aborted: jobIds, notFound: [] };
+    });
+    const releaseAdoptedJob = vi.fn();
+    const emitSessionReleased = vi.fn();
+    const log = vi.fn<(message: string) => void>();
+    const releaseFailedWorkflowDescendants = createFailedWorkflowDescendantReleaser({
+      progressStore: harness.progressStore,
+      runtime: harness.runtime,
+      coordinatorCommit: (cb) => harness.progressStore.commit(cb),
+      getExecutionService: () => ({ abort }),
+      createInvocationContext: harness.createInvocationContext,
+      releaseAdoptedJob,
+      emitSessionReleased,
+      log,
+    });
+
+    try {
+      expect(releaseFailedWorkflowDescendants('workflow-1')).toEqual([
+        { jobId: nextJobId, sessionId: nextSessionId, sessionClaimRelease: 'released' },
+      ]);
+      expect(abort).toHaveBeenCalledWith([failedJobId]);
+      expect(abort).toHaveBeenCalledWith([nextJobId]);
+      expect(releaseAdoptedJob).not.toHaveBeenCalledWith(failedJobId);
+      expect(releaseAdoptedJob).toHaveBeenCalledWith(nextJobId);
+      expect(createProjectionSessionLookup(harness.db).readProviderSession(failedSessionId)?.activeJobId).toBe(
+        failedJobId,
+      );
+      expect(createProjectionSessionLookup(harness.db).readProviderSession(nextSessionId)?.activeJobId).toBeUndefined();
+      expect(emitSessionReleased).toHaveBeenCalledWith({ sessionId: nextSessionId, jobId: nextJobId });
+      expect(log).toHaveBeenCalledWith(
+        `Workflow recovery could not confirm child ${failedJobId} stopped; retained adopted runtime ownership and session claim ${failedSessionId}: ${stopError.message}\n`,
+      );
+    } finally {
+      harness.db.close();
+    }
+  });
+
+  it('releases descendants after a returned workflow failure', async () => {
+    const harness = createHarness({
+      atomPhase: 'running',
+      projectionPhase: null,
+      atomTerminals: {
+        0: {
+          content: '',
+          outcome: {
+            kind: 'job_fault',
+            fault: { kind: 'wrapper_crashed', cause: { message: 'workflow child failed' } },
+          },
+          durationMs: 0,
+        },
+      },
+    });
+    const finalizeWorkflow = vi.fn<(intent: WorkflowFinalizationIntent) => void>();
+    const releaseFailedWorkflowDescendants = vi.fn(() => []);
+
+    try {
+      await expect(
+        resumeAll({
+          db: harness.db,
+          progressStore: harness.progressStore,
+          loadJobDetails: loadJobProjectionDetails,
+          getExecutionService: () => harness.executionSvc,
+          createInvocationContext: harness.createInvocationContext,
+          finalizeWorkflow,
+          releaseFailedWorkflowDescendants,
+          signal: new AbortController().signal,
+          time: fixedTime,
+        }),
+      ).resolves.toEqual(['workflow-1']);
+      expect(finalizeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: 'failed', workflowJobId: 'workflow-1' }),
+      );
+      expect(releaseFailedWorkflowDescendants).toHaveBeenCalledWith('workflow-1');
+    } finally {
+      harness.db.close();
+    }
+  });
+
+  it('releases descendants after emitting a returned aborted finalization intent', async () => {
     const harness = createHarness({
       atomPhase: 'running',
       projectionPhase: null,
@@ -1492,13 +1584,14 @@ describe('workflow recovery branch rules', () => {
           finalizeWorkflow,
           releaseFailedWorkflowDescendants,
           log,
+          signal: new AbortController().signal,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
       expect(finalizeWorkflow).toHaveBeenCalledWith(
         expect.objectContaining({ outcome: 'aborted', workflowJobId: 'workflow-1' }),
       );
-      expect(releaseFailedWorkflowDescendants).not.toHaveBeenCalled();
+      expect(releaseFailedWorkflowDescendants).toHaveBeenCalledWith('workflow-1');
       expect(log).toHaveBeenCalledWith(expect.stringContaining('with aborted outcome'));
       expect(log.mock.calls.flat().join('')).not.toContain('after recovery failed');
     } finally {
@@ -1524,12 +1617,44 @@ describe('workflow recovery branch rules', () => {
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
           releaseFailedWorkflowDescendants,
+          signal: new AbortController().signal,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
       expect(finalizeWorkflow).toHaveBeenCalledWith(
         expect.objectContaining({ outcome: 'aborted', workflowJobId: 'workflow-1' }),
       );
+    } finally {
+      harness.db.close();
+    }
+  });
+
+  it('contains an item-local AbortError while the coordinator signal is live', async () => {
+    const harness = createHarness({ atomPhase: 'running', projectionPhase: 'running' });
+    const finalizeWorkflow = vi.fn<(intent: WorkflowFinalizationIntent) => void>();
+    const releaseFailedWorkflowDescendants = vi.fn(() => []);
+    const localAbort = new AbortError({ stage: 'workflow child lookup' });
+
+    try {
+      await expect(
+        resumeAll({
+          db: harness.db,
+          progressStore: harness.progressStore,
+          loadJobDetails: loadJobProjectionDetails,
+          getExecutionService: () => {
+            throw localAbort;
+          },
+          createInvocationContext: harness.createInvocationContext,
+          finalizeWorkflow,
+          releaseFailedWorkflowDescendants,
+          signal: new AbortController().signal,
+          time: fixedTime,
+        }),
+      ).resolves.toEqual(['workflow-1']);
+      expect(finalizeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: 'failed', workflowJobId: 'workflow-1' }),
+      );
+      expect(releaseFailedWorkflowDescendants).toHaveBeenCalledWith('workflow-1');
     } finally {
       harness.db.close();
     }
@@ -1555,6 +1680,7 @@ describe('workflow recovery branch rules', () => {
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
           releaseFailedWorkflowDescendants,
+          signal: new AbortController().signal,
           time: fixedTime,
         }),
       ).rejects.toBe(finalizerError);
@@ -1569,7 +1695,9 @@ describe('workflow recovery branch rules', () => {
     const harness = createHarness({ atomPhase: 'running', projectionPhase: 'running' });
     const finalizeWorkflow = vi.fn<(intent: WorkflowFinalizationIntent) => void>();
     const releaseFailedWorkflowDescendants = vi.fn(() => []);
-    const cancellation = new AbortError({ stage: 'workflow recovery' });
+    const cancellation = new Error('coordinator stopped workflow recovery');
+    const controller = new AbortController();
+    controller.abort(cancellation);
     harness.executionSvc.waitStream.mockReturnValue(failWait(cancellation));
 
     try {
@@ -1582,6 +1710,7 @@ describe('workflow recovery branch rules', () => {
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
           releaseFailedWorkflowDescendants,
+          signal: controller.signal,
           time: fixedTime,
         }),
       ).rejects.toBe(cancellation);

--- a/tests/unit/workflow/recover-branches.test.ts
+++ b/tests/unit/workflow/recover-branches.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { JobStore } from '#src/jobs/store.js';
 import { SimulationRuntime } from '#tools/simulation/runtime.js';
+import { createSimulationBackend } from '#tools/simulation/core/backend.js';
+import { AbortError } from '#src/runtime/abort.js';
 import type { InvocationContext } from '#src/runtime/invocation-context.js';
-import type { JobTerminal } from '#src/jobs/records.js';
+import type { JobLaunch, JobTerminal } from '#src/jobs/records.js';
 import type { WaitStreamEvent, WaitStreamRequest } from '#src/jobs/wait.js';
 import { applyBundledStoreSchema } from '#src/store/db.js';
 import { createEventBodyCodec } from '#src/store/event-body-codec.js';
@@ -17,7 +19,7 @@ import { buildWorkflowPlan, type WorkflowPlan } from '#src/workflow/plan.js';
 import { commitWorkflowEvents } from '#src/workflow/projections.js';
 import { loadJobProjectionDetails } from '#src/jobs/read-queries.js';
 import { resumeAll } from '#src/workflow/recover.js';
-import type { WorkflowExecutionPort } from '#src/workflow/execution-contract.js';
+import { createWorkflowExecutionError, type WorkflowExecutionPort } from '#src/workflow/execution-contract.js';
 import type { WorkflowFinalizationIntent } from '#src/workflow/finalization.js';
 import { permissiveProviderLookupPort } from '#tests/helpers/append-context.js';
 import { commitJobTerminal } from '#tests/helpers/job-commits.js';
@@ -29,6 +31,11 @@ import { composeReducers } from '#src/store/reducers.js';
 import { sessionContinuationLeaseClaimedEvent } from '#src/sessions/continuation-lease-events.js';
 import { jobLaunchRequestedEvent } from '#src/jobs/store.js';
 import type { ProviderSession } from '#src/sessions/entry.js';
+import { createProjectionSessionLookup } from '#src/sessions/lookup.js';
+import { createWorkflowRecoveryFinalizer } from '#src/coordinator/services/workflow-recovery-finalizer.js';
+import { createRecoveryCoordinator } from '#src/coordinator/services/recovery/index.js';
+import { createFailedWorkflowDescendantReleaser } from '#src/coordinator/services/workflow-recovery-descendants.js';
+import { seedTestSessionProjection } from '#tests/helpers/session.js';
 
 // NOTE: "running" and "queued" branches today share the same code path
 // (both hit waitForAtoms). We retain two tests so that if phase-differentiated
@@ -50,6 +57,7 @@ const fixedTime = {
 
 const PROJECT_ROOT = '/tmp/coral-workflow-project';
 const BACKEND_NAMESPACE = 'workflow-test-ns';
+const noFailedWorkflowDescendants = () => [];
 
 function running(jobId: string, sessionId: string) {
   return {
@@ -76,6 +84,10 @@ async function* emit(events: WaitStreamEvent[]): AsyncGenerator<WaitStreamEvent>
   for (const event of events) {
     yield event;
   }
+}
+
+async function* failWait(error: unknown): AsyncGenerator<WaitStreamEvent> {
+  throw error;
 }
 
 function createWorkflowPlan(expression = 'architect'): WorkflowPlan {
@@ -264,6 +276,44 @@ function createHarness(options: {
   return { db, plan, progressStore, executionSvc, createInvocationContext, waitRequests };
 }
 
+function appendRecoverableWorkflowRoot(progressStore: JobStore, workflowId: string, projectRoot: string): void {
+  const plan = buildWorkflowPlan(workflowId, parseExpression('architect'), { defaultProvider: 'codex' });
+  commitWorkflowEvents(
+    progressStore.getDb(),
+    (c) => {
+      c.append(workflowPlanDeclaredEvent(workflowId, plan, TEST_PROVIDER_SCOPE));
+      return undefined;
+    },
+    fixedTime,
+    permissiveProviderLookupPort,
+  );
+  progressStore.appendLaunchRequested(workflowId, {
+    jobId: workflowId,
+    owner: { kind: 'workflow', id: workflowId },
+    sessionId: null,
+    provider: null,
+    projectRoot,
+    backendNamespace: BACKEND_NAMESPACE,
+    jobKind: 'workflow',
+    pool: 'default',
+    enqueueSequence: progressStore.nextEnqueueSequence(),
+    request: { prompt: '', cwd: projectRoot, bypassPermissions: false, coralEnv: {} },
+    createdAt: '2026-04-27T00:00:00.000Z',
+  });
+  progressStore.commit((c) => {
+    c.append({
+      type: 'job.runtime.started',
+      stream: { kind: 'job', id: workflowId },
+      namespace: BACKEND_NAMESPACE,
+      project: projectRoot,
+      refs: { jobId: workflowId, workflowId },
+      body: { transport: 'workflow', startedAt: '2026-04-27T00:00:00.000Z' },
+    });
+    return undefined;
+  });
+  progressStore.getDb().prepare('DELETE FROM projection_workflows WHERE workflow_id = ?').run(workflowId);
+}
+
 function setPendingReplacementLease(
   harness: ReturnType<typeof createHarness>,
   expiresAt = '2099-01-01T00:00:00.000Z',
@@ -399,6 +449,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -438,6 +489,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow: vi.fn(),
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -492,6 +544,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow: vi.fn(),
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -524,6 +577,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow: vi.fn(),
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -576,6 +630,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -605,6 +660,7 @@ describe('workflow recovery branch rules', () => {
         getExecutionService: () => harness.executionSvc,
         createInvocationContext: harness.createInvocationContext,
         finalizeWorkflow: vi.fn(),
+        releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
         time: fixedTime,
       });
 
@@ -632,6 +688,7 @@ describe('workflow recovery branch rules', () => {
         getExecutionService: () => harness.executionSvc,
         createInvocationContext: harness.createInvocationContext,
         finalizeWorkflow: vi.fn(),
+        releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
         time: fixedTime,
       });
 
@@ -665,6 +722,7 @@ describe('workflow recovery branch rules', () => {
         getExecutionService,
         createInvocationContext: createReplacementContext,
         finalizeWorkflow: vi.fn(),
+        releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
         time: fixedTime,
       });
 
@@ -744,6 +802,7 @@ describe('workflow recovery branch rules', () => {
         getExecutionService: () => harness.executionSvc,
         createInvocationContext: harness.createInvocationContext,
         finalizeWorkflow,
+        releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
         time: fixedTime,
       });
 
@@ -830,6 +889,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -916,6 +976,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -951,6 +1012,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -993,6 +1055,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -1042,6 +1105,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -1076,6 +1140,7 @@ describe('workflow recovery branch rules', () => {
           getExecutionService: () => harness.executionSvc,
           createInvocationContext: harness.createInvocationContext,
           finalizeWorkflow,
+          releaseFailedWorkflowDescendants: noFailedWorkflowDescendants,
           time: fixedTime,
         }),
       ).resolves.toEqual(['workflow-1']);
@@ -1094,5 +1159,436 @@ describe('workflow recovery branch rules', () => {
       harness.db.close();
     }
   });
+
+  it.each([
+    ['plan', '{'],
+    ['provider_scope', '{'],
+    ['lifecycle', 'invalid-lifecycle'],
+  ] as const)('contains malformed workflow %s hydration and visits the next workflow', async (column, value) => {
+    const harness = createHarness({ atomPhase: 'running', projectionPhase: 'running' });
+    appendRecoverableWorkflowRoot(harness.progressStore, 'workflow-2', '/tmp/coral-workflow-project-2');
+    harness.db.prepare(`UPDATE projection_workflows SET ${column} = ? WHERE workflow_id = ?`).run(value, 'workflow-1');
+    const finalizeWorkflow = vi.fn<(intent: WorkflowFinalizationIntent) => void>();
+    const releaseFailedWorkflowDescendants = vi.fn(() => []);
+
+    try {
+      await expect(
+        resumeAll({
+          db: harness.db,
+          progressStore: harness.progressStore,
+          loadJobDetails: loadJobProjectionDetails,
+          getExecutionService: () => harness.executionSvc,
+          createInvocationContext: harness.createInvocationContext,
+          finalizeWorkflow,
+          releaseFailedWorkflowDescendants,
+          time: fixedTime,
+        }),
+      ).resolves.toEqual(['workflow-1', 'workflow-2']);
+      expect(finalizeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: 'failed',
+          workflowJobId: 'workflow-1',
+          lifecycleFault: expect.objectContaining({ kind: 'recovery_failed' }),
+        }),
+      );
+      expect(finalizeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: 'failed',
+          workflowJobId: 'workflow-2',
+          lifecycleFault: expect.objectContaining({
+            kind: 'recovery_failed',
+            message: 'Workflow recovery could not find a workflow projection.',
+          }),
+        }),
+      );
+      expect(releaseFailedWorkflowDescendants).toHaveBeenCalledWith('workflow-1');
+      expect(releaseFailedWorkflowDescendants).toHaveBeenCalledWith('workflow-2');
+    } finally {
+      harness.db.close();
+    }
+  });
+
+  it('contains invocation-context construction failure and visits the next workflow', async () => {
+    const harness = createHarness({ atomPhase: 'running', projectionPhase: 'running' });
+    appendRecoverableWorkflowRoot(harness.progressStore, 'workflow-2', '/tmp/coral-workflow-project-2');
+    const finalizeWorkflow = vi.fn<(intent: WorkflowFinalizationIntent) => void>();
+    const releaseFailedWorkflowDescendants = vi.fn(() => []);
+    const getExecutionService = vi.fn(() => harness.executionSvc);
+
+    try {
+      await expect(
+        resumeAll({
+          db: harness.db,
+          progressStore: harness.progressStore,
+          loadJobDetails: loadJobProjectionDetails,
+          getExecutionService,
+          createInvocationContext: () => {
+            throw new Error('invocation context unavailable');
+          },
+          finalizeWorkflow,
+          releaseFailedWorkflowDescendants,
+          time: fixedTime,
+        }),
+      ).resolves.toEqual(['workflow-1', 'workflow-2']);
+      expect(finalizeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: 'failed',
+          workflowJobId: 'workflow-1',
+          lifecycleFault: expect.objectContaining({
+            kind: 'recovery_failed',
+            message: 'invocation context unavailable',
+          }),
+        }),
+      );
+      expect(getExecutionService).not.toHaveBeenCalled();
+      expect(releaseFailedWorkflowDescendants).toHaveBeenCalledWith('workflow-1');
+      expect(releaseFailedWorkflowDescendants).toHaveBeenCalledWith('workflow-2');
+    } finally {
+      harness.db.close();
+    }
+  });
+
+  it('releases real adopted child state and continues to a healthy workflow after recovery fails', async () => {
+    const backend = createSimulationBackend();
+    const failedWorkflowId = 'workflow-adopted-child';
+    const healthyWorkflowId = 'workflow-after-adopted-child';
+    const failedPlan = buildWorkflowPlan(failedWorkflowId, parseExpression('architect'), {
+      defaultProvider: 'codex',
+    });
+    const healthyPlan = buildWorkflowPlan(healthyWorkflowId, parseExpression('architect'), {
+      defaultProvider: 'codex',
+    });
+    const childJobId = failedPlan.slots[0].slotId;
+    const healthyChildJobId = healthyPlan.slots[0].slotId;
+    const sessionId = 'session-adopted-child';
+    const healthySessionId = 'session-healthy-child';
+    const providerScope = backend.createInvocationContext().providerScope;
+    if (providerScope === undefined) throw new Error('expected simulation provider scope');
+    expect(childJobId.startsWith(`${failedWorkflowId}:`)).toBe(true);
+
+    const appendWorkflowRoot = (workflowId: string, plan: WorkflowPlan): void => {
+      commitWorkflowEvents(
+        backend.progressStore.getDb(),
+        (c) => {
+          c.append(workflowPlanDeclaredEvent(workflowId, plan, providerScope));
+          return undefined;
+        },
+        backend.runtime.time,
+        permissiveProviderLookupPort,
+      );
+      backend.progressStore.appendLaunchRequested(workflowId, {
+        jobId: workflowId,
+        owner: { kind: 'workflow', id: workflowId },
+        sessionId: null,
+        provider: null,
+        projectRoot: backend.projectRoot,
+        backendNamespace: backend.namespace,
+        jobKind: 'workflow',
+        pool: 'default',
+        enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+        request: { prompt: '', cwd: backend.projectRoot, bypassPermissions: false, coralEnv: {} },
+        createdAt: '2026-04-27T00:00:00.000Z',
+      });
+      backend.progressStore.commit((c) => {
+        c.append({
+          type: 'job.runtime.started',
+          stream: { kind: 'job', id: workflowId },
+          namespace: backend.namespace,
+          project: backend.projectRoot,
+          refs: { jobId: workflowId, workflowId },
+          body: { transport: 'workflow', startedAt: '2026-04-27T00:00:00.000Z' },
+        });
+        return undefined;
+      });
+    };
+
+    appendWorkflowRoot(failedWorkflowId, failedPlan);
+    seedTestSessionProjection(backend.progressStore.getDb(), {
+      sessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      activeJobId: childJobId,
+    });
+    const sessionRow = backend.progressStore
+      .getDb()
+      .prepare<[string], { entry: string }>('SELECT entry FROM projection_sessions WHERE session_id = ?')
+      .get(sessionId);
+    if (sessionRow === undefined) throw new Error('expected adopted child session');
+    const sessionEntry = JSON.parse(sessionRow.entry) as ProviderSession;
+    sessionEntry.binding = {
+      provider: 'codex',
+      kind: 'profile',
+      binding: {
+        profile: { canonicalLocation: '/tmp/sim/accounts/codex', routing: { kind: 'home' } },
+        guarantee: 'profile-only',
+      },
+    };
+    backend.progressStore
+      .getDb()
+      .prepare('UPDATE projection_sessions SET entry = ? WHERE session_id = ?')
+      .run(JSON.stringify(sessionEntry), sessionId);
+
+    backend.runtime.spawner.enqueueDurable({ pid: 41_424, exit: null });
+    const durable = await backend.runtime.process.durable.launch({
+      provider: 'codex',
+      command: 'codex',
+      args: ['exec'],
+      jobDir: backend.progressStore.jobDir(childJobId),
+    });
+    const childLaunch: JobLaunch = {
+      jobId: childJobId,
+      owner: { kind: 'workflow', id: failedWorkflowId },
+      sessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      jobKind: 'provider',
+      pool: 'default',
+      enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+      providerAction: 'exec',
+      parentWorkflowJobId: failedWorkflowId,
+      workflowSlotId: childJobId,
+      workflowSlotGeneration: 0,
+      request: { prompt: '', cwd: backend.projectRoot, bypassPermissions: false, coralEnv: {} },
+      createdAt: '2026-04-27T00:00:00.000Z',
+    };
+    backend.progressStore.appendLaunchRequested(childJobId, childLaunch);
+    backend.progressStore.appendRuntimeStarted(childJobId, durable.runtimeRecord);
+
+    appendWorkflowRoot(healthyWorkflowId, healthyPlan);
+    seedTestSessionProjection(backend.progressStore.getDb(), {
+      sessionId: healthySessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      activeJobId: healthyChildJobId,
+    });
+    backend.progressStore.appendLaunchRequested(healthyChildJobId, {
+      ...childLaunch,
+      jobId: healthyChildJobId,
+      owner: { kind: 'workflow', id: healthyWorkflowId },
+      sessionId: healthySessionId,
+      parentWorkflowJobId: healthyWorkflowId,
+      workflowSlotId: healthyChildJobId,
+      enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+    });
+    commitJobTerminal(backend.progressStore, healthyChildJobId, healthySessionId, {
+      content: 'healthy recovery',
+      outcome: { kind: 'completed' },
+      durationMs: 0,
+    });
+    const log = vi.fn<(message: string) => void>();
+    const emitSessionReleased = vi.fn();
+    const restoreActiveLaunch = vi.spyOn(backend.launchCoordinator, 'restoreActiveLaunch');
+    const releaseLaunch = vi.spyOn(backend.launchCoordinator, 'releaseLaunch');
+    const kill = vi.spyOn(backend.runtime.process, 'kill');
+    const coordinatorCommit = (cb: Parameters<JobStore['commit']>[0]) => backend.progressStore.commit(cb);
+    const recoveryCoordinator = createRecoveryCoordinator({
+      progressStore: backend.progressStore,
+      runtime: backend.runtime,
+      runtimeState: { setLaunchFenceActive: vi.fn() },
+      eventBus: backend.eventBus,
+      getRecoveryService: () => backend.service,
+      createInvocationContext: backend.createInvocationContext,
+      log,
+    });
+
+    try {
+      await recoveryCoordinator.runStartupRecovery({
+        namespace: backend.namespace,
+        bundleHash: 'test-bundle',
+        runtime: backend.runtime,
+        progressStore: backend.progressStore,
+        getRecoveryService: () => backend.service,
+        createInvocationContext: backend.createInvocationContext,
+        signal: new AbortController().signal,
+        log,
+        cleanupStaleJobs: () => {},
+        sessionLookup: createProjectionSessionLookup(backend.progressStore.getDb()),
+        coordinatorCommit,
+      });
+      expect(restoreActiveLaunch).toHaveBeenCalledWith(childJobId, 'codex', childLaunch.owner, 'default');
+      expect(backend.launchCoordinator.getActiveJobIds()).toContain(childJobId);
+
+      const releaseFailedWorkflowDescendants = createFailedWorkflowDescendantReleaser({
+        progressStore: backend.progressStore,
+        runtime: backend.runtime,
+        coordinatorCommit,
+        getExecutionService: () => backend.service,
+        createInvocationContext: backend.createInvocationContext,
+        releaseAdoptedJob: recoveryCoordinator.releaseAdoptedJob,
+        emitSessionReleased,
+      });
+      let workflowServiceCalls = 0;
+
+      await expect(
+        resumeAll({
+          db: backend.progressStore.getDb(),
+          progressStore: backend.progressStore,
+          loadJobDetails: loadJobProjectionDetails,
+          getExecutionService: () => {
+            workflowServiceCalls += 1;
+            if (workflowServiceCalls === 1) {
+              throw new Error('workflow recovery failed after child adoption');
+            }
+            return backend.service as never;
+          },
+          createInvocationContext: backend.createInvocationContext,
+          finalizeWorkflow: createWorkflowRecoveryFinalizer({
+            runtime: backend.runtime,
+            progressStore: backend.progressStore,
+            coordinatorCommit,
+            log,
+          }),
+          releaseFailedWorkflowDescendants,
+          log,
+          time: backend.runtime.time,
+        }),
+      ).resolves.toEqual([failedWorkflowId, healthyWorkflowId]);
+
+      expect(backend.progressStore.readStatus(failedWorkflowId)?.phase).toBe('error');
+      expect(backend.progressStore.readStatus(healthyWorkflowId)?.phase).toBe('completed');
+      expect(kill).toHaveBeenCalledWith(durable.pid, 'SIGTERM');
+      expect(releaseLaunch).toHaveBeenCalledWith(childJobId, 'default');
+      expect(backend.launchCoordinator.getActiveJobIds()).not.toContain(childJobId);
+      expect(backend.service.abort([childJobId])).toEqual({ aborted: [], notFound: [childJobId] });
+      expect(
+        createProjectionSessionLookup(backend.progressStore.getDb()).readProviderSession(sessionId)?.activeJobId,
+      ).toBe(undefined);
+      expect(emitSessionReleased).toHaveBeenCalledWith({ sessionId, jobId: childJobId });
+      expect(log).toHaveBeenCalledWith(
+        `Workflow recovery child ${childJobId} session claim ${sessionId} disposition: released.\n`,
+      );
+      expect(releaseFailedWorkflowDescendants(failedWorkflowId)).toEqual([
+        { jobId: childJobId, sessionId, sessionClaimRelease: 'already_absent' },
+      ]);
+    } finally {
+      await recoveryCoordinator.teardown();
+      await backend.backend.shutdown('test cleanup');
+    }
+  });
+
+  it('returns after emitting an aborted finalization intent', async () => {
+    const harness = createHarness({
+      atomPhase: 'running',
+      projectionPhase: null,
+      atomTerminals: {
+        0: { content: '', outcome: { kind: 'aborted', reason: 'user_abort' }, durationMs: 0 },
+      },
+    });
+    const finalizeWorkflow = vi.fn<(intent: WorkflowFinalizationIntent) => void>();
+    const releaseFailedWorkflowDescendants = vi.fn(() => []);
+    const log = vi.fn<(message: string) => void>();
+
+    try {
+      await expect(
+        resumeAll({
+          db: harness.db,
+          progressStore: harness.progressStore,
+          loadJobDetails: loadJobProjectionDetails,
+          getExecutionService: () => harness.executionSvc,
+          createInvocationContext: harness.createInvocationContext,
+          finalizeWorkflow,
+          releaseFailedWorkflowDescendants,
+          log,
+          time: fixedTime,
+        }),
+      ).resolves.toEqual(['workflow-1']);
+      expect(finalizeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: 'aborted', workflowJobId: 'workflow-1' }),
+      );
+      expect(releaseFailedWorkflowDescendants).not.toHaveBeenCalled();
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('with aborted outcome'));
+      expect(log.mock.calls.flat().join('')).not.toContain('after recovery failed');
+    } finally {
+      harness.db.close();
+    }
+  });
+
+  it('contains a thrown workflow execution abort and emits an aborted finalization intent', async () => {
+    const harness = createHarness({ atomPhase: 'running', projectionPhase: 'running' });
+    const finalizeWorkflow = vi.fn<(intent: WorkflowFinalizationIntent) => void>();
+    const releaseFailedWorkflowDescendants = vi.fn(() => []);
+    const workflowAbort = createWorkflowExecutionError('workflow child aborted', true, []);
+
+    try {
+      await expect(
+        resumeAll({
+          db: harness.db,
+          progressStore: harness.progressStore,
+          loadJobDetails: loadJobProjectionDetails,
+          getExecutionService: () => {
+            throw workflowAbort;
+          },
+          createInvocationContext: harness.createInvocationContext,
+          finalizeWorkflow,
+          releaseFailedWorkflowDescendants,
+          time: fixedTime,
+        }),
+      ).resolves.toEqual(['workflow-1']);
+      expect(finalizeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: 'aborted', workflowJobId: 'workflow-1' }),
+      );
+    } finally {
+      harness.db.close();
+    }
+  });
+
+  it('propagates a failed workflow finalizer without releasing descendants', async () => {
+    const harness = createHarness({ atomPhase: 'running', projectionPhase: 'running' });
+    const finalizerError = new Error('workflow finalizer unavailable');
+    const finalizeWorkflow = vi.fn(() => {
+      throw finalizerError;
+    });
+    const releaseFailedWorkflowDescendants = vi.fn(() => []);
+
+    try {
+      await expect(
+        resumeAll({
+          db: harness.db,
+          progressStore: harness.progressStore,
+          loadJobDetails: loadJobProjectionDetails,
+          getExecutionService: () => {
+            throw new Error('workflow execution recovery failed');
+          },
+          createInvocationContext: harness.createInvocationContext,
+          finalizeWorkflow,
+          releaseFailedWorkflowDescendants,
+          time: fixedTime,
+        }),
+      ).rejects.toBe(finalizerError);
+      expect(finalizeWorkflow).toHaveBeenCalledOnce();
+      expect(releaseFailedWorkflowDescendants).not.toHaveBeenCalled();
+    } finally {
+      harness.db.close();
+    }
+  });
+
+  it('propagates coordinator cancellation without invoking the workflow finalizer', async () => {
+    const harness = createHarness({ atomPhase: 'running', projectionPhase: 'running' });
+    const finalizeWorkflow = vi.fn<(intent: WorkflowFinalizationIntent) => void>();
+    const releaseFailedWorkflowDescendants = vi.fn(() => []);
+    const cancellation = new AbortError({ stage: 'workflow recovery' });
+    harness.executionSvc.waitStream.mockReturnValue(failWait(cancellation));
+
+    try {
+      await expect(
+        resumeAll({
+          db: harness.db,
+          progressStore: harness.progressStore,
+          loadJobDetails: loadJobProjectionDetails,
+          getExecutionService: () => harness.executionSvc,
+          createInvocationContext: harness.createInvocationContext,
+          finalizeWorkflow,
+          releaseFailedWorkflowDescendants,
+          time: fixedTime,
+        }),
+      ).rejects.toBe(cancellation);
+      expect(finalizeWorkflow).not.toHaveBeenCalled();
+      expect(releaseFailedWorkflowDescendants).not.toHaveBeenCalled();
+    } finally {
+      harness.db.close();
+    }
+  });
 });
-import { seedTestSessionProjection } from '#tests/helpers/session.js';

--- a/tools/simulation/core/backend.ts
+++ b/tools/simulation/core/backend.ts
@@ -57,6 +57,7 @@ import { coordinatorPaths } from '../../../src/infra/path/coordinator.js';
 import * as discussRecovery from '../../../src/discuss/shell/recovery.js';
 import { ExecutionService } from '../../../src/coordinator/execution-service.js';
 import { createWorkflowRecoveryFinalizer } from '../../../src/coordinator/services/workflow-recovery-finalizer.js';
+import { createFailedWorkflowDescendantReleaser } from '../../../src/coordinator/services/workflow-recovery-descendants.js';
 import { jobsReconcile } from '../../../src/jobs/startup.js';
 import { openStoreDatabase } from '../../../src/store/db.js';
 import { createEventBodyCodec } from '../../../src/store/event-body-codec.js';
@@ -812,6 +813,15 @@ export function createSimulationBackend(scenario: SimulationScenario = {}): Simu
           progressStore,
           coordinatorCommit: (cb) => progressStore.commit(cb),
           log: identity.log,
+        }),
+        releaseFailedWorkflowDescendants: createFailedWorkflowDescendantReleaser({
+          progressStore,
+          runtime,
+          coordinatorCommit: (cb) => progressStore.commit(cb),
+          getExecutionService,
+          createInvocationContext,
+          releaseAdoptedJob: recoveryCoordinator.releaseAdoptedJob,
+          emitSessionReleased: (payload) => eventBus.emit('session:released', payload),
         }),
         time: runtime.time,
       });

--- a/tools/simulation/core/backend.ts
+++ b/tools/simulation/core/backend.ts
@@ -776,7 +776,7 @@ export function createSimulationBackend(scenario: SimulationScenario = {}): Simu
       cleanupStaleJobs,
       recoverPersistedDiscussFn,
     }) => {
-      await jobsReconcile.runStartup({
+      const recoveryProgressStore = await jobsReconcile.runStartup({
         recoveryCoordinator,
         namespace: identity.namespace,
         bundleHash: identity.bundleHash,
@@ -804,7 +804,7 @@ export function createSimulationBackend(scenario: SimulationScenario = {}): Simu
 
       await workflowRecover.resumeAll({
         db: storeDb,
-        progressStore,
+        progressStore: recoveryProgressStore,
         loadJobDetails: loadJobProjectionDetails,
         getExecutionService: (ctx) => getExecutionService(ctx) as never,
         createInvocationContext,
@@ -815,14 +815,16 @@ export function createSimulationBackend(scenario: SimulationScenario = {}): Simu
           log: identity.log,
         }),
         releaseFailedWorkflowDescendants: createFailedWorkflowDescendantReleaser({
-          progressStore,
+          progressStore: recoveryProgressStore,
           runtime,
           coordinatorCommit: (cb) => progressStore.commit(cb),
           getExecutionService,
           createInvocationContext,
           releaseAdoptedJob: recoveryCoordinator.releaseAdoptedJob,
           emitSessionReleased: (payload) => eventBus.emit('session:released', payload),
+          log: identity.log,
         }),
+        signal,
         time: runtime.time,
       });
       signal.throwIfAborted();


### PR DESCRIPTION
## The incident

A WSL reboot killed the coordinator mid-turn, leaving one codex app-server job `running`. Every boot afterwards died:

```
InterruptedRecoveryBlockedError: Interrupted app-server recovery remains incomplete for c2bb3f5e-…
Fatal startup error → state: stopped_with_diagnostic, retryable: false, exitCode: 1
```

Coral was down for **every project**, permanently, with no self-healing. `backend status` said "Backend not running" — true, but a fresh process was spawning and dying each time. There was no offline escape: this release exposes only `backend status`, `shutdown`, and `store-reset {list,report}`. Recovery required moving an 18.7 MB store aside by hand. It then happened a second time, to the agents dispatched to fix it.

## The invariant

**A failure that belongs to a single job or workflow is never a process verdict.**

The mechanism conflated the two, and its own log line gave it away: it printed `Recovery launch fence retained` and then re-threw, so the registry and the fence flag died with the process. The only thing that survived was a non-terminal row guaranteeing the identical failure next boot. It also contradicted the invariant documented where recovery is invoked (`src/coordinator/lifecycle.ts`): *"Per-job isolation: corrupt sessions should not abort recovery."*

Closing one throw site did not close the class. Review found four more. All five are closed here:

| Site | Was |
|---|---|
| Interrupted app-server finalization | Fatal, `retryable: false` — the reported outage |
| Durable finalization | Fatal |
| Register-stage exceptions | Fatal — a *thrown* authority/service/finalization error escaped the register loop, which runs outside adoption's per-job catch |
| Workflow `resumeAll` | Fatal — rethrew *after* terminalizing the workflow, so the throw accomplished nothing |
| Post-start durable finalization | Re-registered the dead job and **globally** reactivated the launch fence, refusing unrelated jobs in unrelated projects |

Each now records the reason with the existing `recovery_parse_failed` fault, releases the session claim, drops registry ownership, and continues. Only abort/cancellation and a genuinely failed terminalization still propagate.

## Why this is safe

- **The session stays resumable.** `releaseJob` clears only `activeJobId` and the claimed continuation lease; it never touches `conversationRef` or `providerContinuity`.
- **Refusing to boot never protected a live host.** A persisted `hostRef` carries no pid, socket, or port; `instanceId` is minted at spawn and lives only in the in-memory entry map, so a fresh coordinator *cannot* reach a prior process's host. The designed path is already `probe → stale → openReplacement`. The real double-drive guard is durable and independent: `claimForJobAtomic` refuses while `activeJobId` is set.
- **The claim is released in the same boot.** `planSessionClaimReleases` only clears it on the *next* boot, because it runs before adoption — so without this, the conversation that triggered the incident could not be resumed until a restart.

## Diagnosability

`serializeBootstrapError` now includes the `cause` chain, with a depth cap: the incident's `startup-diagnostic.json` recorded only the wrapper, leaving no way to learn why. The `recovery_parse_failed` describer no longer claims a parse happened — that string is what the operator reads, since `ensureResultArtifact` regenerates `result.md` from the cause chain. Claim release returns `released | already_absent | owned_by_another_job` and the log reports which, instead of asserting a release it had not verified. Log lines carry the disposition and the `jobs detail` next step.

## Review

Two rounds. Round 1 (5 Claude agents) rejected the first commit with 3 blocking; round 2 (8 Codex agents — 7 project agents plus architect/critic) rejected the remediation with 4 more blocking availability paths, and all seven role reviewers independently found that the kill escalation was correct but **entirely unverified** — the cited invariant only scans `safeKill` call sites, and the failed-stop test scheduled a real unref'd five-second timer that could reach the real `process.kill` after mock restoration. Both are fixed; per the test reviewer's prescription the invariant is left unwidened, with two pre-existing unescalated sites out of scope.

## Verification

`lint`, `tsc --noEmit`, `typecheck:tests`, `format:check`, `npm run build` (the only gate that enforces the simulation import seal), `npm test` (436 files / 4323 tests), `test:store-reset:integration`, `verify:store-reset-build`, `test:e2e:store-reset:build`, `test:e2e:lifecycle`, `test:integration` (272 passed / 1 skipped). CI green on Node 24 and 26.

`src/store/schema.sql` is byte-unchanged and no fault kind was added, so the store format fingerprint is unaffected — no user's store resets. No version bump, no `clients/bridge/` rebuild.

## Out of scope

The separately reviewed cross-version continuity plan owns the deeper semantics: a `resume` route so an interrupted app-server can continue instead of only finalize, tri-state carrier observation, and a continuity verdict when the host is unreachable. Also left alone: `coral-cli abort` reporting success without writing a terminal, `backend status` not distinguishing a crash-looping daemon from an absent one, and two pre-existing unescalated SIGTERM sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)