### PR TITLE
fix: restore Copilot agent exposure and resolve plan's review provider by identity

### DIFF
--- a/clients/.github/plugin/plugin.json
+++ b/clients/.github/plugin/plugin.json
@@ -20,6 +20,6 @@
   ],
   "category": "productivity",
   "skills": "./skills/",
-  "agents": [],
+  "agents": "./agents/",
   "hooks": "./hooks/copilot.json"
 }

--- a/clients/skills/plan/SKILL.md
+++ b/clients/skills/plan/SKILL.md
@@ -120,8 +120,6 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
     Complexity gate passed: {M} files, {localized fix summary} — skipping review.
     ```
 
-    A gate pass is a zero-result run: no review phase produced a resolver result, so the Review Summary reports `Final verdict: NOT REVIEWED`, omits "Key changes from review", and uses the gated handoff. No extra branch — the same rule that covers a skipped or failed phase.
-
     If ANY criterion fails → proceed to Review Phases.
 
     #### Review Phases

--- a/clients/skills/plan/SKILL.md
+++ b/clients/skills/plan/SKILL.md
@@ -13,12 +13,12 @@ Execute a multi-round planning session with architect/critic review.
 | Argument       | Mode                                                                                                                              |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `<prompt>`     | Self-execute on current host (default)                                                                                            |
-| `--delegate`   | Add review pass on the other host (Claude → Codex, Codex → Claude, Copilot → Codex; from SessionStart `Current host:`) |
+| `--delegate`   | Add a review pass on `<other-host>` (see Review Phases for the mapping). On a host that is not itself a provider it **replaces** Phase 2 rather than adding to it, so the net is still one review phase. |
 | `round=N`      | Review rounds for every applicable phase (default `1`). e.g. `round=3` for deeper iteration.                                      |
-| `round=N,M`    | Per-phase budget: Phase 1 (`<other-host>`) gets `N` rounds, Phase 2 (`<current-host>`) gets `M`. **Turns `--delegate` on.**       |
+| `round=N,M`    | Per-phase budget: Phase 1 (`<other-host>`) gets `N` rounds, Phase 2 gets `M`. **Turns `--delegate` on.**                          |
 | `--no-handoff` | Internal: skip implementation prompt at step 5 (caller controls next step)                                                        |
 
-Reviewers and the resolver always run — the round budget only sets how many times each phase iterates.
+Reviewers and the resolver always run in every review phase that dispatches — the round budget only sets how many times each phase iterates.
 
 **Parsing the round budget** (`round=…` and `--round=…` are the same token):
 
@@ -80,14 +80,14 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
     ### 4. Review Loop
 
     Phase 0 always runs first. Phase 0b (Complexity Gate) may skip review phases.
-    Phase 1 runs only when `--delegate` is set — explicitly, or implied by a two-value `round=N,M` (review on the other host). Phase 2 always runs (unless skipped by Complexity Gate; review on the current host).
+    Phase 1 runs only when `--delegate` is set — explicitly, or implied by a two-value `round=N,M` (review on `<other-host>`). Phase 2 runs when the current host is itself a registered provider, or when Phase 1 did not already resolve to `<phase-2-provider>`; it is skipped by the Complexity Gate, and skipped when it would repeat Phase 1's provider or re-attempt a provider Phase 1's dispatch already failed on.
 
     **Round budget**: `{maxRounds[P]}` is phase P's own budget. `round=N` gives every phase `N`; `round=N,M` gives Phase 1 `N` and Phase 2 `M`; absent gives every phase `1`. Each phase iterates up to its own budget and then exits — a phase at budget `1` runs exactly one round with no iteration. Phase structure is independent of the budget: Phase 1 (if `--delegate`) and Phase 2 still run whatever the numbers are.
 
     **Task registration**: Before starting Phase 0, register one Task per applicable phase:
     - `TaskCreate({ subject: "Phase 0 — Frame Gate" })`
     - `TaskCreate({ subject: "Phase 1 — <other-host> review" })` (only if `--delegate`, explicit or implied)
-    - `TaskCreate({ subject: "Phase 2 — <current-host> review" })`
+    - `TaskCreate({ subject: "Phase 2 — <phase-2-provider> review" })` (omit when Phase 2 is excluded because Phase 1 resolves to the same provider)
     - `TaskCreate({ subject: "Execution Ordering" })`
 
     On phase start: `TaskUpdate({ taskId, status: "in_progress" })`.
@@ -120,16 +120,34 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
     Complexity gate passed: {M} files, {localized fix summary} — skipping review.
     ```
 
+    A gate pass is a zero-result run: no review phase produced a resolver result, so the Review Summary reports `Final verdict: NOT REVIEWED`, omits "Key changes from review", and uses the gated handoff. No extra branch — the same rule that covers a skipped or failed phase.
+
     If ANY criterion fails → proceed to Review Phases.
 
     #### Review Phases
 
-    Let `<current-host>` come from SessionStart `Current host:`. Let `<other-host>` = the other of `codex`/`claude` — and `codex` when `<current-host>` is `copilot`, which is a plugin host but not a delegation target.
+    Let `<other-host>` be the registered provider that is not the current host (Claude → Codex, Codex → Claude, Copilot → Codex). Let `<phase-2-provider>` be the current host when it is itself a registered Coral provider (`codex`, `claude`), and `<other-host>` otherwise — Copilot is a plugin host but not a provider, so on Copilot Phase 2 resolves to `<other-host>`.
 
     | Phase | Condition | Provider | Round Label | Budget |
     |-------|-----------|----------|-------------|--------|
     | 1 | `--delegate`, explicit or implied by `round=N,M` | `<other-host>` | `(<other-host capitalized>)` | `{maxRounds[1]}` |
-    | 2 | always | `<current-host>` | `(<current-host capitalized>)` | `{maxRounds[2]}` |
+    | 2 | the current host is itself a registered provider, **or** `<phase-2-provider>` is one Phase 1 did not already resolve to | `<phase-2-provider>` | `(<phase-2-provider capitalized>)` | `{maxRounds[2]}` |
+
+    `<phase-2-provider>` is not a second delegation concept — it is a label for whichever provider Phase 2 resolved to, so the Round Label, the Task subject, and the Review Summary can name it without repeating the resolution rule at each site.
+
+    **What "a phase ran" means.** Every phase ends in exactly one of three states, and the whole protocol — this condition, the verdict, and the coverage line — reads that state:
+
+    - **not attempted** — its condition was false, so no dispatch was made;
+    - **attempted and failed** — it dispatched and no round produced a resolver result;
+    - **produced a result** — at least one round completed and the resolver returned a synthesis. A phase that completed round 1 and failed in round 2 **produced a result**.
+
+    **Phase 2's condition.** `<phase-2-provider>` resolves to the current host when that host is itself a registered provider, and to `<other-host>` otherwise — this resolution always succeeds, so Phase 2 is never skipped for want of a provider. Then:
+
+    - Phase 1 **produced a result** on `<phase-2-provider>` → Phase 2 does not run. Two phases on the same provider are one review reported as two. Record the reason "`<other-host>` already used by Phase 1".
+    - Phase 1 **attempted and failed** on `<phase-2-provider>` → Phase 2 does not run, and does not dispatch. Record the reason "`<other-host>` dispatch already failed in Phase 1: {observed error}". Re-dispatching would repeat a binding failure that is deterministic within one run — the same reason the retry is skipped in `<Error_Handling>`.
+    - Otherwise Phase 2 dispatches. If its dispatch does not survive the one retry, it takes the skip path: record the observed error and report it in the Review Summary rather than failing.
+
+    On Claude and Codex the current host is itself a provider, so `<phase-2-provider>` is always that host, only the last branch is ever reached, and behaviour is exactly as today.
 
     Run the phases in order. For each applicable phase, repeat up to that phase's own `{maxRounds[P]}` rounds (default 1):
 
@@ -143,6 +161,8 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
     ```
     Reviewers always run in `--deep` methodology and the resolver always runs — both are independent of the round budget.
     Run `coral-cli wait jobs <job>` and classify the result from its rendered output, not exit code `75` alone. `Result path: <path>` marks a terminal result; read that artifact for the full workflow result and locate the resolver's synthesis section there, even when a terminal `provider_exit` propagated code `75`. A status beginning `Still waiting` with `(cursor: <cursor>)` means the workflow is still live; only then resume with `coral-cli wait jobs <job> --cursor <cursor>`. If a transient error instead prints `remediation:`, follow that exact command. A non-zero `provider_exit` code is terminal and is passed through unchanged (0–255).
+
+    A phase that never dispatched — excluded, skipped, or its launch failed on round 1 — has no workflow result and does not enter 4b–4d: record its coverage note and continue to the next phase, or to 4e (Execution Order) if it was the last.
 
     **4b. Post-Round Processing**
 
@@ -240,7 +260,7 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
   <Error_Handling>
     | Scenario | Action |
     |----------|--------|
-    | Workflow job fails | Retry once. If still fails and more phases remain, skip to next phase. Otherwise AskUserQuestion. |
+    | Workflow launch or job fails | Retry once — skip the retry when the launch failed on provider binding, which is deterministic and will fail identically. If it still fails, the phase takes the skip path whichever phase it is: record its outcome as **attempted and failed**, report it as a coverage note quoting the observed error, and continue to the next phase — or to 4e when none remains. Never `AskUserQuestion`, and never fail the run. |
     | Resolver fails | Retry once. If still fails, AskUserQuestion. |
   </Error_Handling>
   <Constraints>
@@ -259,10 +279,18 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
     **Plan file**: `CORAL_PROJECT/plans/{topic}.md`
 
     ### Review Summary
-    - Phases: [0 (Frame Gate) + 1 (<other-host>) + 2 (<current-host>)] or [0 (Frame Gate) + 2 (<current-host>)]
-    - Rounds: rounds actually run / budget, per phase — e.g. `Phase 1: 2/3, Phase 2: 1/1`
-    - Final verdict: [APPROVED / APPROVED WITH CONDITIONS]
-    - Key changes from review: [brief list]
+    - Phases: list only the phases that produced a result — `0 (Frame Gate) + 1 (<other-host>) + 2 (<phase-2-provider>)`, `0 (Frame Gate) + 2 (<phase-2-provider>)`, `0 (Frame Gate) + 1 (<other-host>)`, or `0 (Frame Gate)` alone.
+    - Rounds: rounds **actually completed** / budget, per phase — e.g. `Phase 1: 2/3, Phase 2: 1/1`. A phase that never dispatched reports `0/{maxRounds[P]}`; a phase that failed partway reports the rounds it completed, never `0`.
+    - ⚠️ One line per phase that did not run, or that ran fewer rounds than its budget — **Phase {P} {skipped | ended early}**: {reason}.
+      - Phase 1, skipped — `<other-host>` dispatch failed: "{observed error}"
+      - Phase 2, skipped — `<other-host>` already used by Phase 1 | `<other-host>` dispatch already failed in Phase 1: "{observed error}" | `<phase-2-provider>` dispatch failed: "{observed error}"
+      - Either phase, ended early — dispatch failed in round {M} of {maxRounds[P]}: "{observed error}"; this phase's verdict is its round {M−1} verdict.
+
+      Add "The plan is unreviewed." only when no review phase produced a result. Append "Install and authenticate a provider CLI (`coral-cli codex` / `coral-cli claude`, or `/coral:equip`) and re-run for a second perspective." **only** to a reason whose text is a dispatch failure — never to "already used by Phase 1", which no install changes.
+    - Final verdict: [APPROVED / APPROVED WITH CONDITIONS / NOT REVIEWED]
+      - `NOT REVIEWED` when NO review phase produced a resolver result — the Complexity Gate skipped review, or neither Phase 1 nor Phase 2 produced one (each was not attempted, or attempted and failed).
+      - Otherwise the verdict of the last phase that produced a result, unaffected by a skip elsewhere.
+    - Key changes from review: [brief list]  ← omit entirely when the verdict is NOT REVIEWED
     - ⚠️ **Unsatisfied Success Criteria**: [list with reasons] *(omit if all satisfied)*
 
     ### Final Plan
@@ -272,9 +300,13 @@ Do NOT use EnterPlanMode — it writes to `~/.claude/plans/` which is not projec
 
     ### Implementation Handoff
 
-    **If `--no-handoff`**: stop after showing the summary above. The caller controls the next step.
+    **If `--no-handoff`**: stop after showing the summary above. The caller controls the next step. The caller inherits the verdict and must not present the plan as reviewed when it is `NOT REVIEWED`.
 
     **Otherwise**, ask the user how to implement:
+
+    When the verdict is `NOT REVIEWED`, replace the first question's `question:` value with
+    "This plan was not reviewed — no review phase produced a result. How would you like to implement?".
+    Leave the options unchanged.
     ```
     AskUserQuestion({ questions: [
       { question: "How would you like to implement?", header: "Mode",

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -33,7 +33,7 @@ Codex delegation is a normal CLI-to-backend provider launch.
 | `persona-generator` | `clients/agents/persona-generator.md` | Discuss persona generation                              |
 | `workflow-literal`  | `clients/agents/workflow-literal.md`  | Pipeline step processor for workflow DSL inline prompts |
 
-These agents use Claude Code's native tools. Read-only agents declare `disallowedTools`; execution-oriented agents do not. **The declaration is not enforced by the host.** On Copilot it is ignored outright — a `coral:critic` subagent created a file. The same hole exists on Claude Code (verified on v2.1.224): an agent granted `Bash` writes via shell redirection despite `Write`/`Edit` exclusion, and removing `Bash` from the grant is what blocks it. Treat `disallowedTools` as declared intent, not a sandbox.
+These agents use Claude Code's native tools. Read-only agents declare `disallowedTools`; execution-oriented agents do not. **Copilot does not enforce that declaration** — a `coral:critic` subagent created a file — so on Copilot it is declared intent, not a sandbox.
 
 When spawned via Claude's `Agent` tool inside a host session, they receive the subagent-scoped inject bundle through the `SubagentStart` hook (`asOwner: false` — orchestrator fragment omitted). Copilot fires no `SubagentStart`, so subagents there run without the bundle — see [Hooks — Copilot CLI contract deltas](./hooks.md#copilot-cli-contract-deltas). When launched as provider jobs (`coral-cli … <agent>` or workflow), they receive the provider-scoped bundle via `applyInjectBundle` (no hooks). See [Hooks — Inject bundle](./hooks.md#inject-bundle-shared-guidelines).
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -33,9 +33,9 @@ Codex delegation is a normal CLI-to-backend provider launch.
 | `persona-generator` | `clients/agents/persona-generator.md` | Discuss persona generation                              |
 | `workflow-literal`  | `clients/agents/workflow-literal.md`  | Pipeline step processor for workflow DSL inline prompts |
 
-These agents use Claude Code's native tools. Read-only agents declare `disallowedTools`; execution-oriented agents do not.
+These agents use Claude Code's native tools. Read-only agents declare `disallowedTools`; execution-oriented agents do not. **The declaration is not enforced by the host.** On Copilot it is ignored outright — a `coral:critic` subagent created a file. The same hole exists on Claude Code (verified on v2.1.224): an agent granted `Bash` writes via shell redirection despite `Write`/`Edit` exclusion, and removing `Bash` from the grant is what blocks it. Treat `disallowedTools` as declared intent, not a sandbox.
 
-When spawned via Claude's `Agent` tool inside a host session, they receive the subagent-scoped inject bundle through the `SubagentStart` hook (`asOwner: false` — orchestrator fragment omitted). When launched as provider jobs (`coral-cli … <agent>` or workflow), they receive the provider-scoped bundle via `applyInjectBundle` (no hooks). See [Hooks — Inject bundle](./hooks.md#inject-bundle-shared-guidelines).
+When spawned via Claude's `Agent` tool inside a host session, they receive the subagent-scoped inject bundle through the `SubagentStart` hook (`asOwner: false` — orchestrator fragment omitted). Copilot fires no `SubagentStart`, so subagents there run without the bundle — see [Hooks — Copilot CLI contract deltas](./hooks.md#copilot-cli-contract-deltas). When launched as provider jobs (`coral-cli … <agent>` or workflow), they receive the provider-scoped bundle via `applyInjectBundle` (no hooks). See [Hooks — Inject bundle](./hooks.md#inject-bundle-shared-guidelines).
 
 Agent bodies may say `read CORAL_METHODS/HOW-….md`. That alias resolves from inject path aliases (`{{CORAL_METHODS}}`); agents do not hardcode marketplace install paths.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -24,7 +24,7 @@ All hook scripts are Node.js ESM files that read JSON from stdin, write JSON to 
 
 ## Copilot CLI contract deltas
 
-Copilot reuses Claude Code's hook vocabulary, but five details differ. All were verified against Copilot CLI 1.0.78.
+Copilot reuses Claude Code's hook vocabulary, but seven details differ. All were verified against Copilot CLI 1.0.78.
 
 **Manifest precedence.** Copilot resolves `.github/plugin/plugin.json` before `.claude-plugin/plugin.json` (and never reads `.codex-plugin/`). That is the only reason Copilot loads `copilot.json` rather than Claude's `claude.json` — deleting `clients/.github/plugin/` would silently hand Copilot the Claude registration.
 
@@ -35,6 +35,10 @@ Copilot reuses Claude Code's hook vocabulary, but five details differ. All were 
 **Matchers and tool names.** Under PascalCase events Copilot maps its native tool names onto Claude's where an equivalent exists (`bash` → `Bash`, `view` → `Read`), but `skill` has no alias and stays lowercase — hence `PreToolUse` matches `skill`, not `Skill`. `Monitor` is Claude-only and is omitted. `SessionStart` matchers are *not* filtered (a `compact` matcher fires on every session start), so `copilot.json` keeps one unmatched `SessionStart` group containing only `session-start.mjs`.
 
 **Skill field values.** `tool_input.skill` carries the *bare* skill name under Copilot (`ralph`), not `coral:ralph`; Copilot namespaces it only when two installed plugins ship the same skill name. `isCoralSkillField()` / `isKbSkillField()` accept the bare form **only** when the host is Copilot — on Claude and Codex a bare `plan` is a user's own skill of that name, and matching it would fire Coral's hooks for a skill Coral does not own.
+
+**Agents.** Copilot discovers a plugin's `agents/` directory even when the manifest omits the key, and exposes each as `coral:<name>` — the same identifier the skills spawn — so `agents` is declared rather than suppressed in `clients/.github/plugin/plugin.json`. Backend-only agents (`workflow-literal`, `persona-generator`) become visible as a side effect; both are harmless to spawn. **Caveat**: because Copilot fires no `SubagentStart` (see "Compact recovery and subagent inject are Claude/Codex-only" below), a `coral:*` subagent on Copilot runs **without** Coral's inject bundle, so neither `CORAL_METHODS` (`clients/hooks/coral-skill-vars.mjs`, `clients/hooks/lib/inject-render.mjs`) nor `CORAL_PROJECT` resolves inside it. Every agent that reads its methodology from `CORAL_METHODS/` — `architect`, `critic`, `debugger`, `gap-finder`, `scanner`, `resolver` — is therefore spawnable but methodology-degraded there. Declaring `agents` restores *spawn-ability*, not full parity. The `coral-cli` job path is unaffected: `src/providers/inject.ts` substitutes the same aliases for provider-run agents.
+
+**Model tier is ignored.** Copilot does not honour the abstract `model:` tier in agent frontmatter and silently falls back to the session model, with no error. All 10 files in `clients/agents/` declare a tier, so the declaration is ignored in every case; the observable delta is on the **7** that declare `opus` (`architect`, `critic`, `debugger`, `gap-finder`, `pioneer`, `resolver`, `scanner`), which do not get the opus-tier model a Claude Code user gets. The other three declare `sonnet`, near enough a typical session model that there is nothing to observe.
 
 Host detection lives in `hostKind()` and keys on `COPILOT_PLUGIN_ROOT`, not `COPILOT_CLI`: Copilot exports `COPILOT_CLI` into *every* shell it spawns, so it leaks into unrelated child processes, while `COPILOT_PLUGIN_ROOT` is set only for plugin hook invocations.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -24,7 +24,7 @@ All hook scripts are Node.js ESM files that read JSON from stdin, write JSON to 
 
 ## Copilot CLI contract deltas
 
-Copilot reuses Claude Code's hook vocabulary, but seven details differ. All were verified against Copilot CLI 1.0.78.
+Copilot reuses Claude Code's hook vocabulary, but six details differ. All were verified against Copilot CLI 1.0.78.
 
 **Manifest precedence.** Copilot resolves `.github/plugin/plugin.json` before `.claude-plugin/plugin.json` (and never reads `.codex-plugin/`). That is the only reason Copilot loads `copilot.json` rather than Claude's `claude.json` — deleting `clients/.github/plugin/` would silently hand Copilot the Claude registration.
 
@@ -37,8 +37,6 @@ Copilot reuses Claude Code's hook vocabulary, but seven details differ. All were
 **Skill field values.** `tool_input.skill` carries the *bare* skill name under Copilot (`ralph`), not `coral:ralph`; Copilot namespaces it only when two installed plugins ship the same skill name. `isCoralSkillField()` / `isKbSkillField()` accept the bare form **only** when the host is Copilot — on Claude and Codex a bare `plan` is a user's own skill of that name, and matching it would fire Coral's hooks for a skill Coral does not own.
 
 **Agents.** Copilot discovers a plugin's `agents/` directory even when the manifest omits the key, and exposes each as `coral:<name>` — the same identifier the skills spawn — so `agents` is declared rather than suppressed in `clients/.github/plugin/plugin.json`. Backend-only agents (`workflow-literal`, `persona-generator`) become visible as a side effect; both are harmless to spawn. **Caveat**: because Copilot fires no `SubagentStart` (see "Compact recovery and subagent inject are Claude/Codex-only" below), a `coral:*` subagent on Copilot runs **without** Coral's inject bundle, so neither `CORAL_METHODS` (`clients/hooks/coral-skill-vars.mjs`, `clients/hooks/lib/inject-render.mjs`) nor `CORAL_PROJECT` resolves inside it. Every agent that reads its methodology from `CORAL_METHODS/` — `architect`, `critic`, `debugger`, `gap-finder`, `scanner`, `resolver` — is therefore spawnable but methodology-degraded there. Declaring `agents` restores *spawn-ability*, not full parity. The `coral-cli` job path is unaffected: `src/providers/inject.ts` substitutes the same aliases for provider-run agents.
-
-**Model tier is ignored.** Copilot does not honour the abstract `model:` tier in agent frontmatter and silently falls back to the session model, with no error. All 10 files in `clients/agents/` declare a tier, so the declaration is ignored in every case; the observable delta is on the **7** that declare `opus` (`architect`, `critic`, `debugger`, `gap-finder`, `pioneer`, `resolver`, `scanner`), which do not get the opus-tier model a Claude Code user gets. The other three declare `sonnet`, near enough a typical session model that there is nothing to observe.
 
 Host detection lives in `hostKind()` and keys on `COPILOT_PLUGIN_ROOT`, not `COPILOT_CLI`: Copilot exports `COPILOT_CLI` into *every* shell it spawns, so it leaks into unrelated child processes, while `COPILOT_PLUGIN_ROOT` is set only for plugin hook invocations.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -24,7 +24,7 @@ Resolved absolute paths are injected through `inject/tools.md` (`{{CORAL_METHODS
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/coral:analyze`       | Deep analysis and investigation; `--delegate` runs on the other host                                                                                    |
 | `/coral:preplan`       | Structured problem-definition conversation before planning                                                                                              |
-| `/coral:plan`          | Planning with architect/critic review; `round=N` sets the review-round budget for every phase (default 1); `round=N,M` sets Phase 1 and Phase 2 separately and turns `--delegate` on; `--delegate` adds a review phase on the other host |
+| `/coral:plan`          | Planning with architect/critic review; `round=N` sets the review-round budget for every phase (default 1); `round=N,M` sets Phase 1 and Phase 2 separately and turns `--delegate` on; `--delegate` adds a review phase on the other host, and Phase 2 is skipped when it would repeat it |
 | `/coral:ralph`         | Persistent execution loop with verification; supports `--delegate`, `--team`, and `--red`                                                               |
 | `/coral:code-simplify` | Code simplification and cleanup                                                                                                                         |
 | `/coral:bugfix`        | Diagnosis, planning, and fix execution                                                                                                                  |

--- a/tests/invariants/coral-agent-exposure.test.ts
+++ b/tests/invariants/coral-agent-exposure.test.ts
@@ -62,19 +62,13 @@ describe('coral agent exposure', () => {
   it('every coral:<agent> a skill spawns has an agent file', () => {
     // Assertion 1 alone would pass a skill spawning an agent that does not exist —
     // the same invisible failure, reached from the other side.
-    const missing = [...referencedAgents().entries()]
+    const referenced = referencedAgents();
+    expect(referenced.size).toBeGreaterThan(0); // a rule matching nothing would pass vacuously
+
+    const missing = [...referenced.entries()]
       .filter(([name]) => !existsSync(join(AGENTS_DIR, `${name}.md`)))
       .map(([name, skills]) => `${name} (referenced by ${skills.join(', ')})`);
 
     expect(missing).toEqual([]);
-  });
-
-  it('resolves a representative set, so the extraction rule cannot silently match nothing', () => {
-    // Guards the regex itself: a rule that matched zero tokens would make the
-    // assertion above vacuously true.
-    const referenced = referencedAgents();
-    expect([...referenced.keys()].sort()).toEqual(
-      expect.arrayContaining(['architect', 'critic', 'debugger', 'pioneer', 'resolver', 'scanner']),
-    );
   });
 });

--- a/tests/invariants/coral-agent-exposure.test.ts
+++ b/tests/invariants/coral-agent-exposure.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error — hook libs are plain Node ESM (.mjs) with no type surface.
+import { ALL_SHIPPED_SKILLS } from '../../clients/hooks/lib/coral-skills.mjs';
+
+const CLIENT_MANIFESTS = [
+  'clients/.claude-plugin/plugin.json',
+  'clients/.codex-plugin/plugin.json',
+  'clients/.github/plugin/plugin.json',
+] as const;
+
+const SKILLS_DIR = join(process.cwd(), 'clients', 'skills');
+const AGENTS_DIR = join(process.cwd(), 'clients', 'agents');
+
+function skillBodies(): Array<{ skill: string; text: string }> {
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({ skill: entry.name, path: join(SKILLS_DIR, entry.name, 'SKILL.md') }))
+    .filter(({ path }) => existsSync(path))
+    .map(({ skill, path }) => ({ skill, text: readFileSync(path, 'utf-8') }));
+}
+
+/**
+ * `coral:<name>` references that must resolve to an agent file.
+ *
+ * The `[a-z]` anchor drops the literal placeholder `coral:<agent>`, and skills are
+ * subtracted because `Skill({ skill: "coral:ralph" })` names a skill, not an agent.
+ * The whole file is scanned rather than only `Agent(`/`subagent_type:` sites so that
+ * workflow expressions like `"(coral:architect, coral:critic) -> coral:resolver"` —
+ * the reference class this invariant most needs to cover — are included.
+ */
+function referencedAgents(): Map<string, string[]> {
+  const shipped = new Set<string>(ALL_SHIPPED_SKILLS as string[]);
+  const byAgent = new Map<string, string[]>();
+  for (const { skill, text } of skillBodies()) {
+    for (const [, name] of text.matchAll(/coral:([a-z][a-z-]*)/gu)) {
+      if (shipped.has(name)) continue;
+      byAgent.set(name, [...(byAgent.get(name) ?? []), skill]);
+    }
+  }
+  return byAgent;
+}
+
+describe('coral agent exposure', () => {
+  it.each(CLIENT_MANIFESTS)('%s exposes the agent directory to its client', (manifestPath) => {
+    // A client that declares an empty `agents` suppresses discovery, and every skill
+    // whose default path spawns `coral:<name>` silently loses it — the spawn fails
+    // inside a subagent with nothing surfacing to the session. Shipped once already
+    // (`"agents": []` on the Copilot manifest), so it is asserted rather than trusted.
+    // Two forms are accepted: the explicit directory, or the key absent, which is the
+    // discovery default both sibling manifests rely on today.
+    const manifest = JSON.parse(readFileSync(join(process.cwd(), manifestPath), 'utf-8')) as {
+      agents?: unknown;
+    };
+    if (manifest.agents === undefined) return;
+    expect(manifest.agents).toBe('./agents/');
+  });
+
+  it('every coral:<agent> a skill spawns has an agent file', () => {
+    // Assertion 1 alone would pass a skill spawning an agent that does not exist —
+    // the same invisible failure, reached from the other side.
+    const missing = [...referencedAgents().entries()]
+      .filter(([name]) => !existsSync(join(AGENTS_DIR, `${name}.md`)))
+      .map(([name, skills]) => `${name} (referenced by ${skills.join(', ')})`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('resolves a representative set, so the extraction rule cannot silently match nothing', () => {
+    // Guards the regex itself: a rule that matched zero tokens would make the
+    // assertion above vacuously true.
+    const referenced = referencedAgents();
+    expect([...referenced.keys()].sort()).toEqual(
+      expect.arrayContaining(['architect', 'critic', 'debugger', 'pioneer', 'resolver', 'scanner']),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #294.

Two defects from #292, plus the vocabulary problem underneath the second one. Three commits, each reviewable on its own — the diff is one manifest line, a `plan/SKILL.md` restructure, and docs.

**Please read [the decision comment on #294](https://github.com/kangig94/coral/issues/294#issuecomment-5234893059) first** if you want the reasoning; this is the summary.

## What was broken

**`"agents": []` hid every `coral:*` agent on Copilot.** It was meant to stop Copilot auto-discovering `clients/agents/` (it discovers the directory even when the key is absent), on the belief that Coral's internal protocol files would surface in the agent picker. Wrong belief: Copilot namespaces plugin agents under the plugin name, so they appear as exactly the identifiers the skills already spawn. Six skills — `analyze`, `bugfix`, `init-project`, `pathfind`, `preplan`, `ralph` — reach for `Agent({ subagent_type: "coral:<name>" })` as their **default** path, before `--delegate` is considered. That path was dead, and it hurts most on Copilot, where `--delegate` needs an external CLI.

**`/coral:plan` failed outright.** Phase 2 declared its provider as `<current-host>`, which became `copilot` and reached `coral-cli workflow -p`:

```
Provider 'copilot' is not registered. Choose one of: claude, codex.
  [code=provider_binding_unsupported_selection]
```

Phase 2's condition was `always`, so plain `/coral:plan` hit it too.

## The root cause was vocabulary

Coral's **providers** (`codex`, `claude`) and its **hosts** (`claude`, `codex`, `copilot`) are different sets, but the skills used `<current-host>`/`<other-host>` in provider positions — `coral-cli <other-host> …` is a provider invocation. A host that is not a provider therefore produced a runtime error instead of a defined outcome.

- **`<other-host>`** — kept as-is. It was never the defect: on all three hosts it resolves to a registered provider, so it never failed.
- **`<phase-2-provider>`** — the one new term, local to `plan/SKILL.md`: the current host when that host is itself a registered provider, and `<other-host>` otherwise.

Phase 2 resolves `<phase-2-provider>`, which is the current host when that host is a provider and `<other-host>` otherwise. No host name appears in any condition: Copilot's behaviour falls out of the current host not being a provider. **When a `copilot` provider is registered later, Phase 2 starts working with zero skill edits** — which is the point of doing it this way rather than adding a host guard.

**One new term.** The defect was `<current-host>` — it resolves to `copilot`, not a provider, in a position that requires one. `<other-host>` was always correct on all three hosts, so it is untouched here and in every other skill. The only addition is `<phase-2-provider>` (14 sites, all in `plan/SKILL.md`); the repo keeps one name for the delegation target, `<other-host>`, at 32 sites.

## ⚠️ One change is cross-host

The verdict model is **not** Copilot-scoped, and it is the part Claude and Codex users will see.

`plan` printed `Final verdict: APPROVED` plus "Key changes from review" unconditionally — including on the Complexity-Gate path, where no reviewer ran and the only thing that executed was the orchestrator grading its own plan (the confirmation bias `.claude/rules/agents.md` names as an anti-pattern). Printing `APPROVED` one bullet below a warning that the plan is unreviewed is worse than failing.

The verdict is now keyed to whether **any** phase produced a resolver result:

- zero results → `NOT REVIEWED`, "Key changes" omitted, handoff says so before offering `coral:ralph`
- one or more → that verdict stands, unaffected by a skip elsewhere

Keying on *results* rather than on the skip is what keeps the two failure directions apart: a run with no review must not read `APPROVED`, and a run Phase 1 reviewed must not read `NOT REVIEWED`.

Provider **resolution** on Claude/Codex is unchanged — `<phase-2-provider>` is always the host itself, and only the last branch of Phase 2's condition is ever reached.

## Three findings that shaped the fix

**Availability is observed, not probed.** Nothing reports whether a provider CLI is installed: `src/cli/program.ts` registers no `list`/`status`/`doctor`, and `src/providers/contracts/binding.ts` enumerates every binding failure reason with no "not installed" among them. An absent binary fails in `captureScope` at `src/cli/dispatch.ts:415` — **before a job exists** — which is why the skip could not hang off the existing "Workflow job fails" row. That row now covers launch failures, skips its retry when the failure was provider binding (deterministic within a run), and reports instead of blocking on `AskUserQuestion` — which fired on exactly the shape this PR exists to fix.

**Phase 1 and Phase 2 collided on Copilot.** With `--delegate` (or `round=N,M`, which implies it) both resolved to codex: same reviewers, same plan, same model, both budgets spent, and a summary reading `1 (Codex) + 2 (Codex)` as though two perspectives had been obtained. Phase 2 is now excluded when it would repeat Phase 1's provider, reported as a coverage note.

**"Did the phase run" was undefined** for a phase that ran and produced nothing — one input admitted three different outcomes. Phases now end in one of three states (not attempted / attempted and failed / produced a result), and the condition, verdict and coverage line all read that state.

## Verification

| | |
|---|---|
| **Agent exposure** | Verified by **execution**, not self-report — a Copilot transcript carries `"agent_type":"coral:debugger"`, so `/coral:bugfix`'s diagnose step ran with no `--delegate` and no external CLI |
| **Known degradation** | Same transcript: `SubagentStart` appears **0 times**. Copilot subagents get no inject bundle, so `CORAL_METHODS`/`CORAL_PROJECT` do not resolve inside them; the methodology loaded only because the orchestrator substituted the literal path. Declaring `agents` restores **spawn-ability, not parity** — documented rather than claimed away |
| **Zero regressions** | Failing test **ID set** compared against `origin/main` in a clean worktree: 29 → 29, **0 new, 0 fixed**. Compared as a set, not a count, so one fix cancelling one regression cannot hide. (All 29 are pre-existing; they are spread across `recovery/source-revisions`, `hooks`, `sessions` — not confined to one suite) |
| **The new invariant actually works** | Mutation-checked both ways: reverting `agents` to `[]` fails assertion 1; adding a reference to a nonexistent agent fails assertion 2 |

Lint, typecheck and build are clean. Per `CONTRIBUTING.md` this carries **source only** — no version bump, no `clients/bridge/` rebuild.

## Process

Ran `/coral:preplan` then `/coral:plan round=3` (the skill this PR fixes — Phase 2 was routed manually to `claude`, which is the fallback this PR makes automatic). Three review rounds, 45 findings. Two are worth flagging because they were **my own errors caught by review**:

- Round 1's fix for the `APPROVED`-on-unreviewed problem over-corrected: an unconditional `NOT REVIEWED` then mislabelled a **completed** Phase 1 review as unreviewed and discarded its change list — on the normal Copilot `--delegate` path. Round 2 caught it.
- I argued against availability-based resolution on the grounds it would make `--delegate` non-deterministic. `src/providers/bootstrap.ts` registers exactly two providers, so the non-self set is a singleton and there was nothing to choose between. Factually wrong.

Round 3 traced all 24 combinations of {host} × {`--delegate`} × {peer present} × {round 1 outcome}.

**Caveats worth knowing:**

- Round 3 ended at the round cap with a `Continue` verdict, so its own amendments were not re-reviewed by fresh reviewers.
- Tests ran on **Node 22**; `package.json` declares `engines.node >= 24` (CI runs 24/26). The ID-set comparison is still valid — both sides ran on the same runtime — but the absolute failure set will differ on CI.

## Deliberately out of scope

- **`disallowedTools` is enforced on no host.** Ignored outright by Copilot (a `coral:critic` subagent created a file); on Claude Code v2.1.224 an agent granted `Bash` writes via shell redirection despite `Write`/`Edit` exclusion. Removing `Bash` blocks it. Tightening grants changes agent capability everywhere — its own change. This PR only fixes the doc that implied enforcement.
- **`<other-host>`'s fixed mapping is availability-blind.** On Copilot with `claude` installed and `codex` absent, Phase 2 still tries codex, fails, and skips — leaving a working provider unused. Needs a first-class availability surface (`coral-cli provider status` or equivalent).
- **Registering a `copilot` provider** is the real fix for Phase 2 on Copilot; this PR is what makes it a zero-skill-edit addition.



