### PR TITLE
fix: let the release pin the Copilot marketplace to its tag

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -4,14 +4,12 @@
     "name": "kangig94"
   },
   "metadata": {
-    "description": "Coral — structured agent workflows for Copilot CLI, Claude Code, and Codex",
-    "version": "0.10.4"
+    "description": "Coral — structured agent workflows for Copilot CLI, Claude Code, and Codex"
   },
   "plugins": [
     {
       "name": "coral",
       "description": "Structured planning, execution, and review workflows for Copilot CLI — multi-round plan/review, verified execution loops, multi-agent discussion, and a persistent knowledge base.",
-      "version": "0.10.4",
       "source": "./clients"
     }
   ]

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -38,6 +38,21 @@ execFileSync('node', ['scripts/check-simulation.mjs'], { stdio: 'inherit' });
 
 const { version } = JSON.parse(readFileSync('package.json', 'utf8'));
 
+/**
+ * Copilot rejects the `git-subdir` object Claude Code uses — verified against Copilot CLI 1.0.78, where only
+ * `{source:"github", repo, ref, path}` installs — so the two marketplaces name the same tag in different
+ * shapes. The repo slug is read back out of the Claude manifest rather than repeated here, so a fork changes
+ * one URL and both clients follow.
+ */
+function pinnedCopilotSource(releaseVersion) {
+  const claudeUrl = JSON.parse(readFileSync('.claude-plugin/marketplace.json', 'utf8')).plugins?.[0]?.source?.url;
+  const repo = /github\.com[/:](?<slug>[^/]+\/[^/]+?)(?:\.git)?$/u.exec(claudeUrl ?? '')?.groups?.slug;
+  if (repo === undefined) {
+    throw new Error(`Cannot derive the Copilot marketplace repo from the Claude marketplace url: ${claudeUrl}`);
+  }
+  return { source: 'github', repo, ref: `v${releaseVersion}`, path: 'clients' };
+}
+
 // Sync manifest versions (single source of truth: package.json). The plugin
 // manifests live under clients/ (the plugin root); marketplace manifests stay
 // at the repo root and point back at ./clients. Each client reads a different
@@ -81,6 +96,18 @@ for (const path of [
         pluginSource.ref = releaseRef;
         changed = true;
       }
+    }
+  }
+
+  // Copilot's manifest is read from the default branch, so `main` must carry a source that installs today —
+  // a bare `./clients`, which resolves against that same branch. Pinning is therefore written by the release
+  // rather than committed: the release commit lands on `main`, so from then until the next release Copilot
+  // resolves the tag just built instead of whatever has since merged.
+  if (release && path === '.github/plugin/marketplace.json') {
+    const pinned = pinnedCopilotSource(version);
+    if (JSON.stringify(json.plugins?.[0]?.source) !== JSON.stringify(pinned)) {
+      json.plugins[0].source = pinned;
+      changed = true;
     }
   }
 


### PR DESCRIPTION
Closes #293.

## The problem

Copilot installs tracked `main` while Claude Code and Codex both resolved to `v<version>`. Two consequences while unpinned:

1. Un-released commits on `main` reached Copilot users immediately, bypassing the release gate.
2. `clients/bridge/*.cjs` is only rebuilt by the Release workflow, so Copilot users got `main`'s latest `clients/hooks/` and `clients/skills/` against the **previous release's** bundle. Harmless while no PR touched both; a mismatched pair the first time one did.

## Why the pin is written by the release, not committed

Copilot reads `.github/plugin/marketplace.json` **from the default branch**. Whatever `main` carries has to install *today* — so a committed tag would name a release that does not exist yet and fail every Copilot install until it was cut.

So `main` keeps the working `"./clients"` source, and `build:release` replaces it. The release commit lands on `main`, so from that moment until the next release Copilot resolves the tag just built rather than whatever has since merged. There is no window where the manifest points at nothing.

On release, `.github/plugin/marketplace.json` becomes:

```json
"source": {
  "source": "github",
  "repo": "kangig94/coral",
  "ref": "v0.10.5",
  "path": "clients"
}
```

Not the `git-subdir` object Claude uses — #293 A/B-tested the forms against Copilot CLI 1.0.78 and that one is rejected with `Invalid marketplace.json: plugins.0.source: Invalid input`. Only the `github` form installs, and the pin was confirmed to take effect rather than merely pass validation.

The repo slug is read back out of `.claude-plugin/marketplace.json` rather than repeated here, so a fork changes one URL and both clients follow.

## The manifest stops claiming a version

It stated one in two places, `metadata.version` and `plugins[0].version`. Once a tag decides what gets installed, the plugin manifest inside that tag is the only honest answer — a second copy in the marketplace can only agree by coincidence or disagree by drift. Both are removed; the build's version sync skips fields that are absent, so nothing re-adds them.

## Verification

- Simulated the release rewrite against the committed manifests: produces the `github` form above with the slug derived from the Claude URL.
- `npm run build` (non-release) leaves both manifests untouched and does not re-add the version fields.
- `lint` and `format:check` pass.

Untested here: Copilot CLI itself is not available in this environment, so the accepted `source` shape rests on #293's recorded A/B test rather than a fresh run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
