### PR TITLE
fix: keep a retained host log from filling the frame that carries it

### DIFF
--- a/src/providers/host-diagnostics.ts
+++ b/src/providers/host-diagnostics.ts
@@ -1,6 +1,13 @@
-import { MAX_BUFFER } from '../infra/process-constants.js';
-
-export const PROVIDER_HOST_LOG_MAX_BYTES = MAX_BUFFER;
+/**
+ * A retained host log rides an operator response, and that response has to fit one IPC frame. Sizing this at
+ * `MAX_BUFFER` made the two equal, so a host that filled its log left no room for the JSON around it — the
+ * frame overflowed by roughly the envelope. The budget is therefore set on its own merits and kept well under
+ * the frame, which `tests/invariants/diagnostics-fit-one-frame.test.ts` holds in place.
+ *
+ * One mebibyte is thousands of stderr lines. This is a tail for diagnosis, not an archive: a host that has
+ * said more than this has already said enough to explain itself.
+ */
+export const PROVIDER_HOST_LOG_MAX_BYTES = 1024 * 1024;
 export const PROVIDER_HOST_COMPLETED_OBSERVATION_LIMIT = 256;
 
 export type ProviderHostLogEntry = Readonly<{

--- a/tests/integration/coordinator/provider-proxy-startup.integration.test.ts
+++ b/tests/integration/coordinator/provider-proxy-startup.integration.test.ts
@@ -332,16 +332,18 @@ function composeProductionStartup(
   }> = {},
 ): ProductionStartupHarness {
   const db = createDb([record]);
+  // A caller supplies a runtime to control time, never to opt out of the sandbox — so the isolation is layered
+  // on top of whatever it hands over rather than replaced by it. When this was an either/or, the one case that
+  // brought its own clock also silently read the developer's real `gen2/run`, found a live daemon's handoff
+  // capsule there, and attempted a redemption the fixture asserts never happens.
+  const base = options.runtime ?? createRealRuntime('prod');
   const time = options.runtime?.time ?? new VirtualTime();
-  const baseRuntime = createRealRuntime('prod');
-  const runtime =
-    options.runtime ??
-    ({
-      ...baseRuntime,
-      time,
-      storage: noCapsuleStorage(baseRuntime.storage),
-      process: absentProcessPort(baseRuntime.process),
-    } satisfies Runtime);
+  const runtime = {
+    ...base,
+    time,
+    storage: noCapsuleStorage(base.storage),
+    process: absentProcessPort(base.process),
+  } satisfies Runtime;
   const fatals = vi.fn();
   const lifecycleRef = new ProviderProxySetLifecycleRef();
   const progressStore = {

--- a/tests/integration/coordinator/provider-proxy-startup.integration.test.ts
+++ b/tests/integration/coordinator/provider-proxy-startup.integration.test.ts
@@ -314,6 +314,17 @@ function noCapsuleStorage(base: StoragePort): StoragePort {
  * time is always readable and never matches what the fixture recorded, which is the mismatch the reaper reads
  * as absence. Nothing here reaches the operating system.
  */
+/** A runtime that reaches neither the developer's capsules nor their process table, on the supplied clock. */
+function sandboxedRuntime(time: TimePort): Runtime {
+  const base = createRealRuntime('prod');
+  return {
+    ...base,
+    time,
+    storage: noCapsuleStorage(base.storage),
+    process: absentProcessPort(base.process),
+  } satisfies Runtime;
+}
+
 function absentProcessPort(base: ProcessPort): ProcessPort {
   return {
     ...base,
@@ -327,23 +338,21 @@ function composeProductionStartup(
   record: ProviderOperationRecord,
   inheritance: unknown,
   options: Readonly<{
+    /** For a case that stages capsules on disk: its storage is the fixture, so the sandbox steps aside. */
     runtime?: Runtime;
+    /** For a case that only wants to drive the clock, and should keep the sandbox. */
+    time?: TimePort;
     progressStore?: Partial<Pick<JobProgressStore, 'commit' | 'readStatus' | 'readLaunchProjection'>>;
   }> = {},
 ): ProductionStartupHarness {
   const db = createDb([record]);
-  // A caller supplies a runtime to control time, never to opt out of the sandbox — so the isolation is layered
-  // on top of whatever it hands over rather than replaced by it. When this was an either/or, the one case that
-  // brought its own clock also silently read the developer's real `gen2/run`, found a live daemon's handoff
-  // capsule there, and attempted a redemption the fixture asserts never happens.
-  const base = options.runtime ?? createRealRuntime('prod');
-  const time = options.runtime?.time ?? new VirtualTime();
-  const runtime = {
-    ...base,
-    time,
-    storage: noCapsuleStorage(base.storage),
-    process: absentProcessPort(base.process),
-  } satisfies Runtime;
+  // Wanting a clock and wanting the host's filesystem are different asks, and this used to conflate them:
+  // supplying a runtime for the clock also handed over real storage, so the one case that did read the
+  // developer's `gen2/run`, found a live daemon's handoff capsule, and attempted the redemption the fixture
+  // declares never happens. Only a case that stages capsules itself passes a runtime now; asking for a clock
+  // keeps the sandbox.
+  const runtime = options.runtime ?? sandboxedRuntime(options.time ?? new VirtualTime());
+  const { time } = runtime;
   const fatals = vi.fn();
   const lifecycleRef = new ProviderProxySetLifecycleRef();
   const progressStore = {
@@ -905,10 +914,7 @@ async function terminalizationUncertaintyStartupCase(mode: 'atomic-unknown' | 'u
             throw new Error('atomic-terminalization-sentinel');
           },
         };
-  const harness = composeProductionStartup(record, inheritance, {
-    runtime: { ...createRealRuntime('prod'), time },
-    progressStore,
-  });
+  const harness = composeProductionStartup(record, inheritance, { time, progressStore });
   const outcome = await productionStartupOutcome(harness);
   const snapshot = harness.lifecycleRef.get()?.snapshot();
   const result = {

--- a/tests/invariants/diagnostics-fit-one-frame.test.ts
+++ b/tests/invariants/diagnostics-fit-one-frame.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PROVIDER_HOST_TOMBSTONE_DIAGNOSTIC_BYTE_BUDGET,
+  PROVIDER_HOST_TOMBSTONE_DIAGNOSTIC_FACT_BUDGET,
+} from '#src/providers/host-admission.js';
+import { PROVIDER_HOST_LOG_MAX_BYTES } from '#src/providers/host-diagnostics.js';
+import { MAX_FRAME_BYTES } from '#src/transport/line-framing.js';
+
+/**
+ * Provider-host diagnostics are retained by one budget and delivered under another. The transport frame cap
+ * exists to stop an unterminated write from exhausting coordinator memory, not to bound legitimate payloads —
+ * so a payload that fills its own retention budget must still fit inside a frame, with room for the JSON
+ * envelope carrying it.
+ *
+ * Those two numbers were once both ten mebibytes, set independently in files that never referenced each
+ * other. A host that filled its log then produced a frame that overflowed by about the size of its own
+ * envelope, and the operator surface failed with `frame_too_large` on a payload nothing was wrong with.
+ *
+ * Equality is the specific defect, so the assertions below demand a margin rather than an ordering: a budget
+ * that merely fits is a budget that breaks the first time a field is added to the record around it.
+ */
+describe('provider-host diagnostics fit one IPC frame', () => {
+  const ENVELOPE_HEADROOM_RATIO = 0.5;
+
+  it('keeps a single host log well under the transport frame cap', () => {
+    expect(PROVIDER_HOST_LOG_MAX_BYTES).toBeLessThan(MAX_FRAME_BYTES * ENVELOPE_HEADROOM_RATIO);
+  });
+
+  it('keeps the retained tombstone budget well under the transport frame cap', () => {
+    expect(PROVIDER_HOST_TOMBSTONE_DIAGNOSTIC_BYTE_BUDGET).toBeLessThan(MAX_FRAME_BYTES * ENVELOPE_HEADROOM_RATIO);
+  });
+
+  /**
+   * An inventory response carries every owner's live hosts alongside the retained tombstones, so the sum is
+   * what actually has to fit — not either budget alone. The live path has no total of its own today; this
+   * states the exposure in the one place that would notice it growing, and names the host count the current
+   * numbers survive.
+   */
+  it('survives a plausible fleet of live hosts alongside the retained tombstones', () => {
+    const PLAUSIBLE_LIVE_HOSTS = 4;
+    const worstCaseResponseBytes =
+      PLAUSIBLE_LIVE_HOSTS * PROVIDER_HOST_LOG_MAX_BYTES + PROVIDER_HOST_TOMBSTONE_DIAGNOSTIC_BYTE_BUDGET;
+    expect(worstCaseResponseBytes).toBeLessThan(MAX_FRAME_BYTES);
+  });
+
+  it('bounds retained facts as well as bytes, so neither alone can fill a frame', () => {
+    expect(PROVIDER_HOST_TOMBSTONE_DIAGNOSTIC_FACT_BUDGET).toBeGreaterThan(0);
+    expect(Number.isSafeInteger(PROVIDER_HOST_TOMBSTONE_DIAGNOSTIC_FACT_BUDGET)).toBe(true);
+  });
+});


### PR DESCRIPTION
A live coordinator answered an operator request with:

```
FrameTooLargeError: IPC frame exceeded 10485760 bytes (observed 10486912)
```

The overflow is **1,152 bytes**. That is not a runaway write — it is a legitimate response missing by about the size of its own envelope.

## The frame cap is not a payload limit

It has been there since the v0.6.0 rewrite (#200), and it guards memory rather than message size. The framer accumulates bytes until it sees a newline, so without a ceiling one client that never terminates a frame can exhaust the coordinator.

## What broke it

#300 sized the host-log retention budget at `MAX_BUFFER`, in a file that never mentions the transport:

| Constant | Value | Owner |
| --- | --- | --- |
| `MAX_FRAME_BYTES` | 10 MiB | `transport/line-framing.ts` (#200) |
| `PROVIDER_HOST_LOG_MAX_BYTES` | **10 MiB** | `providers/host-diagnostics.ts` (#300) |

Two numbers agreeing by coincidence, one nested inside the other. A host that filled its log left exactly zero room for the JSON carrying it.

## The fix

The budget is set on its own merits and kept well clear — **1 MiB**, which is thousands of stderr lines. This is a tail for diagnosis, not an archive.

The relationship is what actually has to hold, so `tests/invariants/diagnostics-fit-one-frame.test.ts` states it, including the **sum an inventory response really carries** — every live host's log plus the retained tombstone budget — since either budget fitting alone proves nothing about the response. It demands margin rather than mere ordering, because a budget that only just fits breaks the first time a field is added to the record around it.

Mutation-verified: restoring the old 10 MiB value fails two of its assertions.

**Not fixed here**: the live-host path still has no total of its own, unlike tombstones, so the response grows with host count. The invariant names the fleet size the current numbers survive, which is where that will surface if it moves.

**Related**: #303's shorter idle window reduces how often a host lives long enough to fill its log, which lowers the frequency of this symptom — but that is mitigation, not the fix.

## Second commit: an unconditional sandbox for the startup fixture

Chasing an integration failure alongside this found a real isolation hole. `composeProductionStartup` applied its storage and process stubs **only when the caller did not supply a runtime**. Callers supply one to control time, not to opt out of the sandbox — and the single case that did lost both stubs with it. It then read the developer's real `gen2/run`, found a live daemon's handoff capsule, and attempted the redemption the fixture declares must never happen: one extra lifecycle fatal, on any machine where Coral happens to be running.

Verified against the condition that produced it — with a live handoff capsule present in the real run directory, that case went from failing to passing, and the three `capsule-redemption` fatals disappeared.

That first attempt then broke the case it was not for. Capsule retirement stages a capsule *precisely so discovery finds one*, and a blanket no-capsule stub left it with nothing to retire — every observed count went to zero. Both asks are legitimate, and conflating them in either direction breaks the other.

So the third commit separates them: `time` keeps the sandbox, `runtime` is the deliberate opt-out for a case that brings its own fixture, and the process port is stubbed alongside storage rather than left reaching the machine's process table.

**This closes the file.** `test:integration` passes end to end — which it had not since the containment work landed.

## Verification

`tsc`, `typecheck:tests`, `lint`, `format:check`, `knip`, `build` — all exit 0. `npm test` — 553 files / 5,977 tests, exit 0.

`test:integration` — 57 files / 543 tests, exit 0, three consecutive full-file runs with a live handoff capsule present on disk.

Mutation-verified: returning that one case to a real-storage runtime reproduces the original failure exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
