### PR TITLE
fix: bound the KB daemon's own teardown so it cannot outlive its coordinator

### DIFF
--- a/docs/todo/kb-daemon-independent-containment.md
+++ b/docs/todo/kb-daemon-independent-containment.md
@@ -1,0 +1,83 @@
+# TODO — give the KB daemon an enforcer outside its own process
+
+**Status**: open. Scoped on 2026-08-14 after a production KB daemon survived a graceful coordinator SIGTERM —
+reparented to init, unresponsive to SIGTERM, cleared only by SIGKILL. The immediate defect is fixed; the
+guarantee behind it is not, and this document is the part deliberately left out.
+
+## What was fixed, and what it actually claims
+
+The daemon had five stop triggers — parent watchdog, stdin `shutdown` request, stdin `end`, SIGTERM, SIGINT —
+funnelling into one `stop()` behind a single `settled` latch. The first arrival ran the cleanup and the other
+four became no-ops. Cleanup itself awaited `kbWriteHost.dispose()` with no bound. Five detectors, no enforcer.
+
+`createKbDaemonTerminalWindowAuthority` (`src/kb-daemon/daemon-main.ts`) added the missing half: the first stop
+request opens a window that no later arrival can extend or disarm, cooperative disposal is aborted partway
+through it, and the process exits at its close.
+
+**That bounds every stop in which the event loop still turns** — including the production case, whose SIGTERM
+handler did run and found the stop already latched.
+
+**It is not a guarantee, and must not be described as one.** The timers are in the same event loop as the
+teardown they police. A loop blocked synchronously never reaches them. That is not hypothetical: curate can
+reach `git merge-file` through `execFileSync` with no timeout (`src/kb/curate/frontmatter-merge-driver.ts`),
+and while the main thread sits in `spawnSync`, no watchdog tick, no stdin `end`, and no signal handler runs.
+
+## The shape the guarantee actually needs
+
+An enforcer that is not the coordinator and not the daemon. Both candidate owners share one failure mode:
+whoever owns the guarantee can die first. Parent-local escalation dies with the parent —
+`gracefulKill` schedules its SIGKILL in the coordinator's own event loop
+(`src/infra/process-supervision.ts:13-23`), so a coordinator that exits destroys the escalation before it
+fires. Child-local escalation, which is what shipped, fails when the child's loop is what wedged.
+
+Coral already runs this pattern correctly once. The provider guardian/reaper hold a deadline that survives
+coordinator loss, latch before awaited teardown, report scheduling lateness rather than pretending the bound
+was met, and confirm containment *absence* rather than trusting leader exit
+(`src/provider-proxy/enforcement.ts`, `src/provider-proxy/orphan-deadline.ts`).
+
+A design exploration on 2026-08-14 proposed generalising that semantic core into a `src/leased-containment/`
+domain and having KB depend on it: a process containment may exist only under an authenticated coordinator
+tenancy, and an untransferred tenancy makes the containment irreversibly terminal by a precomputed absolute
+deadline. Its conclusions worth keeping:
+
+- **Do not import `provider-proxy/orphan-deadline.ts` from KB.** It carries provider-specific timing, pairing,
+  protocol and successor policy. Depending on it would make `provider-proxy/` a second, falsely named home for
+  generic process lifetime and invert the layering the invariants enforce.
+- **Do not copy it either.** One concept, two homes, guaranteed drift.
+- **`prctl(PR_SET_PDEATHSIG)`, cgroups, launchd jobs and native addons are ruled out** — they would make the
+  guarantee depend on a different mechanism per host, which the no-per-OS-divergence rule forbids outright.
+
+One claim from that exploration was **over-read and should not be carried forward**: that the first transition
+is blocked because a successor cannot attach to an already-running old-build daemon, making the design
+incompatible with the hot-upgrade rule. Restarting the *KB daemon* during an upgrade is not a cold upgrade of
+Coral. The constraint binds the coordinator's own continuity, not this child's.
+
+## Also open, found in the same audit
+
+Each is real and independently verified from source; none is a survival bug once the daemon bounds its own
+teardown, which is why they were left out rather than folded in.
+
+- **Detached grandchildren are not covered by anything.** `runtime.process.exec` spawns each child into its own
+  process group (`src/runtime/real.ts:364-382`, `src/runtime/exec-builder.ts:88-96`) with no containment
+  recorded, so uv, Marker and curl/wget children can be stranded — and a daemon that now exits *faster* makes
+  stranding more reachable, not less. Covering them means the containment authority must own or gate the spawn
+  through the runtime process port; a wrapper that registers after `spawn` still has an execution race. Until
+  that exists, the claim is bounded to the daemon's own process and calling it "KB containment" would be false.
+- **Coordinator shutdown can skip asking the daemon to stop at all.** `shutdown.ts` wraps KB disposal in
+  `runBudgetedStep`, and `withBudget` skips the task outright when the drain budget is exhausted — while the
+  immediately preceding `recovery coordinator teardown` is unbudgeted and can consume it. Converting it to
+  `runRequiredBudgetedStep` is *not* the fix: on exhaustion that path fires the task with an already-aborted
+  signal on the argument that its synchronous prefix has run, and here the stdin write lives inside an async
+  `runExclusive` turn, so nothing would be sent either way — it would trade a silent skip for a shutdown error.
+- **Recovery teardown is itself unbounded**, and it is what exhausts that budget:
+  `src/coordinator/services/recovery/index.ts` aborts finalizations and then unconditionally awaits every
+  commit-started promise with no timeout.
+- **Liveness is policed rather than derived.** `daemon-main.ts` installs `setInterval(() => undefined, 60_000)`
+  purely to pin the event loop, so the process can outlive the parent pipe and then relies on a poll to notice.
+  The stdin `data` listener already references the loop, which makes the keepalive close to redundant; removing
+  it would make parent EOF structurally sufficient. Left alone deliberately — `stopAsync` clears it *before*
+  the disposal await, so it was not what held the stranded daemon open, and changing it would be an unrelated
+  behavioural risk riding along with a fix.
+- **No test kills a coordinator and asserts the daemon disappears.** The runtime-host tests release their
+  mocked work before awaiting disposal and the supervisor tests emit `close` by hand, so every existing
+  assertion is about the happy path. The gap is process-level by nature and needs a process-level test.

--- a/src/coordinator/lifecycle.ts
+++ b/src/coordinator/lifecycle.ts
@@ -1133,6 +1133,14 @@ async function runLifecycleStartup({
     idleTimer.stopWatching();
     state.ownershipCheckerTeardown?.();
     state.ownershipCheckerTeardown = null;
+    // The KB daemon is started fire-and-forget above, so a failure at any later startup step can find a child
+    // already spawned. Everything else this block closes is in-process and dies with us; the daemon is the one
+    // piece that outlives this coordinator when it is skipped.
+    try {
+      await kbDaemonSupervisor?.dispose('coordinator startup failed');
+    } catch {
+      // best effort
+    }
     try {
       await closeServerFn(server);
     } catch {

--- a/src/kb-daemon/daemon-main.ts
+++ b/src/kb-daemon/daemon-main.ts
@@ -35,7 +35,21 @@ import { canonicalizeWorkDir, type CanonicalWorkDir, WorkDirectoryError } from '
 
 const DEFAULT_PARENT_WATCHDOG_INTERVAL_MS = 1_000;
 
+/**
+ * How long cooperative disposal is given before its signal is aborted, and how long the whole teardown is
+ * given before this process exits regardless.
+ *
+ * Set here rather than derived from the shared signal-escalation constants. Those measure grace around a
+ * signal sent to some other process — and `SIGKILL_GRACE_MS` in particular is time to confirm a disappearance
+ * *after* SIGKILL, not grace before one. Borrowing them would assert an alignment with the supervisor's own
+ * stop timeout that nothing keeps true, since that timeout is a separately hard-coded value. The durations
+ * happen to coincide today; that is arithmetic, not a shared schedule.
+ */
+const DEFAULT_DISPOSE_ABORT_MS = 5_000;
+const DEFAULT_TERMINAL_EXIT_MS = 10_000;
+
 type IntervalHandle = ReturnType<typeof setInterval>;
+type TimeoutHandle = ReturnType<typeof setTimeout>;
 
 type PendingParentRequest = {
   resolve: (response: KbDaemonParentResponseMessage) => void;
@@ -206,6 +220,92 @@ export function startKbDaemonParentWatchdog(options: KbDaemonParentWatchdogOptio
   return handle;
 }
 
+/** One opened window. The deadline is already running; this is the part of it a caller can observe. */
+export type KbDaemonTerminalWindow = Readonly<{
+  /**
+   * Aborted at the cooperative mark, so the joins that do observe a signal get their chance to unwind before
+   * the process is taken out from under them.
+   *
+   * Not every join observes it. Disposal's `initPromise` join, a corpus mutation-lock wait already queued
+   * behind another writer, and an expansion `stop()` already in flight each finish on their own schedule.
+   * That is exactly why the exit is not made conditional on disposal having noticed.
+   */
+  signal: AbortSignal;
+}>;
+
+/** Seams for the window's two timers. Every field defaults to the real process-level behaviour. */
+export type KbDaemonTerminalWindowOptions = {
+  disposeAbortMs?: number;
+  terminalExitMs?: number;
+  setTimeoutFn?: (fn: () => void, ms: number) => TimeoutHandle;
+  exit?: (code: number) => void;
+  log?: (message: string) => void;
+};
+
+/** Holds a process's single window, so that opening it is something every stop trigger may attempt. */
+export type KbDaemonTerminalWindowAuthority = Readonly<{
+  /**
+   * Opens the window, or returns the one already open. Idempotence is the contract, not an optimisation: a
+   * teardown that is overrunning must not be able to buy itself more time by being asked to stop again, so
+   * the deadline belongs to the first request and every later one inherits it.
+   */
+  open(exitCode: number): KbDaemonTerminalWindow;
+}>;
+
+/**
+ * The authority over the window within which this process must cease to exist.
+ *
+ * A stop request used to be five triggers sharing one latch: whichever arrived first ran the cleanup, and the
+ * other four became no-ops. Cleanup that never finished was therefore never escalated by anything — five
+ * detectors, no enforcer. This window is the missing half. It is opened by the first trigger and is not itself
+ * a trigger, so no later arrival can disarm it and none is needed to enforce it.
+ *
+ * The deadline is never cleared. A teardown that finishes cleanly usually reaches exit before the window
+ * closes — though not always, since a daemon whose parent pipe is still open has nothing else that ends it,
+ * and this timer is then what does.
+ *
+ * What this buys: an enforcement point that is reached on any stop where the event loop keeps making progress.
+ * That covers the case that stranded a daemon in production, whose SIGTERM handler did run, found the stop
+ * already latched, and returned.
+ *
+ * What it is not: a wall-clock bound. A timer fires when it becomes *eligible*, so a long synchronous stretch
+ * inside disposal, or heavy timer starvation, delays the exit by however long that stretch lasts — and a loop
+ * blocked indefinitely never reaches either timer at all. Nothing inside this process can close that; only an
+ * enforcer outside it can.
+ */
+export function createKbDaemonTerminalWindowAuthority(
+  options: KbDaemonTerminalWindowOptions = {},
+): KbDaemonTerminalWindowAuthority {
+  const disposeAbortMs = options.disposeAbortMs ?? DEFAULT_DISPOSE_ABORT_MS;
+  const terminalExitMs = options.terminalExitMs ?? DEFAULT_TERMINAL_EXIT_MS;
+  const setTimeoutFn = options.setTimeoutFn ?? setTimeout;
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const log = options.log ?? ((message: string) => void process.stderr.write(message));
+  let window: KbDaemonTerminalWindow | null = null;
+
+  return Object.freeze({
+    open: (exitCode: number): KbDaemonTerminalWindow => {
+      if (window !== null) {
+        return window;
+      }
+      const controller = new AbortController();
+      const abortTimer = setTimeoutFn(() => {
+        controller.abort(new Error(`KB daemon disposal exceeded its ${disposeAbortMs}ms cooperative window.`));
+      }, disposeAbortMs);
+      const exitTimer = setTimeoutFn(() => {
+        log(`[kb-daemon] teardown did not complete within ${terminalExitMs}ms; exiting.\n`);
+        exit(exitCode);
+      }, terminalExitMs);
+      // Unref'd so the window can never itself be why the process is still alive: it exists to end a
+      // lifetime, not to hold one open.
+      (abortTimer as { unref?: () => void }).unref?.();
+      (exitTimer as { unref?: () => void }).unref?.();
+      window = Object.freeze({ signal: controller.signal });
+      return window;
+    },
+  });
+}
+
 export async function runKbDaemonMain(options: KbDaemonMainOptions = {}): Promise<number> {
   const startedAt = Date.now();
   const pluginRoot = options.pluginRoot ?? process.cwd();
@@ -334,12 +434,16 @@ export async function runKbDaemonMain(options: KbDaemonMainOptions = {}): Promis
     resolveShutdown = resolve;
   });
   let stopPromise: Promise<void> | null = null;
+  const terminal = createKbDaemonTerminalWindowAuthority();
   const stop = (code: number): void => {
-    stopPromise ??= stopAsync(code).finally(() => {
+    // Opened outside the `settled` latch deliberately. The latch belongs to the cleanup, which must run once;
+    // the window belongs to the lifetime, which must end regardless of how that cleanup goes.
+    const window = terminal.open(code);
+    stopPromise ??= stopAsync(code, window.signal).finally(() => {
       stopPromise = null;
     });
   };
-  const stopAsync = async (code: number): Promise<void> => {
+  const stopAsync = async (code: number, signal: AbortSignal): Promise<void> => {
     if (settled) {
       return;
     }
@@ -349,12 +453,14 @@ export async function runKbDaemonMain(options: KbDaemonMainOptions = {}): Promis
       clearInterval(parentWatchdog);
     }
     parentWatchdog = null;
+    // Before disposal, not after it. Cleanup can await work that is itself waiting on a parent response, and
+    // a cancellation sequenced after that await can never be the thing that releases it.
+    cancelPendingParentRequests('KB daemon is shutting down.');
     try {
-      await kbWriteHost.dispose();
+      await kbWriteHost.dispose({ signal });
     } catch (error: unknown) {
       process.stderr.write(`[kb-daemon] write runtime dispose failed: ${errorMessage(error)}\n`);
     } finally {
-      cancelPendingParentRequests('KB daemon is shutting down.');
       resolveShutdown(code);
     }
   };

--- a/tests/invariants/kb-daemon-teardown-wiring.test.ts
+++ b/tests/invariants/kb-daemon-teardown-wiring.test.ts
@@ -1,0 +1,79 @@
+// KB daemon teardown wiring invariant.
+//
+// A KB daemon survived a graceful coordinator SIGTERM in production: reparented
+// to init, ignoring SIGTERM, cleared only by SIGKILL. Its five stop triggers all
+// funnelled into one `stop()` behind a single latch, so the first arrival ran
+// the cleanup and the other four became no-ops, and that cleanup then awaited
+// `kbWriteHost.dispose()` with no bound at all.
+//
+// The repair is four pieces of wiring, and each one is invisible from the outside
+// until the day it matters:
+//
+//   1. `stop()` opens the terminal window, OUTSIDE the cleanup latch. The window
+//      is what makes the four triggers arriving after the first into something
+//      other than no-ops.
+//   2. `stopAsync()` hands that window's signal to `dispose()`. Disposal already
+//      threads a signal through the joins that observe one; before the repair the
+//      caller passed nothing, so every one of them received `undefined`.
+//   3. Pending parent requests are cancelled BEFORE the disposal await, not in a
+//      `finally` after it. Cleanup can await work that is itself waiting on a
+//      parent response, and a cancellation sequenced after that await can never
+//      be the thing that releases it.
+//   4. The coordinator disposes the supervisor when startup fails. The daemon is
+//      started fire-and-forget, so a later startup step throwing can leave a child
+//      already spawned, and it is the one piece that outlives the coordinator.
+//
+// Unit tests cover the window authority's own behaviour. They cannot see any of
+// the above: every one of these could be deleted and those tests would stay
+// green, because they call the authority directly. This test is that gap. It is
+// deliberately structural — the behavioural version needs a process-level test
+// that kills a coordinator and watches a real daemon PID disappear, which is
+// recorded as open in `docs/todo/kb-daemon-independent-containment.md`.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { codeTextOnly } from '../helpers/ts-code-text.js';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+
+const read = (relativePath: string): string => codeTextOnly(readFileSync(join(REPO_ROOT, relativePath), 'utf-8'));
+
+describe('KB daemon stop wiring', () => {
+  const daemonMain = read('src/kb-daemon/daemon-main.ts');
+
+  it('opens the terminal window from stop, not from the latched cleanup', () => {
+    // In `stop`, which every trigger calls — never inside `stopAsync`, which
+    // returns early once the cleanup has been latched by an earlier trigger.
+    const stopBody = /const stop = \(code: number\): void => \{([\s\S]*?)\n {2}\};/u.exec(daemonMain)?.[1];
+    expect(stopBody, 'the stop trigger entry point must still be recognisable').toBeDefined();
+    expect(stopBody).toMatch(/terminal\.open\(/u);
+
+    const stopAsyncBody = /const stopAsync = async \([\s\S]*?\n {2}\};/u.exec(daemonMain)?.[0];
+    expect(stopAsyncBody, 'the latched cleanup must still be recognisable').toBeDefined();
+    expect(stopAsyncBody).not.toMatch(/terminal\.open\(/u);
+  });
+
+  it('hands the window signal to disposal instead of calling it bare', () => {
+    expect(daemonMain).toMatch(/kbWriteHost\.dispose\(\s*\{\s*signal\s*\}\s*\)/u);
+    expect(daemonMain, 'a bare dispose() gives every join inside it `signal: undefined`').not.toMatch(
+      /kbWriteHost\.dispose\(\s*\)/u,
+    );
+  });
+
+  it('cancels pending parent requests before awaiting disposal, not after it', () => {
+    const cancelAt = daemonMain.indexOf('cancelPendingParentRequests(');
+    const disposeAt = daemonMain.search(/await kbWriteHost\.dispose\(/u);
+    expect(cancelAt, 'parent-request cancellation must still exist').toBeGreaterThan(-1);
+    expect(disposeAt, 'the disposal await must still exist').toBeGreaterThan(-1);
+    expect(cancelAt).toBeLessThan(disposeAt);
+  });
+});
+
+describe('coordinator startup-failure cleanup', () => {
+  it('disposes the KB daemon supervisor it started fire-and-forget', () => {
+    const lifecycle = read('src/coordinator/lifecycle.ts');
+    expect(lifecycle).toMatch(/kbDaemonSupervisor\?\.dispose\(/u);
+  });
+});

--- a/tests/unit/kb-daemon/daemon-main.test.ts
+++ b/tests/unit/kb-daemon/daemon-main.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  createKbDaemonTerminalWindowAuthority,
   handleKbDaemonExpansionRpcRequest,
   isProcessAlive,
   resolveKbDaemonParentPid,
@@ -141,6 +142,91 @@ describe('KB daemon main parent watchdog', () => {
     tick?.();
     expect(clearIntervalFn).toHaveBeenCalledTimes(1);
     expect(onParentExit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('KB daemon terminal window', () => {
+  const scheduler = (): {
+    scheduled: { ms: number; fire: () => void; unref: ReturnType<typeof vi.fn> }[];
+    setTimeoutFn: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  } => {
+    const scheduled: { ms: number; fire: () => void; unref: ReturnType<typeof vi.fn> }[] = [];
+    return {
+      scheduled,
+      setTimeoutFn: (fn, ms) => {
+        const unref = vi.fn();
+        scheduled.push({ ms, fire: fn, unref });
+        return { unref } as unknown as ReturnType<typeof setTimeout>;
+      },
+    };
+  };
+
+  it('aborts cooperative disposal first, then exits the process', () => {
+    const { scheduled, setTimeoutFn } = scheduler();
+    const exit = vi.fn();
+    const log = vi.fn();
+
+    const window = createKbDaemonTerminalWindowAuthority({
+      disposeAbortMs: 40,
+      terminalExitMs: 100,
+      setTimeoutFn,
+      exit,
+      log,
+    }).open(7);
+
+    expect(scheduled.map((entry) => entry.ms)).toEqual([40, 100]);
+    expect(window.signal.aborted).toBe(false);
+
+    scheduled[0].fire();
+    expect(window.signal.aborted).toBe(true);
+    expect(exit).not.toHaveBeenCalled();
+
+    scheduled[1].fire();
+    expect(exit).toHaveBeenCalledWith(7);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('100ms'));
+  });
+
+  /**
+   * The load-bearing one. Every stop trigger calls `open`, so a window that re-armed per call would let a
+   * teardown that is already overrunning postpone its own deadline indefinitely — the same shape as the
+   * `settled` latch this window exists to escape, only inverted.
+   */
+  it('gives a later stop request the deadline already running, never a fresh one', () => {
+    const { scheduled, setTimeoutFn } = scheduler();
+    const exit = vi.fn();
+
+    const authority = createKbDaemonTerminalWindowAuthority({
+      disposeAbortMs: 40,
+      terminalExitMs: 100,
+      setTimeoutFn,
+      exit,
+      log: vi.fn(),
+    });
+
+    const first = authority.open(0);
+    const second = authority.open(3);
+
+    expect(second).toBe(first);
+    expect(scheduled).toHaveLength(2);
+
+    scheduled[1].fire();
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('never holds the event loop open on its own', () => {
+    const { scheduled, setTimeoutFn } = scheduler();
+
+    createKbDaemonTerminalWindowAuthority({
+      setTimeoutFn,
+      exit: vi.fn(),
+      log: vi.fn(),
+    }).open(0);
+
+    expect(scheduled).toHaveLength(2);
+    for (const entry of scheduled) {
+      expect(entry.unref).toHaveBeenCalledTimes(1);
+    }
   });
 });
 


### PR DESCRIPTION
A KB daemon survived a graceful coordinator SIGTERM in production: reparented to init, unresponsive to SIGTERM, cleared only by SIGKILL.

## Cause

The daemon had five stop triggers — parent watchdog, stdin `shutdown`, stdin `end`, SIGTERM, SIGINT — all funnelling into one `stop()` behind a single `settled` latch. The first arrival ran the cleanup and the other four became no-ops rather than escalating, and that cleanup then awaited disposal with no bound. Five detectors, no enforcer. The stranded daemon's SIGTERM handler *did* run; it found the stop already latched and returned.

## Change

- The first stop request opens a terminal window that no later arrival can disarm or extend. Idempotence is its contract: a teardown that is overrunning must not buy itself more time by being asked to stop again.
- Disposal's abort signal is derived from that window. The plumbing already existed end to end through `disposeState`; the daemon was the one caller passing nothing, so every `{ signal }` downstream was `{ signal: undefined }`.
- Parent-request cancellation moves ahead of the disposal await. Cleanup can wait on parent work that a cancellation sequenced after it can never release.
- The coordinator now disposes the supervisor when startup fails after the fire-and-forget daemon start. Everything else that cleanup path closes dies with the coordinator; the daemon is the piece that does not.

## What this does not claim

Not independent containment. The timers share an event loop with the teardown they police, so they bound any stop where that loop keeps making progress but give no wall-clock guarantee. The enforcer that would live outside the process, and the detached exec grandchildren no owner reaps today, are recorded in `docs/todo/kb-daemon-independent-containment.md`.

## Verification

`tests/invariants/kb-daemon-teardown-wiring.test.ts` covers the wiring the unit tests structurally cannot see — all four regressions it guards were mutation-verified to fail it. Every gate green: tsc, typecheck:tests, lint, format, knip, build, unit (5924), simulation, integration, store-reset, e2e lifecycle, e2e store-reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)