### PR TITLE
fix: stop the KB daemon burning a core on an artifact ahead of the corpus

### DIFF
--- a/src/coordinator/live/kb-daemon-supervisor.ts
+++ b/src/coordinator/live/kb-daemon-supervisor.ts
@@ -310,6 +310,31 @@ export function createKbDaemonSupervisor(options: KbDaemonSupervisorOptions): Kb
   let operation: Promise<unknown> | null = null;
   let probeOperation: Promise<KbDaemonHealthSnapshot> | null = null;
   let stderrBuffer = '';
+  let lastStderrLine: string | null = null;
+  let repeatedStderrLines = 0;
+  /**
+   * The retained buffer alone is a diagnostic nobody reads: it is capped, cleared on every restart, and
+   * surfaced only when someone thinks to ask the supervisor for it. A KB daemon once announced its own
+   * failure 8.4 million times into it while the backend log stayed completely empty, which turned a message
+   * the daemon had already written into an hour of `/proc` forensics. So the daemon's stderr goes to the log
+   * an operator actually reads.
+   *
+   * Consecutive identical lines collapse into a count because that same incident is what forwarding has to
+   * survive: 8.4 million copies of one sentence is a 1.4 GB log file, and replacing a silent failure with a
+   * full disk is not an improvement. Every *distinct* line is still emitted.
+   */
+  const forwardDaemonStderrLine = (line: string): void => {
+    if (line === lastStderrLine) {
+      repeatedStderrLines += 1;
+      return;
+    }
+    if (repeatedStderrLines > 0) {
+      log(`[kb-daemon] previous line repeated ${repeatedStderrLines} more time(s)`);
+      repeatedStderrLines = 0;
+    }
+    lastStderrLine = line;
+    log(`[kb-daemon] ${line}`);
+  };
   let nextRequestId = 1;
   const pendingRequests = new Map<string, PendingRequest>();
   const activeParentRequests = new Map<string, { generation: number; controller: AbortController }>();
@@ -848,6 +873,9 @@ export function createKbDaemonSupervisor(options: KbDaemonSupervisorOptions): Kb
     lastError = undefined;
     lastSetupError = undefined;
     stderrBuffer = '';
+    // A fresh process repeating what the previous one said is news, not a repeat.
+    lastStderrLine = null;
+    repeatedStderrLines = 0;
     lastHeartbeatAt = undefined;
     lastHeartbeatLatencyMs = undefined;
     daemonUptimeMs = undefined;
@@ -968,7 +996,14 @@ export function createKbDaemonSupervisor(options: KbDaemonSupervisorOptions): Kb
       });
 
       stderr.on('data', (chunk) => {
-        stderrBuffer = appendBuffer(stderrBuffer, String(chunk));
+        const text = String(chunk);
+        stderrBuffer = appendBuffer(stderrBuffer, text);
+        for (const line of text.split('\n')) {
+          const trimmed = line.trim();
+          if (trimmed.length > 0) {
+            forwardDaemonStderrLine(trimmed);
+          }
+        }
       });
 
       spawned.on('error', (error) => {

--- a/src/coordinator/live/kb-daemon-supervisor.ts
+++ b/src/coordinator/live/kb-daemon-supervisor.ts
@@ -116,6 +116,31 @@ type KbDaemonSupervisorOptions = {
   log?: (message: string) => void;
 };
 
+/**
+ * How much of a dead daemon's output may travel as its exit diagnostic.
+ *
+ * The retained stderr buffer is capped at `MAX_BUFFER`, which is the same ten mebibytes as the transport's
+ * `MAX_FRAME_BYTES`. Handing the whole buffer to `lastError` therefore produced a health response that
+ * overflowed one IPC frame by exactly the JSON around it — `frame_too_large` at 10,486,912 bytes against a
+ * 10,485,760 limit — and every operator command that reads daemon health failed while the diagnostic was
+ * needed most. `PROVIDER_HOST_LOG_MAX_BYTES` was the same equality in the provider host log; this is the
+ * second place it lived.
+ *
+ * The tail, not the head: the output that explains an exit is the output nearest to it.
+ */
+export const KB_DAEMON_EXIT_DIAGNOSTIC_MAX_CHARS = 64 * 1024;
+
+function daemonExitDiagnostic(stderr: string): string {
+  const trimmed = stderr.trim();
+  if (trimmed.length === 0) {
+    return 'daemon exited';
+  }
+  if (trimmed.length <= KB_DAEMON_EXIT_DIAGNOSTIC_MAX_CHARS) {
+    return trimmed;
+  }
+  return `[earlier output truncated]\n${trimmed.slice(-KB_DAEMON_EXIT_DIAGNOSTIC_MAX_CHARS)}`;
+}
+
 const DEFAULT_START_TIMEOUT_MS = 5_000;
 const DEFAULT_STOP_TIMEOUT_MS = 5_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 2_000;
@@ -1031,7 +1056,7 @@ export function createKbDaemonSupervisor(options: KbDaemonSupervisorOptions): Kb
             phase = 'stopped';
           } else {
             phase = 'failed';
-            lastError = stderrBuffer.trim().length > 0 ? stderrBuffer.trim() : 'daemon exited';
+            lastError = daemonExitDiagnostic(stderrBuffer);
             lastSetupError = undefined;
           }
           notifyExitListeners();

--- a/src/engines/orama/artifact-port.ts
+++ b/src/engines/orama/artifact-port.ts
@@ -519,7 +519,7 @@ export class OramaArtifactPort implements EngineArtifactPort {
       const { metadata } = readOramaProjectionArtifact(this.files, artifactPath, metadataPath);
       const lanes = corpusLanes(target.corpusInterest);
       if (lanes.some((lane) => corpusLaneAhead(metadata, target.snapshot, lane))) {
-        return { kind: 'unavailable', reason: 'ahead-of-authority' };
+        return { kind: 'stale', reason: 'ahead-of-authority' };
       }
       if (
         lanes.some((lane) => !corpusLaneMatches(metadata, target.snapshot, lane)) ||

--- a/src/projection-consumers/authority-apply.ts
+++ b/src/projection-consumers/authority-apply.ts
@@ -18,7 +18,12 @@ import type {
 } from '../store/consumer-contract.js';
 import type { ConsumerCursorRepository } from './persistence.js';
 import type { ConsumerState } from './state.js';
-import { isCorpusAuthoritativeFreshness, isKbCorpusSnapshot, toConsumerApplyError } from './state.js';
+import {
+  isCorpusAuthoritativeFreshness,
+  isKbCorpusSnapshot,
+  repeatsPreviousApplyFailure,
+  toConsumerApplyError,
+} from './state.js';
 
 const EMPTY_PROJECTION_INPUT: KbProjectionInput = {
   index: {
@@ -284,6 +289,7 @@ async function runCorpusApply(
       deps.repository.repairCorpusCursor(reg, authoritativeFreshness.appliedSnapshot);
       recordCorpusFreshness(state, projectionInput, options.forceGeneration);
       deps.resolveWaiters(state, authoritativeFreshness.appliedSnapshot);
+      clearLastApplyError(state);
       return true;
     }
 
@@ -300,9 +306,7 @@ async function runCorpusApply(
         signal: controller.signal,
       });
       if (applyResult !== undefined && 'advance' in applyResult && applyResult.advance === false) {
-        if (state.kind === 'corpus') {
-          state.lastApplyError = null;
-        }
+        clearLastApplyError(state);
         return true;
       }
       const appliedSnapshot =
@@ -313,6 +317,7 @@ async function runCorpusApply(
       deps.repository.advanceCorpusCursor(reg, appliedSnapshot);
       recordCorpusFreshness(state, projectionInput, options.forceGeneration);
       deps.resolveWaiters(state, appliedSnapshot);
+      clearLastApplyError(state);
       return true;
     } finally {
       if (trackTextProjection) {
@@ -321,10 +326,21 @@ async function runCorpusApply(
     }
   } catch (err) {
     const applyError = toConsumerApplyError(err, deps.now().toISOString());
+    // The failure callback exists so a consumer can ask for the repair that would let the next attempt
+    // succeed. An identical failure twice in a row means the previous repair changed nothing, so asking for
+    // it again can only produce the same failure — and when that repair is itself "apply again", the two
+    // form a cycle with no timer, no backoff and no attempt limit in it. Orama's default callback did
+    // exactly that against an artifact ahead of the corpus authority, and the daemon spent an hour at 100%
+    // CPU running ~50k applies a second, each one certain to fail the same way.
+    //
+    // One notification per distinct failure is all the callback can act on, so that is what it gets.
+    const repeatedFailure = state.kind === 'corpus' && repeatsPreviousApplyFailure(state.lastApplyError, applyError);
     if (state.kind === 'corpus') {
       state.lastApplyError = applyError;
     }
-    invokeApplyFailureCallback(state, applyError);
+    if (!repeatedFailure) {
+      invokeApplyFailureCallback(state, applyError);
+    }
     deps.rejectWaiters(state, applyError);
     backendLog.error(`ConsumerDriver apply failed (${reg.id})`, err);
     return false;
@@ -396,6 +412,16 @@ async function prepareCorpusProjectionInput(
           generatedCommunityDocsHash: generatedCommunityFreshness.generatedCommunityDocsHash,
         }),
   });
+}
+
+/**
+ * Cleared on every path that ends in progress, so that "the same failure as last time" stays a statement
+ * about consecutive failures. A success between two identical failures makes the second one news again.
+ */
+function clearLastApplyError(state: ConsumerState): void {
+  if (state.kind === 'corpus') {
+    state.lastApplyError = null;
+  }
 }
 
 function invokeApplyFailureCallback(state: ConsumerState, applyError: ConsumerApplyError): void {

--- a/src/projection-consumers/state.ts
+++ b/src/projection-consumers/state.ts
@@ -193,12 +193,13 @@ export function isCorpusAuthoritativeFreshness(value: unknown): value is CorpusA
       reason === 'artifact-missing' ||
       reason === 'lane-behind' ||
       reason === 'generated-community-changed' ||
-      reason === 'projection-identity-changed'
+      reason === 'projection-identity-changed' ||
+      reason === 'ahead-of-authority'
     );
   }
   if (freshness.kind === 'unavailable') {
     const reason = (value as Extract<CorpusAuthoritativeFreshness, { kind: 'unavailable' }>).reason;
-    return reason === 'malformed' || reason === 'probe-failed' || reason === 'ahead-of-authority';
+    return reason === 'malformed' || reason === 'probe-failed';
   }
   return false;
 }
@@ -230,6 +231,15 @@ export function toConsumerApplyError(err: unknown, at: string): ConsumerApplyErr
     return { message: err, at, cause: err };
   }
   return { message: 'Consumer apply failed', at, cause: err };
+}
+
+/**
+ * Whether a failure says nothing the previous one did not already say. Compared on the message alone: `at` is
+ * a timestamp that differs by construction, and `cause` carries the original error object, which is a fresh
+ * instance every throw. The message is what the failure callback would act on.
+ */
+export function repeatsPreviousApplyFailure(previous: ConsumerApplyError | null, current: ConsumerApplyError): boolean {
+  return previous !== null && previous.message === current.message;
 }
 
 export function consumerNotRegisteredError(consumerId: string): CoralSetupError {

--- a/src/store/consumer-contract.ts
+++ b/src/store/consumer-contract.ts
@@ -135,11 +135,21 @@ export type CorpusAuthoritativeFreshness =
         | 'artifact-missing'
         | 'lane-behind'
         | 'generated-community-changed'
-        | 'projection-identity-changed';
+        | 'projection-identity-changed'
+        /**
+         * The artifact records applying further than the authority has ever reached — it belongs to a corpus
+         * history this authority no longer has, which is what a store reset leaves behind.
+         *
+         * Stale, not unavailable, because the consumer is a rebuildable cache: an artifact from a history that
+         * no longer exists is worth exactly what a missing one is worth, and rebuilding costs only CPU. It was
+         * classified `unavailable` — a hard apply error — which meant the cursor could never advance past it.
+         * Nothing about retrying changed that, so the retry ran forever.
+         */
+        | 'ahead-of-authority';
     }
   | {
       readonly kind: 'unavailable';
-      readonly reason: 'malformed' | 'probe-failed' | 'ahead-of-authority';
+      readonly reason: 'malformed' | 'probe-failed';
     };
 
 export interface JournalConsumerReadPort {

--- a/tests/invariants/diagnostics-fit-one-frame.test.ts
+++ b/tests/invariants/diagnostics-fit-one-frame.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { KB_DAEMON_EXIT_DIAGNOSTIC_MAX_CHARS } from '#src/coordinator/live/kb-daemon-supervisor.js';
 import {
   PROVIDER_HOST_TOMBSTONE_DIAGNOSTIC_BYTE_BUDGET,
   PROVIDER_HOST_TOMBSTONE_DIAGNOSTIC_FACT_BUDGET,
@@ -47,5 +48,19 @@ describe('provider-host diagnostics fit one IPC frame', () => {
   it('bounds retained facts as well as bytes, so neither alone can fill a frame', () => {
     expect(PROVIDER_HOST_TOMBSTONE_DIAGNOSTIC_FACT_BUDGET).toBeGreaterThan(0);
     expect(Number.isSafeInteger(PROVIDER_HOST_TOMBSTONE_DIAGNOSTIC_FACT_BUDGET)).toBe(true);
+  });
+
+  /**
+   * The provider host log was not the only place this equality lived. A dead KB daemon's whole retained
+   * stderr — capped at `MAX_BUFFER`, which is also ten mebibytes — became its `lastError`, so the health
+   * response overflowed a frame by exactly its own envelope and every operator command that reads daemon
+   * health failed at the moment the diagnostic mattered. Budgeted in characters rather than bytes, so the
+   * headroom has to absorb multi-byte output too.
+   */
+  it('keeps a dead daemon’s exit diagnostic well under the transport frame cap', () => {
+    const WORST_CASE_UTF8_BYTES_PER_CHAR = 4;
+    expect(KB_DAEMON_EXIT_DIAGNOSTIC_MAX_CHARS * WORST_CASE_UTF8_BYTES_PER_CHAR).toBeLessThan(
+      MAX_FRAME_BYTES * ENVELOPE_HEADROOM_RATIO,
+    );
   });
 });

--- a/tests/unit/engines/orama/metadata-ac1.test.ts
+++ b/tests/unit/engines/orama/metadata-ac1.test.ts
@@ -518,7 +518,10 @@ describe('Orama authoritative freshness', () => {
     });
   });
 
-  it('classifies metadata ahead of authority as unavailable', async () => {
+  // Stale, not unavailable: an artifact recording more applied than the authority ever had belongs to a
+  // corpus history this authority no longer has — a store reset leaves exactly this. As `unavailable` it was
+  // a hard apply error the cursor could never move past, so the retry that followed it never terminated.
+  it('classifies metadata ahead of authority as stale, so the projection rebuilds', async () => {
     const kb = createRuntime(allocateRoot('coral-orama-ahead-of-authority-'));
     await applyCurrentSnapshot(kb);
     const artifactPort = createOramaArtifactPort(kb.projectionArtifacts.files, kb.projectionArtifacts.runtimeDir, []);
@@ -527,7 +530,7 @@ describe('Orama authoritative freshness', () => {
     writeMetadata(kb, { ...metadata, contentSeq: metadata.contentSeq + 1 });
 
     await expect(artifactPort.readAuthoritativeFreshness(target)).resolves.toEqual({
-      kind: 'unavailable',
+      kind: 'stale',
       reason: 'ahead-of-authority',
     });
   });

--- a/tests/unit/projection-consumers/consumer-driver-waitfresh.test.ts
+++ b/tests/unit/projection-consumers/consumer-driver-waitfresh.test.ts
@@ -394,7 +394,7 @@ describe('ConsumerDriver waitFreshUntil', () => {
     }
   });
 
-  it.each(['malformed', 'probe-failed', 'ahead-of-authority'] as const)(
+  it.each(['malformed', 'probe-failed'] as const)(
     'fails closed and rejects waiters when authoritative freshness is unavailable: %s',
     async (reason) => {
       const apply = vi.fn(async () => {});
@@ -439,6 +439,76 @@ describe('ConsumerDriver waitFreshUntil', () => {
       }
     },
   );
+
+  /**
+   * An artifact ahead of the authority is a cache from a corpus history the authority no longer has — what a
+   * store reset leaves behind. Classified `unavailable` it was a hard apply error, so the cursor could never
+   * move past it and every retry hit the same wall. It is a rebuildable cache: rebuild it.
+   */
+  it('rebuilds instead of failing when the artifact is ahead of the authority', async () => {
+    const apply = vi.fn(async () => {});
+    const onApplyFailure = vi.fn();
+    const snapshot = buildSnapshot({ snapshotId: 'ahead', contentSeq: 4, metadataSeq: 4 });
+    const { db, driver, consumerId, handle } = createCorpusDriver(
+      apply,
+      REAL_CONSUMER_DRIVER_TIMERS,
+      onApplyFailure,
+      undefined,
+      async () => ({ kind: 'stale', reason: 'ahead-of-authority' }),
+    );
+
+    try {
+      const waitResult = driver.waitFreshUntil('corpus', snapshot, consumerId, 5000);
+      driver.notify('corpus', snapshot);
+      await driver.drainAll();
+
+      await expect(waitResult).resolves.toBeUndefined();
+      expect(apply).toHaveBeenCalledTimes(1);
+      expect(onApplyFailure).not.toHaveBeenCalled();
+      expect(handle.status()).toMatchObject({ authority: 'corpus', snapshotId: 'ahead', pending: false });
+    } finally {
+      await driver.shutdown();
+      db.close();
+    }
+  });
+
+  /**
+   * The load-bearing one. Orama's default failure callback asks for a reconcile, and a reconcile schedules
+   * another apply of the same consumer — so a failure that repeats identically is a cycle with no timer in
+   * it. That is how a KB daemon came to run ~50k applies per second for an hour. A callback that fires once
+   * per *distinct* failure keeps the repair request and drops the cycle.
+   */
+  it('notifies the failure callback once per distinct failure, not once per identical retry', async () => {
+    const onApplyFailure = vi.fn();
+    const snapshot = buildSnapshot({ snapshotId: 'repeat', contentSeq: 2, metadataSeq: 2 });
+    let failure = 'first failure';
+    const { db, driver } = createCorpusDriver(
+      async () => {
+        throw new Error(failure);
+      },
+      REAL_CONSUMER_DRIVER_TIMERS,
+      onApplyFailure,
+    );
+    const errorSpy = vi.spyOn(backendLog, 'error').mockImplementation((): void => {});
+
+    try {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        driver.notify('corpus', snapshot);
+        await driver.drainAll();
+      }
+      expect(onApplyFailure).toHaveBeenCalledTimes(1);
+
+      // A different failure is news the callback has not acted on yet.
+      failure = 'second failure';
+      driver.notify('corpus', snapshot);
+      await driver.drainAll();
+      expect(onApplyFailure).toHaveBeenCalledTimes(2);
+    } finally {
+      errorSpy.mockRestore();
+      await driver.shutdown();
+      db.close();
+    }
+  });
 
   it('fails closed when a consumer returns a false current proof', async () => {
     const apply = vi.fn(async () => {});


### PR DESCRIPTION
A live KB daemon was found at 100% CPU for 72 minutes straight — 211 million read syscalls, 266 GB against a 1.3 MB store — while writing nothing and answering no RPC, so KB mutations failed with `kb_unavailable`.

## Cause

A persisted Orama artifact recorded corpus sequence 53882 while the authority was at 10: a projection cache left behind by a store reset, belonging to a history the authority no longer has.

Classified `unavailable`, that became a hard apply error, so the cursor could never advance past it and every retry hit the same wall. Orama's default failure callback then turned *each* failure into a reconcile request; reconcile scheduled another apply of the same consumer; and because `forceCorpusApply` only bumps a generation and returns, the requester's single-flight guard cleared long before the apply it asked for. Failure fed its own retry through a promise microtask — no timer, no backoff, no attempt limit — at roughly 50,000 certain-to-fail applies a second.

## Change

Three things had to be true for that hour to happen, so all three change.

1. **An artifact ahead of the authority is stale, not unavailable.** It is a rebuildable cache; one from a history that no longer exists is worth exactly what a missing one is worth, and rebuilding costs only CPU. `malformed` and `probe-failed` stay `unavailable` — a corrupt or unreadable file is not the same claim as a cache from another history.
2. **An apply failure identical to the one before it no longer re-invokes the failure callback.** That callback exists so a consumer can request the repair that makes the next attempt succeed; an unchanged repeat means the last repair changed nothing. This is the general fix — it closes the cycle for any consumer and any future permanent failure, not just this trigger.
3. **The daemon's stderr reaches the backend log.** It had been accumulating in a capped in-memory buffer nobody reads, so a daemon that announced this exact failure 8.4 million times left a completely empty log. Consecutive identical lines collapse into a count, because 8.4 million copies of one sentence is a 1.4 GB log file and a full disk is not an improvement on silence.

## Not a regression

The feedback edge dates to v0.9.0 (`a432f6f2`), and every file involved is byte-identical to `v0.10.5`. The 0.10.6 deploy only supplied a boot that met the mismatch.

## Verification

Both behavioural changes mutation-verified to fail exactly their own test. Every gate green: tsc, typecheck:tests, lint, format, knip, build, unit (5918), simulation, integration, store-reset, e2e lifecycle, e2e store-reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)