### PR TITLE
fix: keep session-less job terminals out of the retention release pair

### DIFF
--- a/src/sessions/retention-release-pair-recovery-source.ts
+++ b/src/sessions/retention-release-pair-recovery-source.ts
@@ -26,6 +26,17 @@ export type RetentionReleasePairComponent =
       readonly jobId: string;
     };
 
+/**
+ * A retention pair is a session claim and the job terminal that releases it, so a terminal carrying no
+ * session has no claim to release and never belongs to this boundary. Workflow roots and KB jobs
+ * legitimately have none; admitting them fails hydration on a value the pair itself never reads.
+ * The targeted `pair` scan states this as equality against a concrete session and is already stricter.
+ */
+const RETENTION_PAIR_EVENT_PREDICATE = `(
+             type = 'session.claim.released'
+          OR (type = 'job.terminal.recorded' AND json_extract(refs, '$.sessionId') IS NOT NULL)
+        )`;
+
 function scanRetentionReleaseAndTerminalRows(
   db: Database,
   subjectKey?: string,
@@ -36,7 +47,7 @@ function scanRetentionReleaseAndTerminalRows(
       .prepare<[string], EventsRow>(
         `SELECT ${EVENT_COLUMNS}
            FROM events
-          WHERE type IN ('session.claim.released', 'job.terminal.recorded')
+          WHERE ${RETENTION_PAIR_EVENT_PREDICATE}
             AND seq = ?`,
       )
       .all(subjectKey);
@@ -63,7 +74,7 @@ function scanRetentionReleaseAndTerminalRows(
     .prepare<[], EventsRow>(
       `SELECT ${EVENT_COLUMNS}
          FROM events
-        WHERE type IN ('session.claim.released', 'job.terminal.recorded')
+        WHERE ${RETENTION_PAIR_EVENT_PREDICATE}
         ORDER BY seq ASC`,
     )
     .all();

--- a/tests/unit/recovery/source-revisions.test.ts
+++ b/tests/unit/recovery/source-revisions.test.ts
@@ -668,6 +668,32 @@ function createP4RevisionDb() {
   return db;
 }
 
+/**
+ * A workflow root has no provider session, so its terminal carries no `refs.sessionId`. It is a real
+ * durable shape, not corruption, and it must stay outside a boundary that pairs a session claim with the
+ * terminal releasing it.
+ */
+function insertSessionlessWorkflowTerminal(db: ReturnType<typeof createP4RevisionDb>, seq: number): void {
+  db.prepare(
+    `INSERT INTO events (
+       seq, ts, type, stream_kind, stream_id, namespace, project,
+       correlation_id, causation_seq, refs, body
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    seq,
+    P4_NOW,
+    'job.terminal.recorded',
+    'job',
+    'p4-workflow-root',
+    'p4-ns',
+    '/p4',
+    null,
+    null,
+    JSON.stringify({ jobId: 'p4-workflow-root' }),
+    Buffer.from('{"terminal":"workflow"}'),
+  );
+}
+
 function rawContinuationToken(raw: unknown): { readonly kind: string; readonly key: string } | null {
   if (typeof raw !== 'object' || raw === null || !('continuation' in raw)) return null;
   const continuation = raw.continuation;
@@ -862,6 +888,33 @@ async function quarantineFixedP4Composite(
 }
 
 describe('P4 recovery source revisions', () => {
+  it('keeps a session-less workflow terminal out of the retention release pair', async () => {
+    const db = createP4RevisionDb();
+    try {
+      insertSessionlessWorkflowTerminal(db, 5);
+      const quarantine = new RecoveryQuarantineStore(db, REVISION_TIME);
+      const scanned: number[] = [];
+
+      await RecoveryContainment.each(retentionReleasePairComponentSource(db), {
+        signal: new AbortController().signal,
+        quarantine,
+        processLocalCleanup: { kind: 'not-required' as const },
+        hydrate: (raw: RawRetentionReleaseAndTerminalRow) => raw,
+        requiredObligations: () => [],
+        settle: (raw: RawRetentionReleaseAndTerminalRow) => {
+          scanned.push(raw.seq);
+          return { kind: 'advanced' as const, outcome: 'settled' as const, facts: [], detail: 'observed' };
+        },
+        onFault: ({ error }) => ({ kind: 'fatal' as const, error }),
+      });
+
+      expect(scanned).toEqual([1, 2]);
+      expect(quarantine.list()).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
   it('re-attempts every row-granular component when its raw persisted bytes change', async () => {
     const cases: ReadonlyArray<{
       readonly name: string;


### PR DESCRIPTION
## What broke

`recovery: degraded` on any machine that runs workflows, from **0.10.5** onward. Observed on a live 0.10.6 daemon: 13 quarantine entries accumulated over a day, every one `job_kind=workflow`.

```
Runtime Components:
  recovery: degraded
    reason: recovery-quarantine (13 unresolved rows)
    last error: Job terminal event 44257 has no refs.sessionId.
```

## Why

A retention pair is a session claim and the job terminal that releases it. The discovery scan in `retention-release-pair-recovery-source.ts` selected **every** `job.terminal.recorded` with no predicate on the session, and `lifecycle-reactor.ts` then threw when `refs.sessionId` was absent.

A workflow root has no provider session, so its terminal legitimately has none — and can never take part in a retention pair. Terminals on this store, by kind:

| job_kind | terminals | no sessionId |
|---|---|---|
| provider | 219 | 0 |
| workflow | 13 | 13 |

Session assignment was never wrong. The reader assumed a session that a workflow root correctly does not have.

The same file already spelled the predicate correctly: the targeted `pair` query constrains the terminal to a concrete `sessionId`. Only the two unkeyed scans omitted it — one concept, two spellings, and the looser one runs on startup. They now share `RETENTION_PAIR_EVENT_PREDICATE`.

Introduced by #291, which is absent from 0.10.4 and present in 0.10.5, 0.10.6 and 0.10.7 — matching the reported "0.10.4 worked, everything after did not".

## Existing quarantine rows clear themselves

The retry scan is keyed by seq, so an entry quarantined under the old scan now finds nothing, and `containment.ts` retires it via `subjectAbsentDisposition()` — `authoritative source no longer contains the retry subject`. No operator cleanup step.

## Latent sibling

KB jobs also carry no session and sit on the same path; this machine simply had no KB job terminal yet. The single predicate covers both.

## Why no test caught it

The suites never drive a workflow-root terminal through this recovery source, so 6002 unit tests stayed green while the running daemon reported degraded. The regression test added here drives the real source through `RecoveryContainment` and was mutation-verified: reverting the predicate turns it RED with the production error, restoring it turns it GREEN.

## Scope

2 files, +66/-2, 15 of them source. No new invariants, no refactors, no ownership moves. Independent of #309 — that branch touches only `src/sessions/projections.ts` here, and this quarantine predates its first commit by 16 hours on a build that does not contain it.

## Gates

tsc · typecheck:tests · lint · format:check · knip · build · check:simulation · `npm test` 5966 passed · test:integration 543 passed · store-reset ×2 · e2e store-reset · build:dev + e2e:lifecycle · build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)