### PR TITLE
docs: bring seven open-work records onto main

### DIFF
--- a/docs/todo/cli-terminal-width-layout.md
+++ b/docs/todo/cli-terminal-width-layout.md
@@ -1,0 +1,53 @@
+# TODO — define one terminal-width policy for identity-rich CLI output
+
+**Status**: open. Split from PR #309 after the UX review established that the new identity fields expose a
+cross-command layout policy gap rather than one bad cell.
+
+## The problem
+
+Realistic identity rows exceed common terminal widths. A `jobs` row using the short label `critic` is already
+about 86 characters; a maximum-length label is about 103. A workflow-detail replacement row reaches roughly
+117 characters.
+
+`formatTable` receives no terminal-width input, so an 80-column terminal wraps cells and destroys alignment.
+List and detail therefore cannot respond to available width. Follow/wait does receive terminal width, but
+`renderWaitLine` only pads (`src/cli/format/wait.ts:144`); it never bounds the identity label, so prompt labels
+and terminal headers wrap as well.
+
+## Decision required
+
+Choose one responsive rendering policy and apply it consistently across jobs list, job/workflow detail, and
+follow/wait:
+
+- responsive columns with a deterministic priority for hiding or shortening fields;
+- vertical records below a width threshold; or
+- width-aware identity shortening with an unambiguous way to recover the full value.
+
+The policy must cover ordinary rows and replacement rows rather than special-casing the newly added field.
+Whichever shape is selected must preserve the distinction among job id, workflow slot label, generation, and
+replacement identity.
+
+## Required evidence
+
+Regression fixtures must render at exactly 80 columns with UUID job ids, maximum-length labels, and
+replacement rows. They must cover list, detail, and follow/wait so one surface cannot adopt a different
+shortening rule. Wider-terminal fixtures should prove the responsive policy does not unnecessarily discard
+information.
+
+## Why it is split
+
+This is a cross-cutting presentation policy affecting every table and the streaming follow renderer. A local
+truncation in `jobs` would leave detail and wait wrapping differently and could erase the identity distinction
+the current PR is adding.
+
+## Explicitly out of scope
+
+This item does not choose whether `coral-cli jobs` is an automation contract, add structured output, rename
+identity fields, or change backend response schemas. It also does not prescribe ANSI-aware measurement or a
+specific truncation glyph until the rendering policy is chosen.
+
+## Start condition
+
+Begin after one policy is selected for all three surfaces and its information-priority rules are written down.
+The implementation must have a shared width input at each renderer boundary and the 80-column assertions
+above before changing individual cells.

--- a/docs/todo/job-project-scope-from-work-dir.md
+++ b/docs/todo/job-project-scope-from-work-dir.md
@@ -1,0 +1,87 @@
+# TODO — record a job's project from where the work happens, not where the shell was
+
+**Status**: open. Found while dispatching parallel review agents during PR #309: six jobs launched with
+`--work-dir /home/kang/workspace/coral` from a scratchpad cwd became unwaitable from the directory they were
+working in. Not a defect in that PR; recorded separately.
+
+## The problem
+
+One launch request carries two different answers to "which project is this job for", and they disagree
+whenever `--work-dir` names something other than the caller's cwd.
+
+**Authorization already answers `workDir`.** For `sessions.create` and `workflow.run`,
+`src/transport/dispatch.ts:318-343` canonicalizes the request's `workDir` and returns it as the
+`authorizationRoot`; `projectRoot` is used only as the base for resolving a relative `workDir`. The
+capability decision at `:526-528` is therefore made against the directory the provider will actually run in.
+
+**The durable record answers cwd.** `src/cli/dispatch.ts:476` derives `projectRoot` from `process.cwd()`, and
+`buildTransportContextBody` (`:362`) puts that value on every request. The launch record stores it, so
+`projection_jobs.project_root` names the shell's directory rather than the work directory. There is no
+`--project-root` option on any launch command; changing the process cwd is the only way to move a job.
+
+**The two answers then collide at `wait`.** `jobs.wait` runs `rpcPorts.jobs.scopeCheck(jobs, projectRoot)`
+(`src/transport/dispatch.ts:786`) and rejects jobs whose stored `project_root` differs from the caller's, as
+`scope_mismatch` / HTTP 403. A job authorized against project A and doing its work in project A cannot be
+waited on from project A, because it was recorded under project B.
+
+Observed directly: a review job launched with `--work-dir /home/kang/workspace/coral` read and reviewed that
+repository, and `coral-cli jobs detail` reported
+`Project: /tmp/claude-1000/-home-kang-workspace-coral/<session>/scratchpad`.
+
+## Why this is not a security boundary today
+
+The initial reading — that `projectRoot` is a capability binding and must not be caller-chosen — does not
+hold for the top-level operator. `IPC_OPERATOR_PRINCIPAL` is `binding: { kind: 'unbound' }`
+(`src/transport/ipc/server.ts:57`), and `bindingSatisfies` returns `true` for an unbound principal whose
+subject is `operator` or `system` (`src/security/policy/authorize.ts:87-89`). The observed 403 came from
+`jobs.scopeCheck`, a bookkeeping comparison, not from `authorize()`. Nor is cwd less caller-chosen than
+`--work-dir`: `cd` is available to any caller.
+
+Binding is enforced for child principals, whose bound root arrives on the wire
+(`src/security/principal-wire.ts:66`) and is checked by `containsProjectRoot`
+(`src/security/policy/authorize.ts:98-101`) against the **requested** binding — which for launches is already
+the `workDir`. Deriving the recorded project from `workDir` therefore does not weaken that check; it records
+the value that check already uses.
+
+## Decision required
+
+Make one value answer the question. The straightforward form: record the job's `projectRoot` as the
+`authorizationRoot` — `workDir` when supplied, cwd otherwise — leaving cwd as the base for resolving a
+relative `--work-dir`. Because the fallback already unifies the two when `--work-dir` is omitted, only the
+explicit case changes.
+
+The alternative — keep cwd as the record and add an explicit `--project-root` to the launch commands — is
+worse: it adds a third input to a question that already has one too many answers, and it leaves the recorded
+project disagreeing with the authorization decision.
+
+What must be settled before implementing:
+
+- **Whether the record should be the work directory or its enclosing project.** A `--work-dir` pointing at a
+  subdirectory would otherwise register a new "project" per subdirectory and fragment `coral jobs`.
+- **Mixed-vintage listings.** `projection_jobs.project_root` is durable and is not rewritten, so jobs launched
+  before and after the change group differently for the retention window. Decide whether that is acceptable or
+  needs a read-time reconciliation.
+- **Every consumer of the value.** At minimum the `jobs list` cwd filter and its KB-job exemption
+  (`src/jobs/read-queries.ts`), `jobs.scopeCheck`, `jobs.abort`, the discuss and workflow launch paths, and the
+  no-coordinator `CoralStore` read surface. Enumerate them; they must move together or not at all.
+
+## Also worth fixing here
+
+- **The documented usage teaches the mistake.** `docs/skills.md:42` and the `ralph` skill instruct
+  `coral-cli <host> -b -i "…" --work-dir "<project root>" -d` and then `coral-cli wait jobs <id>`. Following
+  that from any other directory produces a job the same skill cannot wait on. Whatever is decided, the skill
+  text and `docs/skills.md` must stop implying that `--work-dir` selects the project.
+- **The failing input is invisible.** `formatJobDetail` prints `Project:` but never the directory the provider
+  ran in (`src/cli/format/jobs.ts`), so nothing on screen explains why a job landed where it did.
+
+## Explicitly out of scope
+
+This item does not change the capability model, the child-principal binding rules, `jobs.scopeCheck` as a
+mechanism, or the provider-host `--work-dir` resolver (`src/cli/commands/backend.ts:408-420`), which is a
+different selector over a live inventory and is correctly documented in `docs/configuration.md:277`.
+
+## Start condition
+
+Begin after the record-vs-enclosing-project question and the mixed-vintage listing policy are decided. The
+implementation must carry a test that launches with an explicit `--work-dir` and then waits on the job from
+that same directory — the case that fails today — plus the full consumer enumeration above.

--- a/docs/todo/jobs-list-structured-output.md
+++ b/docs/todo/jobs-list-structured-output.md
@@ -1,0 +1,46 @@
+# TODO — decide and expose the CLI jobs-output contract
+
+**Status**: open. Split from PR #309 after the UX review found a product-contract decision rather than a
+local table-formatting defect.
+
+## The problem
+
+`coral-cli jobs` renders the `SLOT` column only when at least one row occupies a workflow slot
+(`src/cli/format/jobs.ts:273`). Each project section makes that decision independently
+(`src/cli/format/jobs.ts:304,308,318`), so one invocation can contain both four- and five-column tables.
+
+A script expecting `JOB ID / PHASE / PROVIDER / AGE` begins reading the slot label as `PHASE` as soon as a
+workflow child appears. The command neither declares its table human-only nor offers a structured output
+mode. The HTTP `/jobs` response is already structured; the gap is specifically the CLI surface.
+
+## Decision required
+
+Choose one of two explicit contracts:
+
+1. **Stable tabular contract.** Fix the column schema for the command, including empty slot cells, and treat
+   headers/order/arity as compatibility surface. Add fixtures proving multiple project sections cannot choose
+   different arities.
+2. **Human-only table plus structured mode.** Document the existing table as presentation, not a parsing
+   contract, and add a separately named structured mode whose records are schema-validated and stable for
+   automation.
+
+The second branch may preserve responsive human formatting without making whitespace a protocol, but the
+mode name, encoding, versioning, and error behavior are product decisions that must be made explicitly.
+
+## Why it is split
+
+Adding structured output is a new user-facing CLI surface. Declaring the existing table stable would also
+create a compatibility promise that the command does not currently make. Neither decision follows merely
+from repairing the `SLOT` column, and the HTTP shape does not automatically settle CLI policy.
+
+## Explicitly out of scope
+
+This item does not change the `/jobs` HTTP response, pick JSON/JSONL or a flag name, redesign job identity, or
+solve terminal-width wrapping. Width policy is tracked separately because even a stable five-column table can
+still be unreadable at 80 columns.
+
+## Start condition
+
+Begin only after the CLI owner chooses which branch is the supported automation contract. The implementation
+must then include command help/documentation and regression tests for mixed project sections, empty/non-empty
+slots, and scripts consuming the selected stable surface.

--- a/docs/todo/jobs-read-contract-schema-first.md
+++ b/docs/todo/jobs-read-contract-schema-first.md
@@ -1,0 +1,66 @@
+# TODO — make jobs read contracts schema-first
+
+**Status**: open. Split from PR #309 after the round-5 design pass settled compatibility rules but found the
+conversion too broad for a workflow-identity change.
+
+## The problem
+
+Jobs list/detail responses cross producer, RPC, CLI dispatch, and formatting boundaries without one runtime
+schema as their authority. This PR added `workflowChildren` and `workflowLabel` along that unchecked path. A
+malformed backend response can reach `formatWorkflowChildren`, where `[...children]` throws instead of
+producing a controlled contract error (`src/cli/format/jobs.ts:199`).
+
+The core vocabulary lives as TypeScript-first records in `src/jobs/records.ts:69,246-274`, while `jobs.list`
+and `jobs.detail` lack response schemas in `src/transport/rpc/catalog.ts:254-271`. Producer values pass
+through `src/transport/dispatch.ts:812-840`, and `src/cli/dispatch.ts:582-585` requests typed values rather
+than parsing `unknown`. Approximately 33 consumers depend on the current types, so changing the source of
+those types is a cross-surface conversion, not a local annotation.
+
+## The decision
+
+Make the jobs read contract schema-first in `src/jobs/records.ts`, deriving TypeScript types from:
+
+- `jobStatusSchema` → `JobStatus`;
+- `jobEventSchema`;
+- `jobExitSchema`;
+- `workflowChildJobSummarySchema`;
+- `jobsListResponseSchema`;
+- `jobDetailResponseSchema`.
+
+The detail schema accepts `workflowChildren` as optional wire input and normalizes absence to `[]` at ingress.
+After that normalization, `src/cli/format/jobs.ts` must consume the canonical array without `?? []`.
+
+Add `responseSchema` for `jobs.list` and `jobs.detail` in `src/transport/rpc/catalog.ts`. Parse producer values
+in `src/transport/dispatch.ts`; in `src/cli/dispatch.ts`, request `unknown` and parse it rather than asserting a
+response type.
+
+## Compatibility rules already settled
+
+Response records are additive and unknown-key tolerant. Zod's default strip-on-parse behavior lets an older
+client consume a newer backend's optional additions without a cold upgrade. `.strict()` is therefore unsafe
+for list/detail envelopes, job rows, and statuses. It remains appropriate only for genuinely closed leaf
+values and separately negotiated request objects.
+
+Removing, renaming, or retyping an existing response field is not additive. Any such change requires an
+explicitly versioned or capability-gated protocol transition with mixed-build tests; schema-first ownership
+does not make breaking changes safe by itself.
+
+## Why it is split
+
+Converting a core type family with roughly 33 consumers, adding parsing on both producer and consumer sides,
+and pinning mixed-build behavior is too broad to hide inside a workflow slot/job identity PR. A partial
+conversion would be worse than the current visible gap because callers could not tell which types had runtime
+authority.
+
+## Explicitly out of scope
+
+This item does not redesign the jobs payload, remove additive fields, make envelopes strict, add a new
+transport version, or change CLI presentation. It does not implement structured CLI output; that is a
+separate decision.
+
+## Start condition
+
+Begin when the conversion can be done across all list/detail producers and consumers in one change, with
+contract tests covering malformed responses, missing `workflowChildren`, unknown additive keys, and both
+mixed-build directions. The TypeScript consumer inventory must be refreshed before editing so no cast path is
+left behind.

--- a/docs/todo/persistent-job-export-retention.md
+++ b/docs/todo/persistent-job-export-retention.md
@@ -1,0 +1,28 @@
+# TODO — define retention for persistent job exports
+
+**Status**: open. Recorded during PR #309 round-4 review on 2026-08-15 after the documented meaning of
+`CORAL_JOBS_RETENTION_DAYS` was compared with its cleanup target.
+
+## The gap
+
+Persistent job exports under `~/.coral/exports/jobs/<jobId>/` and the development sibling
+`~/.coral/exports-dev/jobs/<jobId>/` are never pruned. They can contain `result.md`, workflow-child
+`workflow.json`, and archived provider artifacts. `CORAL_JOBS_RETENTION_DAYS` does not govern either tree:
+`cleanupStaleJobs` removes only `<tmpdir>/coral-jobs/<jobId>/` runtime scratch plus the matching durable
+CLI-process runtime metadata.
+
+This is both a disk-usage and a privacy-retention gap. Shortening the existing setting does not shorten the
+lifetime of exported provider output or native-session archives.
+
+## Why this PR does not delete them
+
+Adding deletion now would silently change the lifetime of user data under an existing setting whose runtime
+behavior has never touched that directory. The retention contract needs an explicit operator decision before
+the code acquires destructive authority over exports.
+
+## Decision required
+
+Choose whether persistent exports use a separate setting or an explicitly broadened existing setting, define
+how archived provider artifacts participate, and specify recovery behavior for rebuildable `result.md` and
+`workflow.json` versus non-rebuildable archives. Only then should cleanup resolve and delete exact export
+directories.

--- a/docs/todo/proxy-set-acquisition-silent-abandonment.md
+++ b/docs/todo/proxy-set-acquisition-silent-abandonment.md
@@ -1,0 +1,105 @@
+# TODO — a coordinator can abandon provider-proxy acquisition permanently and silently
+
+**Status**: open. Found while investigating why one machine routed every provider operation through a
+proxy set on 0.10.6 while another, on the same build, never did.
+
+## The symptom
+
+Two machines, same build, opposite behaviour:
+
+- A freshly installed 0.10.6 routed provider operations through a proxy set.
+- A long-lived 0.10.6 coordinator (uptime 1d3h) ran every host coordinator-locally.
+  `backend provider-host list` reported `OWNER = coordinator:83afe3f9-…`, never `proxy:…`, and the
+  coordinator log contained **no proxy-related line at all** — not even a failure.
+
+Silent divergence is the problem. A coordinator that cannot acquire a proxy set keeps working: every
+operation falls back to `local-authorized` at
+`src/coordinator/services/provider-proxy-launch-route.ts`, so nothing fails and nothing is reported.
+The isolation the proxy exists to provide is simply gone, and no surface says so.
+
+## The mechanism
+
+`ensureProxySetFor` (`src/coordinator/live/provider-hosts/index.ts:334`) drops two of the four
+admission outcomes without a word:
+
+```ts
+const admission = lifecycle.beginFreshAcquisition(identityKey, { … });
+if (admission.kind !== 'accepted') {
+  if (admission.kind === 'capacity') {
+    backendLog.warn(`Provider proxy set acquisition refused for …`);
+  }
+  return;                       // startup-discovery-pending and already-represented: no log
+}
+```
+
+`beginFreshAcquisition` (`src/coordinator/services/provider-proxy-set/index.ts:322-359`) returns
+`startup-discovery-pending`, `already-represented`, `capacity`, or `accepted`. Only `capacity` is
+reported.
+
+`already-represented` is the one that sticks. It is returned when any slot holds that `routeKey` in
+`acquiring`, `available`, `draining`, `containing`, `containment-wait`, or
+`absence-delivery-pending`. Of those, only `available` produces a route. So a slot parked in a
+containment or drain state puts the coordinator in a state where:
+
+- `routeFor(identityKey)` returns `null`, so every operation takes the local fallback;
+- `beginFreshAcquisition` returns `already-represented`, so no new set is ever acquired;
+- nothing logs, and nothing retries.
+
+That combination is terminal for the life of the process. `ensureProxySetFor` is only reached from
+host acquisition (`:425`) and slot release (`:324`); neither re-runs once the slot is wedged.
+
+`startup-discovery-pending` has the same silence with a narrower window: a host acquired before
+`completeStartupDiscovery()` / `installDiscoveredCapsules()` runs is dropped, and nothing re-attempts
+acquisition for that entry after discovery completes.
+
+## Why this is worth fixing above its apparent severity
+
+It degrades a safety boundary into an unobserved one. #308 fixed an authority fault that reaped a
+whole proxy set while its operations were still executing — exactly the kind of event that can leave
+a slot in a containment state. If the reap is now survivable but the _re-acquisition_ is not, the
+coordinator quietly stops using the proxy for the rest of its uptime, and the next operator to look
+sees a healthy `backend status`.
+
+It also explains machine-to-machine divergence that currently looks like environment weirdness, and
+it changes what a bug report means: "works on my machine" can mean "my coordinator gave up on the
+proxy hours ago".
+
+## Decision required
+
+Three things, and the second is the actual design question:
+
+1. **Report the silent outcomes.** `already-represented` and `startup-discovery-pending` should be
+   observable. A log line is the floor; a `backend status` runtime-component signal is better,
+   because the condition persists and a startup-time log scrolls away.
+2. **Decide who re-attempts, and when.** Options: re-run `ensureProxySetFor` for live entries once
+   startup discovery completes; have slot-state transitions out of containment/drain trigger
+   acquisition rather than only `onSlotReleased`; or make `already-represented` carry the blocking
+   slot state so the caller can distinguish "a set is coming" from "a set is wedged". The last is the
+   most honest — the caller currently cannot tell those apart, which is why it does nothing.
+3. **Decide whether a wedged slot should be recoverable at all**, or whether it is a defect that
+   should surface as a fault instead of a fallback. Falling back to local is correct for a _transient_
+   gap; it is wrong as a permanent unannounced state.
+
+## Verify the hypothesis first
+
+The cheap decisive test was not run because a long job held the daemon: **restart the coordinator on
+the affected machine** and re-check `backend provider-host list`. A fresh process has empty slots, so
+if `OWNER` becomes `proxy:…` the wedged-slot explanation is confirmed and the work is re-acquisition,
+not acquisition. If it stays `coordinator:…`, the cause is earlier — look at
+`completeStartupDiscovery()` and whether `proxySetAcquisition` is configured on that path at all.
+
+Capture `backend provider-host inspect <ref>` before and after; the affected host showed
+`generation: 80`, so respawn history may be relevant.
+
+## Explicitly out of scope
+
+This item does not change the local-authorized fallback itself, the proxy control protocol, the
+containment model, or #308's authority-fault classification. It is about acquisition being abandoned
+without a signal and without a retry.
+
+## Start condition
+
+Begin after the restart experiment above settles whether this is a re-acquisition failure or an
+initial-acquisition failure. The implementation must include a test that wedges a slot in a
+containment state and asserts the coordinator either re-acquires or reports, rather than silently
+serving `local-authorized` forever.

--- a/docs/todo/wait-result-artifact-availability.md
+++ b/docs/todo/wait-result-artifact-availability.md
@@ -1,0 +1,74 @@
+# TODO — make terminal wait events explicit about result-artifact availability
+
+**Status**: open. Split from PR #309 after the round-5 design pass established the contract but also found a
+mixed-build wire transition that must be designed before implementation.
+
+## The decision
+
+Replace terminal wait events' speculative `resultPath` with a discriminated result-artifact availability
+contract. Artifact materialization failures must preserve the Journal terminal outcome, carry retry
+remediation, and never expose an unverified path as available. Define and test the legacy-wire transition
+before removing the old field.
+
+The replacement value is:
+
+```ts
+type ResultArtifactAvailability =
+  | { availability: 'available'; path: string }
+  | {
+      availability: 'unavailable';
+      reason: 'materialization_failed';
+      detail: string;
+      remediation: 'retry_wait';
+    };
+```
+
+Artifact availability is not part of terminal success. Exit status remains derived only from the durable
+Journal terminal outcome. The five post-commit artifact writers remain warning-only cache materializers; a
+filesystem failure must not rewrite lifecycle truth.
+
+## Evidence and present symptom
+
+The terminal arm of `WaitStreamEvent` exposes an unconditional `resultPath: string`
+(`src/jobs/wait.ts:68-77`).
+`WaitCoordinator.resultPathFor` catches an artifact rebuild failure and falls back to the expected filename
+(`src/jobs/shell/wait.ts:362-372`), even though that path has not been verified. The subscription validator
+accepts the same unconditional field (`src/jobs/wait-stream-event.ts:73-84`). The sole production
+`WaitCoordinator` construction already supplies `ensureResultArtifact`
+(`src/coordinator/execution-service.ts:108-120`); only the constructor interface
+(`src/jobs/shell/wait.ts:225`) and the four test constructors in `wait-sse-reconnect.test.ts`,
+`wait-carrier-observation.test.ts`, and `workflow-usage.test.ts` permit omission.
+
+Today `coral-cli wait` can therefore print `Result path: …/result.md` and exit 0 when the file does not exist.
+The exit code is correct for the durable job outcome; presenting the path as available is not.
+
+## Why it is split
+
+The value change is small, but the wait event is an established subscription protocol across mixed builds.
+An older CLI requires `resultPath`; a newer backend cannot supply one after materialization failure without
+lying. Removing or changing the field without a transition would convert a cache failure into an uncontrolled
+wire-parse failure.
+
+The settled transition direction is:
+
+- a verified legacy terminal event may retain its legacy path while both sides can represent only the old
+  shape;
+- an unavailable artifact becomes a controlled subscription error for clients that cannot represent the new
+  discriminant;
+- a new client consumes the discriminated value and presents `retry_wait` remediation instead of a path.
+
+The exact capability/version signal, fixtures for both directions, and removal point for `resultPath` remain
+to be specified and tested.
+
+## Explicitly out of scope
+
+This item does not make artifact creation lifecycle-authoritative, change terminal exit status, make the five
+post-commit writers fatal, move export files, or define export retention. It also does not change the
+zero-byte crash-path writers.
+
+## Start condition
+
+Begin only after the mixed-build protocol has executable contract tests for old client/new backend and new
+client/old backend, including both verified legacy paths and materialization failure. Then make
+`ensureResultArtifact` required by the `WaitCoordinator` constructor contract (the production wiring already
+exists), remove its filename fallback, and validate the discriminant at subscription ingress.


### PR DESCRIPTION
Seven `docs/todo/` entries were written while #309 was open and exist only on its branch, which is now closed — plus one that never left a local branch. This lands them on `main` unchanged.

They are the record of what was deliberately left undone during that work and why. Without them, each judgement has to be re-derived from the code.

## What lands

**Latent defects** — real, but nothing reaches them yet:

| File | What it records |
|---|---|
| `job-project-scope-from-work-dir` | Launch authorizes against `--work-dir`, but the durable record takes the project from the CLI's cwd. One request, two answers — and the source of the `scope_mismatch` 403 in #307 item 2. |
| `jobs-read-contract-schema-first` | `jobs.list` and `jobs.detail` cross producer, RPC, dispatch and formatter with no response schema. Includes the compatibility rules the design settled: additive and unknown-key tolerant, `.strict()` unsafe on the envelopes. |
| `persistent-job-export-retention` | `CORAL_JOBS_RETENTION_DAYS` prunes tmp scratch and the durable process-metadata row. Nothing prunes `exports/jobs/<id>/`, and no setting does. |
| `proxy-set-acquisition-silent-abandonment` | Acquisition drops two of four admission outcomes without logging, and one is returned for slot states that produce no route — so a coordinator can stop using the proxy for the rest of its uptime while `backend status` reads healthy. Includes the restart experiment that settles whether this is re-acquisition or initial acquisition. |

**Designed, with a transition to settle first:**

- `wait-result-artifact-availability` — replace the terminal event's speculative `resultPath` with a discriminated availability value, so a materialization failure preserves the journal outcome and never renders an unverified path as available. Split because evolving an established subscription event across mixed builds is a protocol change. Citations corrected in the last review round.

**Product decisions, not repairs:**

- `jobs-list-structured-output` — is the `jobs` table a stable contract for scripts, or human-only with a separate structured mode? Its column count currently changes with the data.
- `cli-terminal-width-layout` — one responsive policy across list, detail and follow. Identity rows already exceed 80 columns.

## Note

Contents are unchanged from where they were written. Three pre-existing files in `docs/todo/` fail `prettier --check` on `main` and are left alone; the seven added here pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)