### PR TITLE
fix: let a crashed workflow's result say what happened

### DIFF
--- a/src/coordinator/composition/defaults.ts
+++ b/src/coordinator/composition/defaults.ts
@@ -151,15 +151,7 @@ export function resolveCoordinatorDefaults(
         ((message, signal) => {
           const progressStore = bindings.getProgressStore();
           if (progressStore === null) return;
-          return markJobsAsError(
-            progressStore,
-            message,
-            runtime.storage,
-            runtime.paths.coral.exports.jobsRoot,
-            runtime.time.now(),
-            signal,
-            (cb) => progressStore.commit(cb),
-          );
+          return markJobsAsError(progressStore, message, runtime.time.now(), signal, (cb) => progressStore.commit(cb));
         });
       const terminateAllFn = options.terminateAllFn ?? (() => bindings.launchCoordinator.terminateAll());
 

--- a/src/coordinator/lifecycle.ts
+++ b/src/coordinator/lifecycle.ts
@@ -16,7 +16,6 @@ import { isTerminalPhase } from '../jobs/phase.js';
 import { parsePositiveInt } from './live/worker-limits.js';
 import { createRecoveryCoordinator, type RecoveryCoordinator } from './services/recovery/index.js';
 import { createReplacementBackendOwnershipChecker } from './ownership-checker.js';
-import { writeResultArtifact } from '../jobs/terminal/export.js';
 import type { JobStore } from '../jobs/store.js';
 import type { JobStatus } from '../jobs/records.js';
 import { jobLaunchRequestBodySchema } from '../jobs/launch.js';
@@ -369,8 +368,6 @@ type StaleJobCleanupPolicyContext = {
 type CrashedJobTerminalizationPolicyContext = {
   readonly progressStore: JobStore;
   readonly message: string;
-  readonly storage: Pick<Runtime['storage'], 'mkdirSync' | 'writeAtomicSync'>;
-  readonly jobsRoot: string;
   readonly endTimeMs: number;
   readonly coordinatorCommit: CommitEventsFn;
 };
@@ -427,7 +424,7 @@ function createStaleJobCleanupPolicy(
 function createCrashedJobTerminalizationPolicy(
   context: CrashedJobTerminalizationPolicyContext,
 ): RecoveryRetryPolicy<RawCrashedJobRow, CrashedJobTerminalizationItem> {
-  const { progressStore, message, storage, jobsRoot, endTimeMs, coordinatorCommit } = context;
+  const { progressStore, message, endTimeMs, coordinatorCommit } = context;
   return {
     processLocalCleanup: { kind: 'not-required' },
     hydrate: (raw) => hydrateCrashedJob(raw, progressStore),
@@ -456,13 +453,10 @@ function createCrashedJobTerminalizationPolicy(
         });
         return undefined;
       });
-      if (status.jobKind === 'workflow') {
-        try {
-          writeResultArtifact(storage, jobsRoot, status.jobId, '');
-        } catch {
-          // Journal terminal state is authoritative; export materialization is best-effort.
-        }
-      }
+      // No export is written here on purpose. The terminal committed above already carries the crash
+      // fault, so `ensureResultMarkdownArtifact` renders it on the next read. Writing a placeholder
+      // instead makes that read a no-op — the file exists, so it is never regenerated — and the
+      // operator is handed a path to an empty file for a failure Coral can describe exactly.
       return {
         kind: 'advanced',
         outcome: 'settled',
@@ -562,13 +556,11 @@ export async function cleanupStaleJobs(
 export async function markJobsAsError(
   progressStore: JobStore,
   message: string,
-  storage: Pick<Runtime['storage'], 'mkdirSync' | 'writeAtomicSync'>,
-  jobsRoot: string,
   endTimeMs: number,
   signal: AbortSignal,
   coordinatorCommit: CommitEventsFn,
 ): Promise<void> {
-  const context = { progressStore, message, storage, jobsRoot, endTimeMs, coordinatorCommit };
+  const context = { progressStore, message, endTimeMs, coordinatorCommit };
   crashedJobTerminalizationRetryContexts.set(progressStore.getDb(), context);
   const policy: RecoveryPolicy<RawCrashedJobRow, CrashedJobTerminalizationItem> = {
     signal,

--- a/src/coordinator/services/recovery/actions.ts
+++ b/src/coordinator/services/recovery/actions.ts
@@ -10,7 +10,6 @@ import type { RecoveryRegistry } from '../../../jobs/reconcile/registry.js';
 import type { Runtime } from '../../../runtime/ports.js';
 import type { ProviderRecoveryAuthority, RecoveryCapableService } from '../../../jobs/reconcile/contracts.js';
 import type { RecoveryCommitFence } from '../../../jobs/reconcile/contracts.js';
-import { writeResultArtifact } from '../../../jobs/terminal/export.js';
 import { gracefulKillByPid } from '../../../infra/process-supervision.js';
 import type { JobLifecycleFault, JobProgressFault } from '../../../jobs/outcome.js';
 import type { RecoveryObligationId, RecoverySettlementFact } from '../../../recovery/containment.js';
@@ -77,15 +76,11 @@ function markRecoveryError(
   action: Extract<RecoveryAction, { type: 'markError' }>,
   ctx: RecoveryActionContext,
 ): readonly RecoverySettlementFact[] {
-  const { runtime, log, settleFault } = ctx;
+  const { log, settleFault } = ctx;
   const facts = settleFault(action.fault);
-  if (action.status.jobKind === 'workflow') {
-    try {
-      writeResultArtifact(runtime.storage, runtime.paths.coral.exports.jobsRoot, action.status.jobId, '');
-    } catch (error: unknown) {
-      log(`Failed to write result artifact for ${action.status.jobId}: ${formatError(error)}\n`);
-    }
-  }
+  // Deliberately no export write. The settled fault is the durable answer, and
+  // `ensureResultMarkdownArtifact` renders it on the next read; an empty placeholder would satisfy the
+  // existence check that guards regeneration and leave that answer permanently unreachable.
   switch (action.fault.kind) {
     case 'missing_launch_record':
       log(`Marked live job with missing launch record: ${action.jobId}\n`);

--- a/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
+++ b/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
@@ -1766,13 +1766,6 @@ describe('lifecycle recovery', () => {
         await modules.lifecycleModule.markJobsAsError(
           progressStore,
           message,
-          {
-            mkdirSync: () => {},
-            writeAtomicSync: () => {
-              throw new Error('injected workflow result export failure');
-            },
-          } as never,
-          runtime.paths.coral.exports.jobsRoot,
           runtime.time.now(),
           signal,
           createTestJobJournalDeps(progressStore, runtime).coordinatorCommit,

--- a/tests/unit/jobs/store.test.ts
+++ b/tests/unit/jobs/store.test.ts
@@ -269,6 +269,27 @@ describe('JobStore', () => {
     expect(store.loadJobProjectionDetail(jobId).exit?.diagnostics.byteCounts).toEqual({ stdout: 123, stderr: 45 });
   });
 
+  it('renders a crashed workflow root from its terminal instead of an empty placeholder', () => {
+    const { runtime, store } = createStore();
+    const workflowJobId = '44444444-4444-4444-8444-444444444444';
+    const sessionId = 'session-crashed-workflow';
+
+    initProviderJob(store, workflowJobId, sessionId);
+    // Exactly what crash terminalization commits: no content, and a fault that describes itself.
+    commitJobTerminal(store, workflowJobId, sessionId, {
+      content: '',
+      outcome: { kind: 'job_fault', fault: { kind: 'wrapper_crashed', cause: { message: 'Backend shutting down' } } },
+      durationMs: 0,
+    });
+
+    const resultPath = store.ensureResultArtifact(workflowJobId);
+
+    // Before, crash terminalization wrote '' here first. The file then existed, so this read returned it
+    // unchanged and the operator was handed a path to nothing for a failure Coral could describe exactly.
+    expect(runtime.storage.readFileSync(resultPath, 'utf-8')).toContain('Backend shutting down');
+    expect(runtime.storage.readFileSync(resultPath, 'utf-8').trim().length).toBeGreaterThan(0);
+  });
+
   it('rebuilds a pre-existing raw workflow child artifact with its durable slot identity', () => {
     const { runtime, store } = createStore();
     const childJobId = '11111111-1111-4111-8111-111111111111';


### PR DESCRIPTION
Closes #307 item 4.

## The bug

A crashed workflow prints `Result path: …/result.md` and the file is 0 bytes. Following the documented "read the artifact" step yields nothing, so the only diagnosis available is the `wait` output that already scrolled past.

## The cause

Not a missing renderer — two deliberate writes of the empty string.

`src/coordinator/lifecycle.ts` commits a terminal carrying the wrapper-crash fault, and four lines later writes `''` over the export. `src/coordinator/services/recovery/actions.ts` does the same on `markError`. Then `ensureResultMarkdownArtifact` short-circuits on the file existing for any job whose `parent_workflow_job_id` is null — which a workflow root's always is — so the placeholder is **never repaired**.

The description was available the whole time. `buildResultMarkdown` falls through to `describeTerminalOutcome` exactly when `terminal.content` is empty, which is the shape every crash terminal has. The empty write was never "we have nothing to say"; it was "we did not ask".

## The change

Delete both writes. The next read renders the fault from the durable terminal.

Removing them leaves `storage` and `jobsRoot` with no reader on that path, so they come off `markJobsAsError` and its policy context rather than remaining in the signature as a claim the function no longer makes. Two call sites, both updated.

## Test

`tests/unit/jobs/store.test.ts` — commits the exact terminal crash terminalization produces (empty content, `job_fault` / `wrapper_crashed`) and asserts the artifact contains the fault message.

Mutation-verified: reintroducing the pre-write inside the test turns it RED, because `ensureResultArtifact` then returns the placeholder untouched. Restoring turns it GREEN.

## Scope

5 files, +32/−39. No wire change, no schema change, no store contract change.

Deliberately **not** included: `docs/todo/wait-result-artifact-availability.md`. That records a different, never-observed defect — `WaitCoordinator` substituting an unverified filename when rebuild *throws* — and it needs a mixed-build subscription transition. It is worth re-scoring now that the common failure is gone; shipping it alone would have reported this 0-byte file as `availability: 'available'`.

## Gates

tsc · typecheck:tests · lint · format:check · knip · build · check:simulation · `npm test` 5983 passed · test:integration 543 passed · store-reset ×2 · e2e store-reset · build:dev + e2e:lifecycle · build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)