### PR TITLE
fix: defer a job whose record this build cannot read, instead of ending it

### DIFF
--- a/src/coordinator/services/recovery/index.ts
+++ b/src/coordinator/services/recovery/index.ts
@@ -1,4 +1,7 @@
+import { ZodError } from 'zod';
+
 import { errorMessage, formatError } from '../../../infra/error-format.js';
+import { StoreDecodeError } from '../../../store/body-codec.js';
 import { ProcessContainmentError } from '../../../infra/process-containment.js';
 import { isTerminalPhase } from '../../../jobs/phase.js';
 import { isAppServerRuntime, type JobTerminalInput } from '../../../jobs/records.js';
@@ -594,6 +597,17 @@ export function createRecoveryCoordinator(
       emitSessionReleased: (payload) => eventBus.emit('session:released', payload),
     });
 
+  /**
+   * A record this build cannot read is not a job that failed. The provider process and its session
+   * outlive the coordinator on purpose — adoption exists so a wrapper lost across a restart or an
+   * upgrade reattaches instead of destroying the work it was supervising. When two builds disagree
+   * about a durable shape, the honest answer is that this coordinator cannot speak for the subject,
+   * which is what the quarantine boundary already holds. Terminalizing instead spends the provider's
+   * work to settle a question about our own schema.
+   */
+  const isUninterpretableRecord = (error: unknown): boolean =>
+    error instanceof StoreDecodeError || error instanceof ZodError;
+
   const settleUnexpectedRecoveryFailure = (
     item: CoordinatorRecoveryItem,
     jobId: string,
@@ -602,6 +616,11 @@ export function createRecoveryCoordinator(
     coordinatorCommit: CommitEventsFn,
     report: (message: string) => void,
   ): RecoveryDisposition => {
+    if (isUninterpretableRecord(error)) {
+      report(`${summary} for ${jobId}: ${errorMessage(error)}. Left for a build that can read it.\n`);
+      return { kind: 'quarantine', detail: `${summary}: record unreadable by this build` };
+    }
+
     const facts = settleFault(
       item,
       jobId,

--- a/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
+++ b/tests/unit/jobs/reconcile/lifecycle-recovery.test.ts
@@ -1,4 +1,5 @@
 import { currentCoralStoreFormat } from '#src/store-format.js';
+import { ZodError } from 'zod';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { allocateTestSession } from '../../../helpers/session.js';
 import { fixtureCanonicalWorkDir } from '../../../helpers/canonical-work-dir.js';
@@ -3641,6 +3642,75 @@ describe('lifecycle recovery', () => {
         );
         expect(reader.get('codex', sessionId)?.activeJobId).toBeUndefined();
         expect(reader.claimForJobSync(sessionId, `${jobId}-later`)).toBe(true);
+      } finally {
+        await stopLifecycleController(controller);
+      }
+    },
+  );
+
+  it.each(['queued', 'running'] as const)(
+    '14c6. an unreadable %s record is quarantined, not terminalized',
+    async (recoveryKind) => {
+      const modules = await loadModules();
+      const pluginRoot = createPluginRoot(`plugin-${recoveryKind}-unreadable-record`);
+      const namespace = modules.pathsModule.pluginRootNamespace(pluginRoot);
+      const projectRoot = createProjectRoot(`project-${recoveryKind}-unreadable-record`);
+      const eventBus = new modules.eventBusModule.TypedEventBus();
+      const db = openTestStoreDb(runtime, ':memory:');
+      const progressStore = new modules.progressStoreModule.JobStore(namespace, runtime, createEventBodyCodec(), {
+        db,
+        eventBus,
+        providers: permissiveProviderLookupPort,
+      });
+      const launchCoordinator = createLaunchCoordinator(modules);
+      const providerRegistry = createRecoveryProviderRegistry(modules);
+      const service = createActualRecoveryService(modules, {
+        progressStore,
+        eventBus,
+        launchCoordinator,
+        providerRegistry,
+        pluginRoot,
+        projectRoot,
+      });
+      const jobId = `${recoveryKind}-unreadable-record-job`;
+      const sessionId = `${jobId}-session`;
+
+      stubLaunchRecord(progressStore, {
+        jobId,
+        sessionId,
+        provider: 'codex',
+        projectRoot,
+        backendNamespace: namespace,
+      });
+      if (recoveryKind === 'queued') {
+        appendQueuedEvent(progressStore, jobId, sessionId, namespace, projectRoot);
+      } else {
+        stubRuntimeRecord(progressStore, { jobId, pid: process.pid });
+      }
+      // What a build that cannot read a newer durable shape actually throws. The provider's session
+      // outlives this coordinator, so adoption must be deferred rather than spent.
+      vi.spyOn(progressStore, 'rebindNamespace').mockImplementationOnce(() => {
+        throw new ZodError([
+          { code: 'invalid_type', expected: 'string', received: 'undefined', path: ['turnId'], message: 'Required' },
+        ]);
+      });
+
+      const { controller } = createLifecycleHarness(modules, {
+        pluginRoot,
+        progressStore,
+        eventBus,
+        launchCoordinator,
+        providerRegistry,
+        servicesByProjectRoot: new Map([[projectRoot, service]]),
+      });
+
+      try {
+        await controller.start();
+
+        expect(progressStore.readStatus(jobId)?.phase).not.toBe('error');
+        expect(
+          progressStore.getDb().prepare(`SELECT state FROM recovery_quarantine WHERE subject_key = ?`).get(jobId),
+        ).toMatchObject({ state: 'active' });
       } finally {
         await stopLifecycleController(controller);
       }


### PR DESCRIPTION
First half of `docs/todo/build-identity-and-upgrade.md`.

## What broke

Four running jobs terminalized together at `07:53:47` on 2026-08-15, each after ~299s, on a machine where the only change was a plugin update from 0.10.6 to 0.10.8. All four recorded:

```
kind: failed
causeRef → recovery_parse_failed
  'Running recovery adoption failed: [ … Zod invalid_union … ]'
```

The failing issue was `path: turnId, code: invalid_type, Required`.

## Why

Updating the plugin swaps the CLI and skills immediately; the running coordinator does not swap. The daemon still reported `0.10.6` while the environment it handed spawned children carried `0.10.8/bin` on `PATH`. In that window a newer writer's durable record has to be read by an older coordinator, and the two builds disagree about `turnId`.

`settleUnexpectedRecoveryFailure` labelled *every* adoption failure `recovery_parse_failed` and settled it as a **terminal** fault. So the first record the coordinator could not parse became a job the coordinator destroyed.

## Why that is wrong regardless of the schema

The provider process and its session outlive the coordinator **on purpose**. `adoptRunningJob` exists so a wrapper lost across a restart or an upgrade reattaches instead of spending the work it was supervising — and it branches on transport, not provider, so this is not codex-specific.

The evidence that the work was recoverable: all four sessions from that incident are still `state: ready`. Coral did not destroy the provider's work. It destroyed its own record of it.

A build that cannot read a record cannot speak for the subject. That is exactly what the quarantine boundary already holds, and `{ kind: 'quarantine' }` was already an available disposition.

## The change

One predicate at the shared settlement point:

```ts
const isUninterpretableRecord = (error: unknown): boolean =>
  error instanceof StoreDecodeError || error instanceof ZodError;
```

A decode or schema error quarantines and leaves the job live. **Every other error keeps today's behaviour** — those are failures, not disagreements about our own shape.

All four call sites go through this function (`queued adoption`, `running adoption`, `adopted durable finalization`, `registration`), so one change covers them without touching four call sites.

## Test

`tests/unit/jobs/reconcile/lifecycle-recovery.test.ts` — parameterized over queued and running. Throws the exact `ZodError` shape observed (`turnId` required) from adoption, then asserts the job's phase is **not** `error` and a `recovery_quarantine` row is `active`.

Mutation-verified: disabling the predicate turns both RED; restoring turns both GREEN.

## Scope

2 files, +89. No wire change, no schema change, no store contract change.

**Not** included: the window itself. Preventing a new CLI from writing records an old coordinator will read is the second half of that TODO, needs the handoff-preflight behaviour established first, and shares a compatibility policy with `jobs-read-contract-schema-first.md`.

## Gates

tsc · typecheck:tests · lint · format:check · knip · build · check:simulation · `npm test` 5985 passed · test:integration 543 passed · store-reset ×2 · e2e store-reset · build:dev + e2e:lifecycle · build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)