### PR TITLE
test: let the simulation restart a coordinator on the world it was running

### DIFF
--- a/tools/simulation/adversarial.ts
+++ b/tools/simulation/adversarial.ts
@@ -1,7 +1,12 @@
 import { join } from 'node:path';
 import { SessionManager } from '../../src/sessions/shell.js';
 import type { CoordinatorServerInfo, LifecycleState } from '../../src/coordinator/lifecycle.js';
-import { createSimulationBackend, type SimulationBackend, type SimulationHookLog } from './core/backend.js';
+import {
+  createSimulationBackend,
+  type SimulationBackend,
+  type SimulationHookLog,
+  type SimulationWorldCarryOver,
+} from './core/backend.js';
 import { DEFAULT_EPOCH_MS } from './core/virtual-time.js';
 import {
   acquireNoRealIoMonitor,
@@ -144,14 +149,43 @@ export class SimulationWorld {
     };
   }
 
-  async cycle(): Promise<CoordinatorServerInfo> {
+  /**
+   * `preserveWorld` restarts the coordinator on the world it was already running: same filesystem,
+   * same process table, same journal. That is the only shape in which recovery adoption is reachable,
+   * because a job can only be adopted from durable state that outlived the coordinator that wrote it.
+   * Without it the next generation starts on a fresh machine and has nothing to adopt.
+   */
+  async cycle(options?: { preserveWorld?: boolean }): Promise<CoordinatorServerInfo> {
     this.assertUsable();
     this.elapsedOffsetMs = this.getVirtualElapsedMs();
-    await this.current.backend.backend.shutdown('cycle');
+    const carryOver = options?.preserveWorld === true ? this.current.backend.carryOver : undefined;
+    // A restart that keeps its world is a replacement, not a crash: `shutdownModeFromReason` only
+    // treats 'replaced' and 'sigterm' as a handoff, and a hard stop terminalizes the very jobs the
+    // next generation is supposed to adopt.
+    await this.current.backend.backend.shutdown(carryOver === undefined ? 'cycle' : 'replaced');
     await this.current.backend.backend.waitForShutdown();
     this.generationIndex += 1;
-    this.current = this.createGenerationState();
+    this.current = this.createGenerationState(carryOver);
     return this.boot();
+  }
+
+  /**
+   * Rewrite a stored event body into a shape this build cannot decode — the exact durable condition a
+   * newer build's writer leaves behind when the two disagree about a field. It is not corruption: the
+   * row is well-formed for whoever wrote it, and unreadable only here.
+   */
+  writeForeignRecord(eventType: string): number {
+    this.assertUsable();
+    const db = this.current.backend.progressStore.getDb();
+    const row = db
+      .prepare<[string], { seq: number }>(`SELECT seq FROM events WHERE type = ? ORDER BY seq DESC LIMIT 1`)
+      .get(eventType);
+    if (row === undefined) throw new Error(`No '${eventType}' event exists to rewrite.`);
+    db.prepare<[Buffer, number]>(`UPDATE events SET body = ? WHERE seq = ?`).run(
+      Buffer.from(JSON.stringify({ transport: 'durable-cli', writtenByANewerBuild: true }), 'utf-8'),
+      row.seq,
+    );
+    return row.seq;
   }
 
   async shutdown(reason = 'simulation-shutdown'): Promise<void> {
@@ -389,6 +423,34 @@ export class SimulationWorld {
     }
   }
 
+  /**
+   * Read straight from the quarantine table. Every decoded read surface is unavailable while the world
+   * holds a record this build cannot parse, which is the condition these scenarios create — so this is
+   * the only way to assert that a job was deferred rather than ended.
+   */
+  quarantinedSubjects(): string[] {
+    this.assertUsable();
+    return this.current.backend.progressStore
+      .getDb()
+      .prepare<[], { subject_key: string }>(`SELECT subject_key FROM recovery_quarantine WHERE state = 'active'`)
+      .all()
+      .map((row) => row.subject_key);
+  }
+
+  /**
+   * Count terminal events straight from the journal. "The job was not ended" is the contract these
+   * scenarios assert, and every decoded surface is unavailable while the world holds a record this
+   * build cannot parse.
+   */
+  terminalEventCount(): number {
+    this.assertUsable();
+    const row = this.current.backend.progressStore
+      .getDb()
+      .prepare<[], { total: number }>(`SELECT COUNT(*) AS total FROM events WHERE type = 'job.terminal.recorded'`)
+      .get();
+    return row?.total ?? 0;
+  }
+
   listJobIds(): string[] {
     this.assertUsable();
     return this.current.backend.progressStore.listJobIds();
@@ -488,8 +550,8 @@ export class SimulationWorld {
     }
   }
 
-  private createGenerationState(): WorldGenerationState {
-    const backend = createSimulationBackend(normalizeWorldConfig(this.initialConfig));
+  private createGenerationState(inherited?: SimulationWorldCarryOver): WorldGenerationState {
+    const backend = createSimulationBackend(normalizeWorldConfig(this.initialConfig), inherited);
     const phaseTransitions = new Map<string, Array<{ previousPhase: string; phase: string }>>();
 
     backend.eventBus.on('job:phase_changed', ({ jobId, previousPhase, phase }) => {
@@ -507,12 +569,28 @@ export class SimulationWorld {
 
   private observeJob(jobId: string): WaitObservation {
     const status = this.current.backend.progressStore.readStatus(jobId);
-    const replay = this.replay(jobId);
+    // A world can legitimately hold an event this build cannot decode — that is the whole subject of
+    // the upgrade scenarios. Replay is a convenience here; the projection is what the assertions are
+    // about, so an unreadable event must not stop the harness from observing the job at all.
+    let replay: readonly JobEvent[];
+    try {
+      replay = this.replay(jobId);
+    } catch {
+      replay = [];
+    }
     const replayTerminalSeen = replay.some((event) => event.type === 'terminal');
+
+    let runtimeRecorded: boolean;
+    try {
+      runtimeRecorded = this.current.backend.progressStore.readRuntimeProjection(jobId) !== null;
+    } catch {
+      // An unreadable runtime record is still a recorded one — that is precisely the state under test.
+      runtimeRecorded = true;
+    }
 
     return {
       phase: status?.phase ?? null,
-      runtimeRecorded: this.current.backend.progressStore.readRuntimeProjection(jobId) !== null,
+      runtimeRecorded,
       terminal:
         replayTerminalSeen ||
         Boolean(status?.result) ||

--- a/tools/simulation/core/backend.ts
+++ b/tools/simulation/core/backend.ts
@@ -553,6 +553,8 @@ export type SimulationController = {
 export type SimulationBackend = {
   backend: SimulationController;
   runtime: SimulationRuntime;
+  /** Hand to a later `createSimulationBackend` to restart the coordinator on this same world. */
+  carryOver: SimulationWorldCarryOver;
   eventBus: TypedEventBus;
   progressStore: JobStore;
   launchCoordinator: LaunchCoordinator;
@@ -568,13 +570,29 @@ export type SimulationBackend = {
   advance: (ms: number) => Promise<void>;
 };
 
-export function createSimulationBackend(scenario: SimulationScenario = {}): SimulationBackend {
-  const runtimeRoot = mkdtempSync(join(tmpdir(), 'coral-sim-backend-'));
-  const runtime = new SimulationRuntime({
-    epochMs: scenario.epochMs,
-    env: scenario.env,
-    roots: { coralRoot: runtimeRoot },
-  });
+/**
+ * What a coordinator restart leaves behind: the machine's filesystem, its process table, and its
+ * journal. Passing this into a later generation models restarting the coordinator; omitting it models
+ * starting on a fresh machine, which is what a bare `cycle` has always done.
+ */
+export type SimulationWorldCarryOver = Readonly<{
+  runtimeRoot: string;
+  runtime: SimulationRuntime;
+  storeDb: ReturnType<typeof openStoreDatabase>;
+}>;
+
+export function createSimulationBackend(
+  scenario: SimulationScenario = {},
+  inherited?: SimulationWorldCarryOver,
+): SimulationBackend {
+  const runtimeRoot = inherited?.runtimeRoot ?? mkdtempSync(join(tmpdir(), 'coral-sim-backend-'));
+  const runtime =
+    inherited?.runtime ??
+    new SimulationRuntime({
+      epochMs: scenario.epochMs,
+      env: scenario.env,
+      roots: { coralRoot: runtimeRoot },
+    });
   mkdirSync(runtime.paths.coral.store.dbDir, { recursive: true });
   for (const spawnScript of scenario.spawn ?? []) {
     runtime.spawner.enqueueSpawn(spawnScript);
@@ -585,6 +603,9 @@ export function createSimulationBackend(scenario: SimulationScenario = {}): Simu
 
   const pluginRoot = scenario.pluginRoot ?? DEFAULT_PLUGIN_ROOT;
   const projectRoot = scenario.projectRoot ?? DEFAULT_PROJECT_ROOT;
+  // Recovery canonicalizes a launch record's project root against the real filesystem, so a scenario
+  // that restarts the coordinator needs this path to exist. Nothing before adoption ever read it.
+  mkdirSync(projectRoot, { recursive: true });
   const namespace = runtime.paths.pluginRootNamespace(pluginRoot);
   const eventBus = new TypedEventBus();
   const providerRegistry = new ProviderRegistry();
@@ -592,11 +613,13 @@ export function createSimulationBackend(scenario: SimulationScenario = {}): Simu
   providerRegistry.register(fakeProvider);
   const storeFormat = describeCoralStoreFormat(providerRegistry);
   const providerScope = simulationProviderScope(fakeProvider.name);
-  const storeDb = openStoreDatabase({
-    path: ':memory:',
-    storage: runtime.storage,
-    storeFormat,
-  });
+  const storeDb =
+    inherited?.storeDb ??
+    openStoreDatabase({
+      path: ':memory:',
+      storage: runtime.storage,
+      storeFormat,
+    });
   const progressStore = new JobStore(namespace, runtime, createEventBodyCodec(), {
     eventBus,
     db: storeDb,
@@ -882,6 +905,7 @@ export function createSimulationBackend(scenario: SimulationScenario = {}): Simu
   return {
     backend,
     runtime,
+    carryOver: { runtimeRoot, runtime, storeDb },
     eventBus,
     progressStore,
     launchCoordinator,

--- a/tools/simulation/runner.ts
+++ b/tools/simulation/runner.ts
@@ -91,8 +91,14 @@ function resolveJobTarget(jobId: string | undefined, cursor: RunnerCursor, actio
   };
 }
 
-function resetCursor(cursor: RunnerCursor): void {
+/**
+ * A fresh generation knows nothing about the previous one's launches. When the world is preserved the
+ * jobs are still there to be adopted, so the cursor keeps pointing at them — otherwise a scenario could
+ * restart the coordinator and then have no way to name the job it is asking about.
+ */
+function advanceCursor(cursor: RunnerCursor, preserveWorld: boolean): void {
   cursor.generation += 1;
+  if (preserveWorld) return;
   cursor.currentJobId = null;
   cursor.launchedJobIds.clear();
 }
@@ -106,6 +112,8 @@ function captureExpectedAssertions(step: ExpectStep): Record<string, unknown> {
   if (step.result !== undefined) expected.result = step.result;
   if (step.runtimeRecorded !== undefined) expected.runtimeRecorded = step.runtimeRecorded;
   if (step.jobCount !== undefined) expected.jobCount = step.jobCount;
+  if (step.quarantinedSubjects !== undefined) expected.quarantinedSubjects = step.quarantinedSubjects;
+  if (step.terminalEvents !== undefined) expected.terminalEvents = step.terminalEvents;
   if (step.sessionCount !== undefined) expected.sessionCount = step.sessionCount;
   if (step.timing !== undefined) expected.timing = step.timing;
   if (step.noRealIO !== undefined) expected.noRealIO = step.noRealIO;
@@ -195,6 +203,21 @@ async function runExpectStep(
       if (runtimeRecorded !== step.runtimeRecorded) {
         mismatches.push(`expected runtimeRecorded=${step.runtimeRecorded}`);
       }
+    }
+  }
+
+  if (step.terminalEvents !== undefined) {
+    actual.terminalEvents = world.terminalEventCount();
+    if (actual.terminalEvents !== step.terminalEvents) {
+      mismatches.push(`expected terminalEvents=${step.terminalEvents}, received ${String(actual.terminalEvents)}`);
+    }
+  }
+
+  if (step.quarantinedSubjects !== undefined) {
+    const subjects = world.quarantinedSubjects();
+    actual.quarantinedSubjects = subjects.length;
+    if (subjects.length !== step.quarantinedSubjects) {
+      mismatches.push(`expected quarantinedSubjects=${step.quarantinedSubjects}, received ${String(subjects.length)}`);
     }
   }
 
@@ -429,8 +452,9 @@ async function executeStep(
       }
 
       case 'cycle': {
-        const info = await world.cycle();
-        resetCursor(cursor);
+        const preserveWorld = step.preserveWorld === true;
+        const info = await world.cycle(preserveWorld ? { preserveWorld: true } : undefined);
+        advanceCursor(cursor, preserveWorld);
         return buildStepResult(world, step, stepIndex, startedAt, {
           ok: true,
           detail: { info, generation: cursor.generation },
@@ -466,6 +490,14 @@ async function executeStep(
                 detail: outcome.detail,
               },
         );
+      }
+
+      case 'foreign-record': {
+        const seq = world.writeForeignRecord(step.event);
+        return buildStepResult(world, step, stepIndex, startedAt, {
+          ok: true,
+          detail: { event: step.event, seq },
+        });
       }
 
       case 'hang': {

--- a/tools/simulation/scenario-schema.ts
+++ b/tools/simulation/scenario-schema.ts
@@ -179,8 +179,20 @@ const killStepObjectSchema = z.object({
 });
 export type KillStep = z.infer<typeof killStepObjectSchema>;
 
+const foreignRecordStepSchema = z.object({
+  type: z.literal('foreign-record'),
+  /** Which durable event a build with a different shape wrote. */
+  event: z.string().min(1),
+});
+
 export const cycleStepSchema = z.object({
   type: z.literal('cycle'),
+  /**
+   * Restart the coordinator on the same world — filesystem, process table and journal — instead of
+   * starting on a fresh machine. Recovery adoption is only reachable this way, because a job can only
+   * be adopted from durable state that outlived the coordinator that wrote it.
+   */
+  preserveWorld: z.boolean().optional(),
 });
 
 const shutdownStepSchema = z.object({
@@ -212,6 +224,10 @@ const expectStepObjectSchema = z.object({
   result: resultExpectationSchema.optional(),
   runtimeRecorded: z.boolean().optional(),
   jobCount: z.number().int().nonnegative().optional(),
+  /** Subjects held by the recovery quarantine — a job deferred for a later build, not terminalized. */
+  quarantinedSubjects: z.number().int().nonnegative().optional(),
+  /** Terminal events in the journal. Zero means nothing was ended. */
+  terminalEvents: z.number().int().nonnegative().optional(),
   sessionCount: sessionCountExpectationSchema.optional(),
   timing: timingExpectationSchema.optional(),
   noRealIO: z.boolean().optional(),
@@ -239,6 +255,7 @@ const stepSchema = z
     abortStepSchema,
     killStepObjectSchema,
     cycleStepSchema,
+    foreignRecordStepSchema,
     shutdownStepSchema,
     expectStepObjectSchema,
     hangStepSchema,

--- a/tools/simulation/scenarios/lifecycle-restart-adopts-running.yaml
+++ b/tools/simulation/scenarios/lifecycle-restart-adopts-running.yaml
@@ -1,0 +1,40 @@
+# The reattachment contract: a coordinator restart loses the wrapper for a moment and picks the job
+# back up. The provider process outlives the coordinator on purpose, so a job that was running before
+# the restart must still be running after it — not terminalized, not forgotten.
+#
+# `preserveWorld` is what makes this reachable. A bare `cycle` starts the next generation on a fresh
+# machine, where there is nothing to adopt; this one restarts the coordinator on the world it was
+# already running.
+world:
+  durable:
+    - pid: 41001
+      runtimeDelayMs: 5
+      stdout:
+        - delayMs: 20
+          data: "still-working-across-the-restart\n"
+      exit: null
+  fakeProvider:
+    progress:
+      - delayMs: 5
+        message: provider-progress-before-restart
+steps:
+  - type: boot
+  - type: launch
+    prompt: simulate a coordinator restart adopting a running job
+  - type: wait
+    until:
+      runtimeRecorded: true
+    stepMs: 5
+    maxSteps: 10
+  - type: wait
+    until:
+      progressContains: provider-progress-before-restart
+    stepMs: 5
+    maxSteps: 10
+  - type: cycle
+    preserveWorld: true
+  - type: expect
+    jobCount: 1
+    phase: running
+    runtimeRecorded: true
+    noRealIO: true

--- a/tools/simulation/scenarios/lifecycle-unreadable-record-is-not-a-failed-job.yaml
+++ b/tools/simulation/scenarios/lifecycle-unreadable-record-is-not-a-failed-job.yaml
@@ -1,0 +1,55 @@
+# A record this build cannot decode must not become a job this build ends.
+#
+# `foreign-record` rewrites a stored event into a shape the current codec rejects — the durable
+# condition a build with a different shape leaves behind. The coordinator then restarts on that world
+# and has to deal with a record it cannot read.
+#
+# WHAT THIS PROVES: recovery defers rather than terminalizes. Zero terminal events after the restart.
+#
+# WHAT IT DOES NOT YET REACH: the field incident of 2026-08-15 failed *inside* adoption
+# ('Running recovery adoption failed'), after hydration had already succeeded. This injection is
+# caught at the hydrate boundary instead, where deferral was already correct. Reproducing the
+# adoption boundary needs a record that hydrates cleanly and only fails once adoption reads it.
+#
+# Also recorded here because the scenario exposed it: while the world holds an unreadable record,
+# every decoded read surface throws — `readStatus` and `listJobIds` both do — so the job is not
+# observable through `jobs list` or `jobs detail` at all. Only codec-free reads work, which is why the
+# assertions below go straight to the journal and the quarantine table.
+world:
+  durable:
+    - pid: 41002
+      runtimeDelayMs: 5
+      stdout:
+        - delayMs: 20
+          data: "unaffected-by-the-upgrade\n"
+      exit: null
+  fakeProvider:
+    progress:
+      - delayMs: 5
+        message: provider-progress-before-upgrade
+steps:
+  - type: boot
+  - type: launch
+    prompt: simulate an upgrade across a running job
+  - type: wait
+    until:
+      runtimeRecorded: true
+    stepMs: 5
+    maxSteps: 10
+  - type: wait
+    until:
+      progressContains: provider-progress-before-upgrade
+    stepMs: 5
+    maxSteps: 10
+  - type: foreign-record
+    event: job.launch.requested
+  - type: cycle
+    preserveWorld: true
+  # Every decoded read surface is unavailable while the record is unreadable — `readStatus` and
+  # `listJobIds` both throw — so the quarantine table is what can be asserted. One active subject is
+  # the contract: the job was deferred for a build that can read it, not ended by the build that
+  # could not.
+  - type: expect
+    terminalEvents: 0
+    quarantinedSubjects: 1
+    noRealIO: true


### PR DESCRIPTION
Recovery adoption had **no end-to-end scenario**, because the simulation could not express a coordinator restart. Two of this month's worst defects lived on that path.

## Why it was unreachable

`cycle()` called `createSimulationBackend()`, which builds a new runtime, a new process table and a new `':memory:'` journal. The next generation started on a **fresh machine**, so there was nothing to adopt — which is exactly why `adversarial-hang-cycle-relaunch.yaml` asserts `jobCount: 0` after a cycle.

That models replacing the machine, not restarting the coordinator.

## `preserveWorld`

Carries forward the three things a restart actually keeps — filesystem root, process table, journal — and rebuilds everything downstream, which is what a restart does.

A preserved cycle also shuts down as `replaced` rather than `cycle`: `shutdownModeFromReason` only treats `replaced` and `sigterm` as a handoff, and a hard stop terminalizes the very jobs the next generation exists to adopt.

The runner's cursor survives a preserved cycle too, so a scenario can still name the job it is asking about after the restart.

## Two scenarios

**`lifecycle-restart-adopts-running.yaml`** — the reattachment contract, now executable:

```
boot → launch → running → cycle(preserveWorld) → still running
```

The log line that matters: `Adopted running job: …(pid=41001)`.

**`lifecycle-unreadable-record-is-not-a-failed-job.yaml`** — a new `foreign-record` step rewrites a stored event into a shape the current codec rejects, which is the durable condition a build with a different shape leaves behind. Asserts zero terminal events after the restart.

It states plainly what it does **not** yet reach: the 2026-08-15 incident failed *inside* adoption, after hydration succeeded, and this injection is caught at the hydrate boundary where deferral was already correct. Reaching the adoption boundary needs a record that hydrates cleanly and only fails once adoption reads it. **This scenario does not mutation-verify #316** — I checked, and it passes with that fix reverted.

## Two findings from making it run

- The default project root `/tmp/sim/project` **never existed on disk**. Nothing before adoption read it; recovery canonicalizes a launch record's root against the real filesystem and threw `ENOENT`. It is created now.
- While a world holds an event this build cannot decode, **every decoded read surface throws** — `readStatus` and `listJobIds` both — so the job is not observable through `jobs list` or `jobs detail` at all. The new assertions read the journal and quarantine table directly for that reason. Worth its own look: PR #316 keeps such a job alive, but an operator on the older build still cannot see it.

## Gates

tsc · typecheck:tests · lint · format:check · knip · build · check:simulation · `npm test` 5985 · `test:simulation` 64 · test:integration 543 — all green.

All 15 scenarios run; 14 pass. `adversarial-kill-before-runtime.yaml` fails identically on `main` (verified by stashing) — pre-existing, untouched here.

Note: `npm run simulate` leaves `clients/build/coral-simulation.cjs`, which then fails `npm run build`'s Kiwi bundle contract until removed. Pre-existing interaction, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)