### PR TITLE
fix: stop codex continuity carrying keys the JSON boundary rejects

### DIFF
--- a/src/providers/codex/request-mapping.ts
+++ b/src/providers/codex/request-mapping.ts
@@ -144,12 +144,18 @@ export function readCodexPersistedContinuity(
   const continuity = decoded.data;
   const cwdScope = readString(options.cwdScope);
   const cwd = readString(continuity.cwd);
-  const parsed = {
-    cwd: cwdScope === undefined ? (cwd === undefined ? undefined : resolve(cwd)) : scopedCodexCwd(cwd, cwdScope),
-    threadId: readString(continuity.threadId),
-    turnId: readString(continuity.turnId),
+  // Build the way `buildCodexContinuity` does — a key present with an `undefined` value is not the
+  // same as an absent key once this reaches the durable JSON boundary, which has no `undefined` and
+  // rejects it. Claude's reader returns Zod's parsed data directly and never had the hazard.
+  const resolvedCwd =
+    cwdScope === undefined ? (cwd === undefined ? undefined : resolve(cwd)) : scopedCodexCwd(cwd, cwdScope);
+  const threadId = readString(continuity.threadId);
+  const turnId = readString(continuity.turnId);
+  return {
+    ...(resolvedCwd === undefined ? {} : { cwd: resolvedCwd }),
+    ...(threadId === undefined ? {} : { threadId }),
+    ...(turnId === undefined ? {} : { turnId }),
   };
-  return parsed;
 }
 
 export function buildCodexContinuity(update: {

--- a/tests/unit/providers/codex/provider-facets.test.ts
+++ b/tests/unit/providers/codex/provider-facets.test.ts
@@ -4,6 +4,7 @@ import { TEST_CODEX_ACCESS } from '../../../helpers/provider-credentials.js';
 import type { DirentLike, StoragePort } from '#src/infra/port-types.js';
 import { codexAppServerLifecycle, codexRecoveryLifecycle } from '#src/providers/codex/provider-facets.js';
 import { buildCodexContinuity } from '#src/providers/codex/request-mapping.js';
+import { jsonValueSchema } from '#src/infra/json-value.js';
 import { codexArtifactCapability, locateCodexRolloutArtifact } from '#src/providers/codex/artifacts.js';
 import type { ArtifactCleanupRuntime, AppServerTransport } from '#src/providers/contract.js';
 import { SimulationRuntime } from '#tools/simulation/runtime.js';
@@ -42,6 +43,26 @@ function leaseWithRpc(
 }
 
 describe('codexRecoveryLifecycle.finalizeInterrupted', () => {
+  it('emits continuity the durable JSON boundary accepts', () => {
+    // Production hands this mutation's continuity to `jsonValueSchema.parse` in
+    // `providers/internal/bound-provider.ts`. JSON has no `undefined`, so a key that exists with an
+    // undefined value is rejected there — and the throw lands inside recovery adoption, where it used
+    // to terminalize the job. `toEqual` cannot see this: it ignores undefined-valued properties, which
+    // is why every existing case here passed while the boundary rejected the same object.
+    const continuity = buildCodexContinuity({ cwd: '/workspace', threadId: 'thread-1' });
+
+    const mutation = codexRecoveryLifecycle.finalizeInterrupted(
+      { resumable: true, updatedContinuity: continuity },
+      continuity,
+      {},
+    );
+
+    const emitted = 'providerContinuity' in mutation ? mutation.providerContinuity : undefined;
+    expect(emitted).toBeDefined();
+    expect(Object.keys(emitted as object)).toStrictEqual(['cwd', 'threadId']);
+    expect(() => jsonValueSchema.parse(emitted)).not.toThrow();
+  });
+
   it('uses the preserved conversation ref when the session is resumable without a parsed thread id', () => {
     const continuity = buildCodexContinuity({
       cwd: '/workspace',


### PR DESCRIPTION
Root cause of the 2026-08-15 incident. **It was never the version skew it looked like.**

## The chain

`readCodexPersistedContinuity` (`src/providers/codex/request-mapping.ts`) rebuilt its result with all three keys always present:

```ts
const parsed = {
  cwd: …,
  threadId: readString(continuity.threadId),
  turnId: readString(continuity.turnId),   // ← undefined when absent, key still there
};
```

`finalizeInterrupted` sends that object on as `providerContinuity`, and production hands it to `jsonValueSchema.parse` in `providers/internal/bound-provider.ts` — a **bare** parse whose union is `null | boolean | number | string | array | object`. JSON has no `undefined`, so it throws a raw `ZodError`.

It throws **inside recovery adoption**, which is why the message was `Running recovery adoption failed` and why, before #316, the job was terminalized.

The journal's issue tree from that morning is exactly this union, failing at `turnId` with `received: "undefined"`.

## Why the upgrade looked like the cause

It isn't one. This fires whenever a codex continuity lacks a turn — a thread with no current turn. Four jobs at the same lifecycle moment died together; single re-runs had different continuity state and survived. The plugin update was the restart that made recovery read continuity, not the reason it failed.

`docs/todo/build-identity-and-upgrade.md` attributes this to two builds disagreeing about `turnId`, inferred from differing bundle strings. That attribution is wrong and needs replacing; the mixed-build window is still a real concern, but this incident is not its evidence.

## Scope, from a graph trace

Every other codex `providerContinuity` producer already launders through `buildCodexContinuity`, which spreads conditionally and omits absent keys:

| Producer | Path |
|---|---|
| `thread-kernel.checkpoint` | `buildCodexContinuity` — safe |
| `snapshotCodexPersistedContinuity` | `buildCodexContinuity` — safe |
| **`finalizeInterrupted`** | `sanitizeCodexProviderContinuity` → the raw reader — **the defect** |

Claude has no equivalent: `readClaudePersistedContinuity` returns Zod's `parsed.data` directly, so absent optionals stay absent.

Fixed at the **source** rather than at its one unsafe consumer, so the reader now behaves like `buildCodexContinuity` and like Claude's, and a future consumer cannot fall into it.

## Why no test caught it

`toEqual` ignores undefined-valued properties. `{cwd: '/workspace', threadId: undefined, turnId: undefined}` compares equal to `{cwd: '/workspace'}`, so every existing `finalizeInterrupted` case passed while the durable boundary rejected the same object.

The new test asserts the key set with `toStrictEqual` and runs the same `jsonValueSchema.parse` production runs. Verified RED before the fix: `expected [ 'cwd', 'threadId', 'turnId' ] to strictly equal [ 'cwd', 'threadId' ]`.

## Relationship to #316

#316 stays correct and stays necessary — a record this build cannot read must not become a job it destroys. This removes the thing that was producing the unreadable value in the first place. Defence in depth, not a replacement.

## Gates

tsc · typecheck:tests · lint · format:check · knip · build · check:simulation · `npm test` 5986 passed · test:integration 543 · store-reset ×2 · e2e store-reset · build:dev + e2e:lifecycle · build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)