### PR TITLE
docs: correct the TODO corpus against source — four wrong causes, one wrong enumeration

### DIFF
--- a/docs/todo/README.md
+++ b/docs/todo/README.md
@@ -15,14 +15,19 @@ a document about an unplanned feature.
 
 ## Build identity — one build's records read by another
 
-|                                                                    |                                                                                                                                                                                                                                                                                                                      |
-| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`build-identity-and-upgrade.md`](./build-identity-and-upgrade.md) | **Highest severity open.** Updating the plugin swaps CLI and skills immediately while the running coordinator does not swap. In that window a new writer's durable record fails the old coordinator's adoption parse, and the parse failure **terminalizes the job**. Four running jobs died this way on 2026-08-15. |
+|                                                                    |                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`build-identity-and-upgrade.md`](./build-identity-and-upgrade.md) | **Re-scored down.** Updating the plugin swaps CLI and skills immediately while the running coordinator does not swap, so two builds are live at once. Nothing has been observed to break because of it — the 2026-08-15 job losses it was written for were a single-build defect (#318), not skew. |
 
-Its first half — a record this build cannot parse must not become a job this build destroys — is small,
-independent, and where the data loss is. Its second half shares a compatibility policy with
+Its first half — a record this build cannot parse must not become a job this build destroys — shipped
+as #316. What remains splits in two: the **record** direction shares a compatibility policy with
 [`jobs-read-contract-schema-first.md`](./jobs-read-contract-schema-first.md) and
-[`result-artifact-availability.md`](./result-artifact-availability.md); settle it once across all three.
+[`result-artifact-availability.md`](./result-artifact-availability.md), settle it once across all
+three; the **output** direction — a live session holding old skill text driving a new CLI — has no
+defense today and is what actually blocks the `wait` change below.
+
+Read its correction section before citing it. It named a cause it had inferred from a bundle-string
+diff rather than reproduced, which is the same defect this index was rewritten to remove.
 
 ---
 
@@ -33,8 +38,9 @@ independent, and where the data loss is. Its second half shares a compatibility 
 | [`cli-machine-channel.md`](./cli-machine-channel.md)             | `wait`'s exit integer and the `jobs` table's column layout are both presentation carrying a protocol. The `wait` contract is **settled** — it becomes a pure monitor whose exit code describes the monitor, not the job. The `jobs` half is an open product decision. Ship as two PRs, never one. |
 | [`cli-terminal-width-layout.md`](./cli-terminal-width-layout.md) | A **third** thing, and it must not join either. Width work rewrites the rows a contract fixture exists to freeze.                                                                                                                                                                                 |
 
-The `wait` change is blocked on build identity: a stale skill reading a new always-zero exit would
-convert failure into success.
+The `wait` change is blocked on build identity's **output** direction specifically: a session still
+holding the old skill's text, reading a new always-zero exit, would convert failure into success. #316
+landing does not unblock it — that was the record direction.
 
 ---
 

--- a/docs/todo/README.md
+++ b/docs/todo/README.md
@@ -11,6 +11,13 @@ asserted opposite facts about one directory, one had scoped its own reported sym
 was built on a cause that had been inferred rather than reproduced, and a live defect was buried inside
 a document about an unplanned feature.
 
+**Re-verified against source the same day**, every claim and every `file:line`. The rewrite had fixed
+how these documents were organised without checking what they asserted. Four entries were wrong in ways
+that would have produced a wrong fix — a defect enumerated at one call site that exists at three, a
+sibling of the same defect one file away, a prescription for a field that no longer crosses the wire,
+and a dismissed constraint that was true of a different directory. Each carries the correction in place
+rather than an edited-clean text, because the corrections are the part that does not re-derive.
+
 ---
 
 ## Build identity — one build's records read by another
@@ -46,9 +53,9 @@ landing does not unblock it — that was the record direction.
 
 ## A job has one root
 
-|                                                          |                                                                                                                                                                                                                                                                                                        |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`job-scope-containment.md`](./job-scope-containment.md) | Authorization already decides against the directory the work happens in; the durable record takes the shell's cwd instead. Record the former, and compare by containment rather than equality. Must land before the jobs read contract — a consumer inventory cannot be audited while the values move. |
+|                                                          |                                                                                                                                                                                                                                                                                                                                                                                                       |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`job-scope-containment.md`](./job-scope-containment.md) | Authorization already decides against the directory the work happens in; the durable record takes the shell's cwd instead. Record the former, and compare by containment rather than equality. **Three launch paths write the record, not one** — initial, resumed, and workflow-replacement. Must land before the jobs read contract — a consumer inventory cannot be audited while the values move. |
 
 ---
 
@@ -76,19 +83,19 @@ would have to satisfy both, and their requirements are opposites.
 
 ## Durable state with no lifecycle owner
 
-|                                                                      |                                                                                                                                                                                      |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`export-lifetime.md`](./export-lifetime.md)                         | Nothing prunes `~/.coral/exports/jobs/`. Ever. Part 1 gives it a retention authority; part 2 is archived-session restore, whose real question is answerable only once part 1 exists. |
-| [`coordinator-socket-identity.md`](./coordinator-socket-identity.md) | The socket path falls back through `TMPDIR`, so two processes with one state root can both bind. Two coordinators over one journal. Small, independent.                              |
+|                                                                      |                                                                                                                                                                                                                                               |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`export-lifetime.md`](./export-lifetime.md)                         | Nothing prunes `~/.coral/exports/jobs/`. Ever — the retention setting's own doc comment says otherwise. Part 1 gives it a retention authority; part 2 is archived-session restore, whose real question is answerable only once part 1 exists. |
+| [`coordinator-socket-identity.md`](./coordinator-socket-identity.md) | The socket path falls back through `TMPDIR`, so two processes with one state root can both bind. Two coordinators over one journal. The **provider endpoint resolver has the same fallback** — fix both together. Small, independent.         |
 
 ---
 
 ## Wire contracts
 
-|                                                                              |                                                                                                                                                                          |
-| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`jobs-read-contract-schema-first.md`](./jobs-read-contract-schema-first.md) | `jobs.list` and `jobs.detail` cross four boundaries with no response schema.                                                                                             |
-| [`result-artifact-availability.md`](./result-artifact-availability.md)       | **Re-score before starting.** The symptom that motivated it was fixed by a ten-line change (#314); what remains has never been observed and costs a protocol transition. |
+|                                                                              |                                                                                                                                                                                                  |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`jobs-read-contract-schema-first.md`](./jobs-read-contract-schema-first.md) | `jobs.list` and `jobs.detail` cross four boundaries with no response schema. The field that motivated it stopped crossing the wire while it sat open; the boundary is the defect, not the field. |
+| [`result-artifact-availability.md`](./result-artifact-availability.md)       | **Re-score before starting.** The symptom that motivated it was fixed by a ten-line change (#314); what remains has never been observed and costs a protocol transition.                         |
 
 ---
 

--- a/docs/todo/build-identity-and-upgrade.md
+++ b/docs/todo/build-identity-and-upgrade.md
@@ -1,13 +1,13 @@
-# TODO — a plugin upgrade destroys in-flight work
+# TODO — two builds are live at once during an upgrade
 
-**Status**: open, **highest severity of the open set**. Observed 2026-08-15 on a live 0.10.6 daemon
-immediately after the plugin was updated to 0.10.8. Four running jobs died together; the operator had
-changed nothing but the plugin version.
+**Status**: open, **re-scored down from "highest severity"**. Its severity came entirely from an
+incident that has since been traced to a different cause. The window it describes is real and was never
+contingent on that incident, but nothing has yet been observed to break because of it.
 
-## What happened
+## Correction — this document named the wrong cause
 
-Four provider jobs launched as one batch terminalized simultaneously at `07:53:47`, each after roughly
-299 seconds. Every one recorded the same outcome:
+An earlier revision opened with the 2026-08-15 incident: four provider jobs, launched as one batch,
+terminalized together at `07:53:47`, each recording
 
 ```
 kind: failed
@@ -15,85 +15,112 @@ causeRef → job.progress.emitted { kind: 'recovery_parse_failed',
   cause: { message: 'Running recovery adoption failed: [ … Zod invalid_union … ]' } }
 ```
 
-The Zod issue that failed was `path: turnId`, `code: invalid_type`, message `Required`.
+and it attributed the parse failure to two builds disagreeing about the shape of `turnId`, inferred
+from a diff of the `0.10.6` and `0.10.8` bundles (`turnId:Je(n.turnId)` against `turnId:null`).
 
-Re-running the same work one at a time succeeded. That is the tell: a re-run begins and ends inside one
-build, while the original batch spanned the version change.
+**That inference was wrong.** The cause was a single-build defect, traced to source and fixed in #318:
+`readCodexPersistedContinuity` rebuilt its result with all three keys always present, so a continuity
+with no current turn carried `turnId` as a key holding `undefined`. Production hands that object to
+`jsonValueSchema.parse`, a union of `null | boolean | number | string | array | object` — and JSON has
+no `undefined`. One build, one writer, one reader, no version skew.
 
-## Why it happens
+The recorded issue tree is what settles it. Its failing branch is
 
-Updating the plugin swaps the CLI and the skills **immediately**. The coordinator does not swap — the
-process already running keeps serving on the build it started with. The daemon in this incident still
-reported `0.10.6` while the environment it handed to spawned children carried
-`…/coral/0.10.8/bin` on `PATH`, both visible in one log line.
+```
+path: ["turnId"], received: "undefined", message: "Required"
+```
 
-So there is a window — arbitrarily long, bounded only by when the coordinator next restarts — in which
-a **new** CLI writes durable records that an **old** coordinator must later read. When the coordinator
-recovers those jobs, adoption parses the durable record with its own schema. The two builds disagree
-about `turnId`: `0.10.6`'s bundle carries `turnId:Je(n.turnId)` where `0.10.8` carries `turnId:null`.
-The parse fails.
+A version skew would have produced a value of the **wrong type**. This is a value that was **absent**.
+The parse never saw a foreign shape; it saw a key that should not have existed.
 
-**The parse failure then kills the job.** `src/coordinator/services/recovery/index.ts:944` routes
-`'Running recovery adoption failed'` into `settleUnexpectedRecoveryFailure` (`:597`), which settles a
-`recovery_parse_failed` fault — a terminal outcome. The queued path does the same at `:679` with
-`'Queued recovery adoption failed'`. A record this coordinator cannot understand becomes a job this
-coordinator destroys.
+The batch/re-run asymmetry, which read so strongly as an upgrade boundary, has a simpler explanation:
+four jobs at the same lifecycle moment shared the same continuity state, and a later single re-run did
+not. The plugin update was the restart that made recovery read continuity at all. It was the occasion,
+not the cause.
 
-## Why this is the most severe item open
+**The lesson is the document's most durable content.** This entry was written during a consolidation
+pass whose own index names "built on a cause that had been inferred rather than reproduced" as one of
+the defects it was correcting — and then did exactly that, from a bundle-string diff. A build
+difference that is _visible_ at the time of a failure is not thereby the failure's cause. Reproduce
+inside one build before writing skew into a record.
 
-It violates the project's own standing rule that a cold upgrade can never be forced on a user. The
-failure is worse than being asked to restart:
+## What shipped, and what it leaves
 
-- it is **silent** — the operator updated a plugin, nothing announced a risk;
-- it **destroys work** rather than deferring it, and the work is often long-running;
-- it is **indiscriminate** — every in-flight job in the window dies, not the one that touched the changed field;
-- it **teaches the wrong lesson** — re-running works, so it reads as flakiness rather than as an upgrade hazard.
+Two independent changes closed the incident and its class:
 
-It also corrupts every other bug report made across an upgrade. Two items in this directory were
-recorded as live defects and turned out to have been fixed two releases earlier; the most plausible
-channel is a stale skill bundle driving a stale CLI. Measurement and this defect share one root.
+- **#318** removes the producer. The codex reader now builds the way `buildCodexContinuity` and the
+  Claude reader already did, so absent optionals stay absent.
+- **#316** removes the destruction. A record this build cannot parse is now quarantined —
+  `StoreDecodeError` and `ZodError` route to `{ kind: 'quarantine' }` instead of settling a terminal
+  fault. This was this document's "half 1" and it landed as written.
 
-## The two halves, and they are separable
+So the data loss is gone, and so is the value that triggered it. What is left is the window itself,
+which needs its own justification rather than the incident's.
 
-**Half 1 — a parse failure must not be a terminal outcome.** Adoption failing to understand a durable
-record is not evidence the job failed. It is evidence _this build_ cannot speak for it. The natural
-disposition is the one recovery already owns for exactly this shape: quarantine the subject, leave the
-job live, and let a build that can parse the record adopt it. `recovery_quarantine` already carries
-boundary, subject, revision and error, and already retires a subject that a later pass can resolve.
+## What remains genuinely open
 
-This half is small, does not depend on the second, and removes the data loss on its own. It is the
-first thing to do.
+Updating the plugin swaps the CLI and the skill bundle **immediately**. The coordinator does not swap —
+the process already running keeps serving on the build it started with, for an arbitrarily long time
+bounded only by its next restart. The evidence for this is independent of the incident: during it, one
+log line showed the daemon reporting `0.10.6` while the environment it handed to spawned children
+carried `…/coral/0.10.8/bin` on `PATH`.
 
-**Half 2 — the window itself.** Options, none costless:
+Two consequences, and they are not the same problem:
+
+**The record direction — a new CLI writes what an old coordinator reads.** No rule anywhere says a
+durable record must be readable by an older reader; nothing enforces additive-only shapes. Since #316
+the failure mode is no longer destruction, it is a **stall**: a job the coordinator declines to adopt
+sits quarantined until a build that can read it runs, and nothing tells the operator that is why their
+job stopped moving. Better than losing the work, still not a behaviour anyone asked for.
+
+**The output direction — a session holding old skill text drives a new CLI.** The plugin swaps skills
+and CLI together on disk, but a Claude Code session already running holds the _previous_ skill's text
+in its context and keeps invoking against the binary that just changed underneath it. Nothing parses
+here and nothing fails; the output is simply read with the wrong expectations. This direction has **no
+defense at all** and is the binding constraint on the `wait` contract change — a stale skill reading
+the new always-zero exit would convert failure into success. See `cli-machine-channel.md`.
+
+A third, weaker claim worth keeping and worth _not_ trusting: two items in this directory were once
+recorded as live defects and turned out to have been fixed two releases earlier, and a stale bundle is
+the most plausible channel. That is an inference, of exactly the kind the correction above warns
+about. Treat it as motivation, not as evidence.
+
+## Options, none costless
 
 - **Refuse the mixed window.** A CLI whose build differs from the live coordinator hands off or refuses
   rather than writing records the coordinator cannot read. `runCliHandoffPreflight`
-  (`src/cli/program.ts:45`) already exists for this and already runs on every invocation; whether it
-  fires when the _sibling bundle_ differs is the thing to verify first.
+  (`src/cli/program.ts:45`) already exists and already runs on every invocation; whether it fires when
+  the _sibling bundle_ differs is the one cheap fact that has never been checked, and it decides
+  between these options.
 - **Make durable records forward-readable.** Additive-only shapes with unknown-key tolerance, so an
   older reader can adopt a newer record. This is the same compatibility rule the jobs read contract
-  needs — see `jobs-read-contract-schema-first.md`, and settle both with one policy rather than two.
+  needs — see `jobs-read-contract-schema-first.md` and `result-artifact-availability.md`, and settle
+  all three with one policy rather than three.
 - **Restart the coordinator on upgrade.** Honest, but it is the cold upgrade the project rules out, and
   it does not help the jobs already running when the restart happens.
 
+Note that none of these address the output direction. A skill already loaded in a live session cannot
+be reached by anything the CLI or coordinator does; that half needs the machine-readable surface
+`cli-machine-channel.md` describes, so that a stale reader fails to find its field instead of
+misreading a value.
+
 ## Evidence to preserve
 
-The incident's records are in the live store: four `projection_jobs` rows created `2026-08-15T07:53:47`
-with `phase='error'`, their `terminal` blobs carrying `outcome.causeRef` into
-`job.progress.emitted` events `51310` and `51317`. Read them before any retention window removes them.
+The incident's records remain in the live store — events `51310` and `51317`, with four
+`projection_jobs` rows created `2026-08-15T07:53:47` at `phase='error'` pointing into them. They are
+now evidence for **#318**, and they are the counter-example this document exists to remember. Read them
+before any retention window removes them.
 
 ## Explicitly out of scope
 
-This item does not redesign the recovery boundary, the handoff protocol, or the store fingerprint. It
-is about a build destroying work it merely fails to understand, and about the window in which two
-builds are live at once.
+The recovery boundary, the handoff protocol, and the store fingerprint are not redesigned here. Nor is
+the continuity defect — it is fixed, and this document is not its home.
 
 ## Start condition
 
-Begin with half 1 — it is independent, it is where the data loss lives, and it needs no decision about
-the window. Verify first whether the same disposition should apply to every
-`settleUnexpectedRecoveryFailure` caller or only to the adoption parses; the summary strings at `:944`
-and `:679` are the two known ones, and the enumeration should be redone rather than trusted from here.
+Establish `runCliHandoffPreflight`'s behaviour when the sibling bundle differs. It is a single
+observation, it is the only unknown gating the record direction's option choice, and it costs nothing.
 
-Half 2 needs the handoff-preflight behaviour established before its options can be compared, and it
-should be settled together with the jobs read contract's compatibility rules rather than separately.
+Then decide whether the record direction is worth doing at all at its re-scored severity, or whether it
+should simply be folded into the one compatibility policy shared with the two wire-contract entries.
+The output direction does not wait on any of that — it is already the constraint blocking `wait`.

--- a/docs/todo/cli-machine-channel.md
+++ b/docs/todo/cli-machine-channel.md
@@ -16,14 +16,16 @@ passes a provider's status through `normalizeExitCode` across the full 0–255 r
 reserves **75** for "still running" (`src/cli/errors.ts:98`).
 
 A reserved code and a 0–255 passthrough cannot coexist — every value the reservation could take is a
-value a child can produce. This is not hypothetical: three skill documents already carry the workaround
-in prose.
+value a child can produce. This is not hypothetical: **six** skill documents already carry the
+workaround in prose.
 
 > `ralph/SKILL.md:176` — "classify each result from its rendered output, **not exit code `75` alone** …
 > even when a terminal `provider_exit` propagated code `75`."
 
-The same sentence appears at `ralph/SKILL.md:205` and `plan/SKILL.md:161`. Three documents instructing
-agents to ignore the exit code is the system reporting that the channel is full.
+The same sentence appears in `analyze` (`:65`), `bugfix` (`:27`), `code-simplify` (`:69`, plus a second
+phrasing at `:75`), `preplan` (`:151`), `plan` (`:161`), and twice in `ralph` (`:176`, `:205`) — eight
+sites across six documents. Six documents instructing agents to ignore the exit code is the system
+reporting that the channel is full.
 
 Exit 1 is overloaded the same way: it means both "your job failed" (`toExitCode`) and "I could not
 attach to your job" (`scope_mismatch` reaching `errorCodeToExit`'s default).
@@ -47,7 +49,7 @@ correct_ — the monitor failed to attach. #307 item 2 therefore reduces to mess
 do instead of surfacing a raw 403. No exit-code change is needed for it.
 
 **What it costs.** `toExitCode`'s outcome mapping goes away, and every skill that branches on it must
-move to the structured record. `ralph`, `plan` and `preplan` all do.
+move to the structured record — all six named above, not the three an earlier revision listed.
 
 **Binding constraint.** This must not ship before the build-identity work's **output** direction. A
 session holding the old skill's text against a new CLI would read the new always-zero exit as

--- a/docs/todo/cli-machine-channel.md
+++ b/docs/todo/cli-machine-channel.md
@@ -49,9 +49,11 @@ do instead of surfacing a raw 403. No exit-code change is needed for it.
 **What it costs.** `toExitCode`'s outcome mapping goes away, and every skill that branches on it must
 move to the structured record. `ralph`, `plan` and `preplan` all do.
 
-**Binding constraint.** This must not ship before the build-identity work. A stale skill driving a new
-CLI would read the new always-zero exit as "everything succeeded" — silently converting failure into
-success, which is the worst available failure direction. See `build-identity-and-upgrade.md`.
+**Binding constraint.** This must not ship before the build-identity work's **output** direction. A
+session holding the old skill's text against a new CLI would read the new always-zero exit as
+"everything succeeded" — silently converting failure into success, which is the worst available
+failure direction. See `build-identity-and-upgrade.md`; note that its shipped half (#316) is the other
+direction and does not lift this.
 
 **Bonus the same change should carry.** A monitor should be able to show what has happened so far
 without waiting for a bound. If the structured surface is a read rather than only a stream, that falls
@@ -83,5 +85,7 @@ a contract regression are indistinguishable in one diff.
 
 ## Start condition
 
-The `wait` half needs `build-identity-and-upgrade.md`'s first half landed, and needs the skill branches
-inventoried before `toExitCode` is removed. The `jobs` half needs the CLI owner to pick a branch.
+The `wait` half needs `build-identity-and-upgrade.md`'s **output** direction answered — not its first
+half, which shipped as #316 and addressed the unrelated record direction. The hazard here is a live
+session holding the old skill's text against a new CLI, and nothing addresses it yet. It also needs the
+skill branches inventoried before `toExitCode` is removed. The `jobs` half needs the CLI owner to pick a branch.

--- a/docs/todo/coordinator-socket-identity.md
+++ b/docs/todo/coordinator-socket-identity.md
@@ -27,6 +27,23 @@ and one store.
 That directly violates `design-rationale.md` §8.2 — exactly one coordinator per Coral installation —
 which every ownership, recovery and handoff guarantee in the system is written on top of.
 
+## The same fallback exists a second time
+
+`providerEndpoint` (`src/infra/path/provider-proxy.ts:126-150`) resolves guardian, proxy and reaper
+sockets with the identical shape: try `generationRunDir(...)`, and on a length overflow fall back to
+`join(env.tempDirectory, 'coral-<uid>')`. Same ambient variable, same consequence — two processes that
+agree on a provider set's identity can disagree on where its socket lives, so an existing set looks
+absent and a second one gets spawned.
+
+It is better hardened in two ways worth copying rather than re-deriving: it **refuses** when even the
+fallback exceeds the limit (`proxy_endpoint_too_long`) instead of returning an unusable path, and it
+asserts the fallback directory is private before returning. What it does not have, and what this item
+is about, is independence from `TMPDIR`.
+
+Fix both together. They are one missing invariant, and fixing the coordinator alone would leave the
+same class live one directory away — the shape that made this defect worth extracting in the first
+place.
+
 ## Why it has not been seen more
 
 It needs the long-path branch, which needs a deep state root, and then it needs two invocations with
@@ -56,4 +73,6 @@ is only the socket path's dependence on ambient environment.
 ## Start condition
 
 Write the failing case first: two `socketPathForRunDir` calls with the same deep `runDir` and different
-`env.tempDirectory`, asserting they agree. It fails today.
+`env.tempDirectory`, asserting they agree. It fails today. Write the matching case for
+`providerEndpoint` in the same commit — same identity, same overflow, different `env.tempDirectory` —
+so the invariant is stated once for both callers rather than discovered twice.

--- a/docs/todo/export-lifetime.md
+++ b/docs/todo/export-lifetime.md
@@ -13,12 +13,33 @@ Nothing prunes `~/.coral/exports/jobs/<id>/`. Ever.
 (`src/coordinator/lifecycle.ts` → `src/jobs/runtime-meta-store.ts`, a `DELETE FROM meta`).
 
 The export tree is `runtime.paths.coral.exports.jobsRoot`, a different root. A repository-wide search
-found no removal targeting it.
+found no removal targeting it. The only prune that exists is
+`STALE_ARTIFACT_PRUNE_OBLIGATION` (`src/coordinator/lifecycle.ts:380-412`), and it removes exactly
+`progressStore.jobDir(jobId)` and the `meta` row — never the export.
 
-The retention document eventually recorded this correctly. The archive-restore document recorded the
-inverse — that the archive is pruned on the first boot after any version change, giving a restore window
-of "until the next upgrade" — and built a blocking design question on top of it. That question was
-answering a constraint that does not exist.
+**The source itself states the false belief.** `resolveJobRetentionMs`'s doc comment
+(`src/coordinator/lifecycle.ts:235-238`) calls it "the terminal-job **export** retention window", for a
+setting whose prune touches only scratch. Correcting that comment belongs in Part 1; leaving it is how
+the next reader re-derives the same wrong fact.
+
+### The archive-restore document was not inventing its constraint
+
+It recorded that the archive is pruned on the first boot after any version change, giving a restore
+window of "until the next upgrade", and built a blocking design question on that. The earlier merge
+dismissed this as a constraint that does not exist. **It exists — for a different directory.** The
+prune's eligibility test is `fromOldBundle || agedOut` (`lifecycle.ts:387-389`), so a scratch artifact
+carrying a previous `bundleHash` is removed regardless of age. That is precisely "pruned on the first
+boot after any version change", and it is true of `progressStore.jobDir`.
+
+The error was applying a true fact about the scratch directory to the export tree — the same shape as
+the incorrect claim `build-identity-and-upgrade.md` had to retract. Two documents describing two
+different roots with one name is what produced the contradiction, and it is why this merge names the
+root every time it makes a claim.
+
+The preserved provider artifacts live **inside** the export tree —
+`exports.jobsRoot/<jobId>/artifacts/<provider>/actions/<archiveActionId>/`
+(`src/sessions/provider-artifact-archive.ts:190-202`) — so they inherit its absent lifetime exactly,
+and no separate decision covers them.
 
 ## What follows from getting the fact right
 

--- a/docs/todo/job-scope-containment.md
+++ b/docs/todo/job-scope-containment.md
@@ -22,15 +22,52 @@ They differ exactly when `--work-dir` names something other than the caller's cw
 usage in `docs/skills.md` and the `ralph` skill instructs precisely that, then instructs a `wait` that
 cannot find the job it just created.
 
+### `:175` is one of three
+
+All three launch paths reach the same builder, `buildProviderLaunch` (`src/jobs/shell/launch.ts:463`),
+and all three pass `ctx.projectRoot` into it:
+
+| Launch path          | Call site           | Orchestrator entry                   |
+| -------------------- | ------------------- | ------------------------------------ |
+| initial provider job | `job-launch.ts:175` | `launchInitialProviderJob` (`:363`)  |
+| workflow replacement | `job-launch.ts:419` | `launchWorkflowReplacement` (`:596`) |
+| resumed provider job | `job-launch.ts:433` | `launchResumedProviderJob` (`:512`)  |
+
+An earlier revision named only `:175`. A fix applied there alone would leave every resumed and every
+workflow-replacement job still recorded against the shell's cwd — the same defect on two of three
+paths, and the two a long-running workflow spends most of its life on.
+
 ## The two fixes, and they are one concept
 
-**1. Record the directory the work happened in.** `job-launch.ts:175` takes `cwd` instead of
+**1. Record the directory the work happened in.** The three launch call sites take `cwd` instead of
 `ctx.projectRoot`. Value-only: no DDL, no Zod contract change, therefore no store fingerprint move and
 no store reset.
 
-Do **not** change the other three `ctx.projectRoot` uses in that file. `:107` and `:217` resolve the
-agent profile — they want the operator's configuration root, which is genuinely the invocation
-directory. `:146` is the session record; leave it until something forces it.
+The builder already wants the right value. `buildProviderLaunch` computes
+`opts.projectRoot ?? request.cwd ?? ''` (`src/jobs/shell/launch.ts:465`) — `request.cwd` **is** the work
+directory, and it is already second in that chain. The fallback never fires only because all three
+callers supply `opts.projectRoot` explicitly, and `launchWorkflowReplacement` types it as required
+(`launch.ts:607`) so it cannot even be omitted. Decide deliberately between dropping the argument and
+letting the existing fallback carry it, or passing `cwd` at each call site; the first is smaller but
+makes an implicit chain load-bearing.
+
+Do **not** change the other five `ctx.projectRoot` uses in `job-launch.ts`. Enumerated, because the
+earlier revision counted three and there are eight in total:
+
+| Line   | Use                                            | Verdict                                                  |
+| ------ | ---------------------------------------------- | -------------------------------------------------------- |
+| `:107` | agent profile resolution                       | leave — wants the operator's configuration root          |
+| `:119` | `const cwd = input.cwd ?? ctx.projectRoot`     | leave — this is the fallback that _defines_ the work dir |
+| `:146` | session record                                 | leave until something forces it                          |
+| `:175` | **initial launch record**                      | **change**                                               |
+| `:217` | agent profile resolution                       | leave — same as `:107`                                   |
+| `:335` | base for `canonicalizeWorkDir(session.cwd, …)` | leave — a resolution base, not a recorded value          |
+| `:419` | **workflow-replacement launch record**         | **change**                                               |
+| `:433` | **resumed launch record**                      | **change**                                               |
+
+While in there: `launch.ts` reads the value back inconsistently for event metadata — `:389` and `:534`
+use the builder's result, `:622` uses `opts.projectRoot` directly. They agree today only because the
+argument is always supplied. Whichever branch fix 1 takes, make all three read the same source.
 
 Do **not** rename the column. `project_root` is misnamed — it is a work root — but a column rename moves
 the store format fingerprint and becomes a destructive reset. That debt is cheap to carry and expensive
@@ -40,6 +77,12 @@ to pay.
 (`src/coordinator/composition/job-control.ts:96`) tests `status.projectRoot !== projectRoot`. The
 predicate it should use already exists and is already used for exactly this question on the
 child-principal path: `containsProjectRoot` (`src/security/policy/authorize.ts:98`).
+
+That predicate is **module-private** — `authorize.ts` does not export it. Reusing it means exporting it
+or moving it to a lower owner; do not copy it, since a second containment predicate is exactly the
+"one concept, two homes" this repository forbids. Note also that `scopeCheckJobs` already carries one
+deliberate exemption (`jobKind === 'kb'`, which belongs to no project); containment must be applied
+without disturbing it.
 
 Apply containment to `scopeCheck` **only** — not to the `jobs list` filter
 (`src/jobs/read-queries.ts`). Naming a job id is an explicit act; listing is ambient, and `cd /` must

--- a/docs/todo/jobs-read-contract-schema-first.md
+++ b/docs/todo/jobs-read-contract-schema-first.md
@@ -6,15 +6,30 @@ conversion too broad for a workflow-identity change.
 ## The problem
 
 Jobs list/detail responses cross producer, RPC, CLI dispatch, and formatting boundaries without one runtime
-schema as their authority. This PR added `workflowChildren` and `workflowLabel` along that unchecked path. A
-malformed backend response can reach `formatWorkflowChildren`, where `[...children]` throws instead of
-producing a controlled contract error (`src/cli/format/jobs.ts:199`).
+schema as their authority.
 
 The core vocabulary lives as TypeScript-first records in `src/jobs/records.ts:69,246-274`, while `jobs.list`
-and `jobs.detail` lack response schemas in `src/transport/rpc/catalog.ts:254-271`. Producer values pass
-through `src/transport/dispatch.ts:812-840`, and `src/cli/dispatch.ts:582-585` requests typed values rather
-than parsing `unknown`. Approximately 33 consumers depend on the current types, so changing the source of
-those types is a cross-surface conversion, not a local annotation.
+and `jobs.detail` lack response schemas in `src/transport/rpc/catalog.ts:253-271` — the only methods in the
+catalog that carry a `responseSchema` are the three `coordinator.provider_host.*` ones (`:139`, `:151`,
+`:163`). Producer values pass through `executeJobsListCatalogRequest` / `executeJobsDetailCatalogRequest`
+(`src/transport/dispatch.ts:808-845`), both of which reach their input by `request as …` cast, and
+`src/cli/dispatch.ts:582-585` requests typed values rather than parsing `unknown`. Measured today, the type
+family (`JobStatus`, `JobEvent`, `JobExit`, `JobsListResponse`, `JobDetailResponse`) has **120 references
+across 24 files** in `src/`, so changing the source of those types is a cross-surface conversion, not a local
+annotation.
+
+### Correction — the field that motivated this no longer crosses the wire
+
+An earlier revision opened with "This PR added `workflowChildren` and `workflowLabel` along that unchecked
+path", written against PR #309. That PR was split and closed. What shipped instead (#312) derives children
+**client-side**: `src/cli/commands/session.ts:161-165` calls `listJobs` and filters on
+`parentWorkflowJobId`, and `WorkflowChildJob` is now defined as `JobsListResponse['jobs'][number]`
+(`src/cli/format/jobs.ts:30`). `workflowLabel` does not exist anywhere in `src/`.
+
+So the concrete failure this document cited — a malformed response reaching `formatWorkflowChildren`, where
+`[...children]` throws instead of producing a controlled contract error (`src/cli/format/jobs.ts:194`) — is
+still reachable, but through **`jobs.list`**, not `jobs.detail`. The unvalidated boundary is the same one;
+the field that crosses it is not.
 
 ## The decision
 
@@ -27,8 +42,10 @@ Make the jobs read contract schema-first in `src/jobs/records.ts`, deriving Type
 - `jobsListResponseSchema`;
 - `jobDetailResponseSchema`.
 
-The detail schema accepts `workflowChildren` as optional wire input and normalizes absence to `[]` at ingress.
-After that normalization, `src/cli/format/jobs.ts` must consume the canonical array without `?? []`.
+`workflowChildJobSummarySchema` describes a **list** row, not a detail field — see the correction above.
+`formatJobDetail` already defaults its `workflowChildren` parameter to `[]` (`src/cli/format/jobs.ts:218`)
+because the CLI assembles that array itself; the schema's job is to make the `jobs.list` rows it is
+assembled from parsed rather than asserted.
 
 Add `responseSchema` for `jobs.list` and `jobs.detail` in `src/transport/rpc/catalog.ts`. Parse producer values
 in `src/transport/dispatch.ts`; in `src/cli/dispatch.ts`, request `unknown` and parse it rather than asserting a
@@ -47,10 +64,13 @@ does not make breaking changes safe by itself.
 
 ## Why it is split
 
-Converting a core type family with roughly 33 consumers, adding parsing on both producer and consumer sides,
-and pinning mixed-build behavior is too broad to hide inside a workflow slot/job identity PR. A partial
-conversion would be worse than the current visible gap because callers could not tell which types had runtime
-authority.
+Converting a core type family with 120 references across 24 files, adding parsing on both producer and
+consumer sides, and pinning mixed-build behavior is too broad to hide inside a workflow slot/job identity PR.
+A partial conversion would be worse than the current visible gap because callers could not tell which types
+had runtime authority.
+
+That the motivating field changed shape while this sat open is itself an argument for the split: the
+boundary is the defect, not any one field crossing it.
 
 ## Explicitly out of scope
 
@@ -61,6 +81,7 @@ separate decision.
 ## Start condition
 
 Begin when the conversion can be done across all list/detail producers and consumers in one change, with
-contract tests covering malformed responses, missing `workflowChildren`, unknown additive keys, and both
-mixed-build directions. The TypeScript consumer inventory must be refreshed before editing so no cast path is
-left behind.
+contract tests covering malformed responses, unknown additive keys, and both mixed-build directions. The
+TypeScript consumer inventory must be refreshed before editing — the count above is a measurement, not a
+constant, and the `request as …` casts in `src/transport/dispatch.ts` are the paths most likely to be
+missed since they type-check today.

--- a/docs/todo/provider-operation-shutdown-quiescence.md
+++ b/docs/todo/provider-operation-shutdown-quiescence.md
@@ -6,11 +6,11 @@ on this work and must not carry another partial version of it.
 
 ## The bug
 
-Shutdown calls `stopProviderOperationReconciler()` before the accepted-request drain begins
-(`src/coordinator/lifecycle.ts:1233-1239`). That stop unsubscribes
-`subscribeProviderOperationMutations` immediately (`src/coordinator/composition/execution-services.ts:375-379`),
+Shutdown calls `stopProviderOperationReconciler()` at `src/coordinator/lifecycle.ts:1226`, five lines
+before `runShutdownSequence` and therefore before the accepted-request drain begins. That stop unsubscribes
+`subscribeProviderOperationMutations` immediately (`src/coordinator/composition/execution-services.ts:375-380`),
 while `ProviderOperationReconciler.stop()` only disables scheduled polling and removes its settlement listener
-(`src/coordinator/services/provider-operation-reconciler.ts:444-451`). It neither fences nor awaits an active
+(`src/coordinator/services/provider-operation-reconciler.ts:444-452`). It neither fences nor awaits an active
 serializer; those serializers remain represented only by the per-operation `inFlight` promise
 (`src/coordinator/services/provider-operation-reconciler.ts:732-771`).
 

--- a/docs/todo/proxy-set-acquisition.md
+++ b/docs/todo/proxy-set-acquisition.md
@@ -12,9 +12,10 @@ guardian identity disagreement on processStartedAtSeconds:
 this acquisition issued 1786780788, the process reported 1786780791.
 ```
 
-Three seconds apart. The check is at `src/coordinator/live/provider-proxy/role-control.ts:175`: an
-acquisition issues an expected identity and compares it against what the spawned process reports; any
-disagreement on `processStartedAtSeconds` fails the acquisition.
+Three seconds apart. The check is `assertIdentityFieldsAgree`
+(`src/coordinator/live/provider-proxy/role-control.ts:167-179`, comparison at `:173`): an acquisition
+issues an expected identity and compares every field against what the spawned process reports; any
+disagreement — `processStartedAtSeconds` included — throws and fails the acquisition.
 
 Acquisition is therefore **attempted, logged, and failed** — not silently skipped. When it fails the
 route stays absent, `routeAppServerOperation` returns `null`, and every operation takes the
@@ -30,12 +31,16 @@ branch, and a real reporting gap — but not at what was happening here.
 
 Two things survive from that version and remain true:
 
-- `ensureProxySetFor` (`src/coordinator/live/provider-hosts/index.ts:334`) reports only the `capacity`
-  refusal. `already-represented` and `startup-discovery-pending` return without a word. That is still a
-  reporting gap worth closing, and it is why the real cause took a second incident to surface.
+- `ensureProxySetFor` (`src/coordinator/live/provider-hosts/index.ts:334-368`) reports only the
+  `capacity` refusal (`:346-350`). Every other non-accepted admission returns silently, and so does the
+  earlier `routeFor(identityKey) !== null` short-circuit at `:341`. That is still a reporting gap worth
+  closing, and it is why the real cause took a second incident to surface.
 - `ProviderProxySetLifecycleSnapshot` already computes `startupDiscoveryCompleted`, `represented`,
-  `available` and `states`, and has **no production consumer** — only an integration test reads it. The
-  observability this needs is already built and unpublished.
+  `available` and `states` (`src/coordinator/services/provider-proxy-set/index.ts:140`, produced by
+  `snapshot()` at `:577`), and has **no production consumer** — its only readers are in
+  `tests/unit/coordinator/services/provider-proxy-set-lifecycle.test.ts`, a unit test, not an
+  integration test as an earlier revision said. The observability this needs is already built and
+  unpublished.
 
 ## The defect
 

--- a/docs/todo/result-artifact-availability.md
+++ b/docs/todo/result-artifact-availability.md
@@ -18,7 +18,7 @@ scope itself away from the thing that prompted it.
 
 ## What actually remains
 
-`WaitCoordinator.resultPathFor` (`src/jobs/shell/wait.ts:362-372`) catches a rebuild failure, logs to
+`WaitCoordinator.resultPathFor` (`src/jobs/shell/wait.ts:362-374`) catches a rebuild failure, logs to
 coordinator stderr, and returns the **expected** filename. The terminal wait event then carries a path
 that was never verified, and `wait` prints it.
 
@@ -47,9 +47,10 @@ discriminated value:
 durable terminal outcome alone — and under the settled `wait` contract, from the monitor's own success
 (see `cli-machine-channel.md`).
 
-The dependency is genuinely optional in the interface (`src/jobs/shell/wait.ts:225`) and four test
-harnesses omit it, but the **sole production composition supplies it**
-(`src/coordinator/execution-service.ts:108`). The work is making the constructor contract require what
+The dependency is genuinely optional in the interface (`ensureResultArtifact?`,
+`src/jobs/shell/wait.ts:226`) and the four test harnesses that construct a `WaitCoordinator` omit it, but
+the **sole production composition supplies it** (`src/coordinator/execution-service.ts:120`, inside the
+one `new WaitCoordinator` at `:108`). The work is making the constructor contract require what
 production already provides, not adding missing wiring.
 
 ## Why it is still split


### PR DESCRIPTION
Two passes. The first replaces the build-identity entry's disproven cause (follow-up to #318); the second verifies **every claim and every `file:line` in all 12 TODO documents** against the code, using grep and the codebase graph.

The 2026-08-15 rewrite fixed how these documents were *organised* without checking what they *asserted*.

---

## Pass 1 — build-identity named the wrong cause

`build-identity-and-upgrade.md` attributed the 2026-08-15 job losses to two builds disagreeing about `turnId`, inferred from a bundle-string diff. #318 traced it to a single-build defect. The journal record (still live, event `51310`) settles it:

```
path: ["turnId"], received: "undefined", message: "Required"
```

Skew produces a value of the **wrong type**. This was a value that was **absent**.

The correction stays in the document as a `## Correction` section — the entry was written during the consolidation pass whose own index lists *"built on a cause that had been inferred rather than reproduced"* among the defects it was fixing, and then did exactly that.

What survives is re-scored and split by direction:

| Direction | Status |
|---|---|
| **Record** — new CLI writes, old coordinator reads | **Stalls** rather than destroys since #316. Shares one compatibility policy with two wire-contract entries. |
| **Output** — a live session holds the previous skill's text against a swapped CLI | **No defense at all.** |

`README.md` and `cli-machine-channel.md` both said `wait` was blocked on build identity's *first half* — which is #316, the record direction. As written, both would have read as **unblocked** the moment #316 merged. The hazard for `wait` is the output direction; both now say so.

---

## Pass 2 — four more entries were wrong

### `job-scope-containment.md` — a defect enumerated at one site that exists at three

The entry named `job-launch.ts:175`. All three launch paths reach the same builder and all three pass `ctx.projectRoot` into the durable record:

| Launch path | Call site | Orchestrator entry |
|---|---|---|
| initial provider job | `job-launch.ts:175` | `launchInitialProviderJob` (`:363`) |
| workflow replacement | `job-launch.ts:419` | `launchWorkflowReplacement` (`:596`) |
| resumed provider job | `job-launch.ts:433` | `launchResumedProviderJob` (`:512`) |

A fix at `:175` alone leaves the bug live on the two paths a long-running workflow spends most of its life on.

Also: `buildProviderLaunch` already computes `opts.projectRoot ?? request.cwd ?? ''` — `request.cwd` **is** the work directory and is already second in that chain. The fallback never fires only because all three callers supply the argument, and `launchWorkflowReplacement` types it as required. The entry now states that choice explicitly.

And the "do not change the other three uses" instruction: there are **eight** `ctx.projectRoot` uses in that file. All eight are now tabulated with a verdict each.

Finally, `containsProjectRoot` — the predicate the entry says to reuse — is **module-private**. Reuse means exporting it, and copying it is forbidden by the repo's own one-concept-one-home rule.

### `coordinator-socket-identity.md` — the same defect one file away

`providerEndpoint` (`src/infra/path/provider-proxy.ts:126-150`) has the identical `env.tempDirectory` fallback. Two processes agreeing on a provider set's identity can disagree on where its socket lives, so an existing set looks absent and a second gets spawned.

It's better hardened in two ways worth copying (refuses when even the fallback overflows; asserts the directory is private) but has the same `TMPDIR` dependence. Both are one missing invariant, and the failing test is now specified for both.

### `jobs-read-contract-schema-first.md` — a prescription for a field that no longer crosses the wire

The entry opened on "This PR added `workflowChildren` and `workflowLabel` along that unchecked path" — written against #309, which was split and closed. #312 shipped **client-side derivation** instead: `src/cli/commands/session.ts:161-165` calls `listJobs` and filters on `parentWorkflowJobId`. `workflowLabel` does not exist anywhere in `src/`.

The unvalidated boundary is unchanged — so the decision stands and the field-specific prescription goes. The cited throw (`[...children]`) is still reachable, but through `jobs.list`, not `jobs.detail`.

"~33 consumers" replaced with a measurement: **120 references across 24 files**.

### `export-lifetime.md` — a dismissed constraint that was true of a different directory

The merge dismissed the archive-restore document's "pruned on the first boot after any version change" as a constraint that does not exist. **It exists — for the scratch directory.** The prune's eligibility test is `fromOldBundle || agedOut` (`lifecycle.ts:387-389`), so an artifact carrying a previous `bundleHash` is removed regardless of age.

The error was applying a true fact about scratch to the export tree — the same shape as the build-identity retraction above.

And the source states the false belief itself: `resolveJobRetentionMs`'s doc comment calls it "the terminal-job **export** retention window" for a setting that prunes only scratch. Correcting that comment is now part of Part 1.

### `cli-machine-channel.md` — understating its own evidence

"Three skill documents already carry the workaround in prose." There are **six**, across eight sites: `analyze`, `bugfix`, `code-simplify` (×2), `preplan`, `plan`, `ralph` (×2).

---

## Verified accurate, no change needed

`provider-operation-shutdown-quiescence.md` (every one of its ~12 line refs checked out; only `lifecycle.ts:1233-1239` → `:1226` drifted), `kb-daemon-independent-containment.md`, `cli-terminal-width-layout.md`, `store-format-routing.md`, `result-artifact-availability.md` (`new WaitCoordinator` count confirmed: 1 production, 4 tests), `proxy-set-acquisition.md` (its unpublished snapshot is read by a **unit** test, not an integration test).

Docs only — no source touched. `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)