### PR TITLE
fix: keep a workflow replacement inside the envelope recovery cleans up

### DIFF
--- a/src/coordinator/services/workflow-recovery-descendants.ts
+++ b/src/coordinator/services/workflow-recovery-descendants.ts
@@ -41,16 +41,21 @@ export function createFailedWorkflowDescendantReleaser(
   ): readonly WorkflowRecoveryDescendantRelease[] => {
     const releases: WorkflowRecoveryDescendantRelease[] = [];
     for (const descendant of descendants) {
-      // `releaseJob` owns this decision and already separates the two cases that matter: `already_absent`
-      // when nothing holds the claim, `owned_by_another_job` when someone else does. An earlier revision
-      // re-derived that judgement here from a projection read and got it wrong in both directions — it
-      // treated an already-released claim as a conflict, and it compared a session version captured when
-      // recovery started against one that recovery's own lawful work had since moved. Waiting for a child
-      // to terminate releases its claim; completing a replacement intent swaps it. Both are this pass
-      // doing its job, and both failed a check meant to catch foreign change.
+      // An earlier revision re-derived this judgement here from a projection read, and got it wrong in
+      // two directions: it treated an already-released claim as a conflict, and it compared a session
+      // version captured when recovery started against one that recovery's own lawful work had since
+      // moved. Waiting for a child to terminate releases its claim; completing a replacement intent
+      // swaps it. Both are this pass doing its job, and both failed a check meant to catch foreign
+      // change.
       //
       // The obligation is per-job and idempotent: what must hold afterwards is that `jobId` does not hold
-      // `sessionId`. Already true is satisfied, not violated.
+      // `sessionId`. All three results say that it does not — `released` because we just released it,
+      // `already_absent` because nothing held it, `owned_by_another_job` because someone else does. None
+      // is a conflict, and the safety property is `releaseJob` itself refusing to touch another owner,
+      // not a throw here. Throwing on the third only turned a benign state into a close this pass can
+      // never satisfy, retried from the persisted `ready-to-close` record on every later pass.
+      // The disposition is reported rather than swallowed: `describeSessionJobClaimReleaseResult`
+      // renders all three, and workflow recovery logs whichever occurred.
       const sessionClaimRelease = releaseSessionJobClaim({
         projectRoot: descendant.projectRoot,
         runtime: deps.runtime,
@@ -60,11 +65,6 @@ export function createFailedWorkflowDescendantReleaser(
         sessionId: descendant.sessionId,
         jobId: descendant.jobId,
       });
-      if (sessionClaimRelease === 'owned_by_another_job') {
-        throw new Error(
-          `Workflow recovery descendant claim for '${descendant.jobId}' session '${descendant.sessionId}' now belongs to another job.`,
-        );
-      }
       releases.push({
         jobId: descendant.jobId,
         sessionId: descendant.sessionId,

--- a/src/coordinator/services/workflow-recovery-descendants.ts
+++ b/src/coordinator/services/workflow-recovery-descendants.ts
@@ -4,7 +4,6 @@ import type { JobStore } from '../../jobs/store.js';
 import type { Runtime } from '../../runtime/ports.js';
 import type { CommitContext, CommitEventsFn } from '../../store/append.js';
 import { releaseSessionJobClaim } from '../../sessions/job-release.js';
-import { readProjectionProviderSession } from '../../sessions/projections.js';
 import type {
   AtomicFailedWorkflowDescendantReleaser,
   WorkflowRecoveryDescendant,
@@ -42,16 +41,16 @@ export function createFailedWorkflowDescendantReleaser(
   ): readonly WorkflowRecoveryDescendantRelease[] => {
     const releases: WorkflowRecoveryDescendantRelease[] = [];
     for (const descendant of descendants) {
-      const entry = readProjectionProviderSession(deps.progressStore.getDb(), descendant.sessionId);
-      if (
-        entry === null ||
-        entry.version !== descendant.expectedSessionVersion ||
-        entry.activeJobId !== descendant.jobId
-      ) {
-        throw new Error(
-          `Workflow recovery descendant claim changed for '${descendant.jobId}' session '${descendant.sessionId}'.`,
-        );
-      }
+      // `releaseJob` owns this decision and already separates the two cases that matter: `already_absent`
+      // when nothing holds the claim, `owned_by_another_job` when someone else does. An earlier revision
+      // re-derived that judgement here from a projection read and got it wrong in both directions — it
+      // treated an already-released claim as a conflict, and it compared a session version captured when
+      // recovery started against one that recovery's own lawful work had since moved. Waiting for a child
+      // to terminate releases its claim; completing a replacement intent swaps it. Both are this pass
+      // doing its job, and both failed a check meant to catch foreign change.
+      //
+      // The obligation is per-job and idempotent: what must hold afterwards is that `jobId` does not hold
+      // `sessionId`. Already true is satisfied, not violated.
       const sessionClaimRelease = releaseSessionJobClaim({
         projectRoot: descendant.projectRoot,
         runtime: deps.runtime,
@@ -61,8 +60,10 @@ export function createFailedWorkflowDescendantReleaser(
         sessionId: descendant.sessionId,
         jobId: descendant.jobId,
       });
-      if (sessionClaimRelease !== 'released') {
-        throw new Error(`Workflow recovery could not release '${descendant.jobId}' session '${descendant.sessionId}'.`);
+      if (sessionClaimRelease === 'owned_by_another_job') {
+        throw new Error(
+          `Workflow recovery descendant claim for '${descendant.jobId}' session '${descendant.sessionId}' now belongs to another job.`,
+        );
       }
       releases.push({
         jobId: descendant.jobId,

--- a/src/workflow/recover.ts
+++ b/src/workflow/recover.ts
@@ -79,7 +79,6 @@ export type WorkflowRecoveryDescendant = {
   readonly jobId: string;
   readonly sessionId: string;
   readonly projectRoot: CanonicalWorkDir;
-  readonly expectedSessionVersion: number;
 };
 
 export type WorkflowRecoveryDescendantRelease = {
@@ -137,12 +136,11 @@ type ResumeWorkflowContext = {
   time: Pick<TimePort, 'now'>;
   onProgress: (workflowId: string, message: string) => void;
   /**
-   * Hands a replacement this pass just committed back to the recovery item, so the durable continuation
-   * names the job that now holds the session instead of the one it replaced. Without it the replacement
-   * is invisible to the close that has to release it: `descendants` is derived from the continuation,
-   * and the continuation was read before this pass created anything.
+   * A mandatory checkpoint, not a notification: recovery may not proceed past a committed replacement
+   * until the durable continuation names it. The continuation was read before this pass created
+   * anything, and the close can only release what it names.
    */
-  onReplacementLaunched: (sessionId: string, jobId: string) => Promise<void>;
+  checkpointReplacement: (sessionId: string, jobId: string) => Promise<void>;
   staleTimeoutMs: number;
   staleCheckIntervalMs: number;
   staleAbortTimeoutMs: number;
@@ -382,7 +380,7 @@ async function resumePendingReplacementIntents(
     // Before any further fallible work — `awaitLaunch` below is the first thing that can throw, and the
     // close that follows a throw can only release what the continuation names. Recording here is what
     // keeps a replacement this pass created inside the envelope this pass cleans up.
-    await deps.onReplacementLaunched(launch.sessionId, resumed.jobId);
+    await deps.checkpointReplacement(launch.sessionId, resumed.jobId);
 
     const readiness = await deps.executionSvc.awaitLaunch(resumed.jobId, BOOTSTRAP_TIMEOUT_MS);
     if (readiness === 'error') {
@@ -1148,7 +1146,6 @@ function continuationDescendants(continuation: WorkflowRecoveryContinuation): re
             jobId: session.activeJobId,
             sessionId: session.sessionId,
             projectRoot: session.projectRoot,
-            expectedSessionVersion: session.version,
           },
         ]
       : [],
@@ -1265,15 +1262,12 @@ async function persistWorkflowContinuation(
 }
 
 /**
- * Moves a session's continuation entry onto the replacement this recovery pass just launched, and adds
- * that replacement to the workflow's child set, then persists the result.
- *
- * The version is re-read rather than incremented: `resume()` returns only the job and session ids, and
- * the claim swap it commits is the only authority on what version the session now carries. Guessing it
- * would reintroduce the same stale-expectation failure one step later, in the check that exists to
- * detect exactly that.
+ * Re-reads the session rather than trusting the launch decision: `resume()` reports which job it created,
+ * not whether that job ended up holding the claim. Confirming it here is what makes the recorded child a
+ * fact about durable state instead of an inference from a return value — and the version comes back with
+ * it, so the continuation stays internally consistent with the projection it mirrors.
  */
-async function recordWorkflowReplacement(
+async function checkpointReplacementInContinuation(
   item: HydratedWorkflowRecovery,
   quarantine: RecoveryQuarantinePort,
   db: Database,
@@ -1281,8 +1275,8 @@ async function recordWorkflowReplacement(
   jobId: string,
 ): Promise<void> {
   const entry = readProjectionProviderSession(db, sessionId);
-  if (entry === null) {
-    throw new Error(`Workflow recovery replacement '${jobId}' left session '${sessionId}' unreadable.`);
+  if (entry === null || entry.activeJobId !== jobId) {
+    throw new Error(`Workflow recovery replacement '${jobId}' did not take the claim on session '${sessionId}'.`);
   }
   item.continuation = {
     ...item.continuation,
@@ -1290,9 +1284,7 @@ async function recordWorkflowReplacement(
       ? item.continuation.childIds
       : [...item.continuation.childIds, jobId],
     providerSessions: item.continuation.providerSessions.map((session) =>
-      session.sessionId === sessionId
-        ? { ...session, activeJobId: entry.activeJobId ?? null, version: entry.version }
-        : session,
+      session.sessionId === sessionId ? { ...session, activeJobId: jobId, version: entry.version } : session,
     ),
   };
   await persistWorkflowContinuation(item, quarantine);
@@ -1510,9 +1502,8 @@ async function settleWorkflowRecovery(
         completion: item.completion,
         drain: item.drain,
         onProgress: options.onProgress ?? (() => {}),
-        onReplacementLaunched: async (sessionId, jobId) => {
-          await recordWorkflowReplacement(item, quarantine, options.db, sessionId, jobId);
-        },
+        checkpointReplacement: (sessionId, jobId) =>
+          checkpointReplacementInContinuation(item, quarantine, options.db, sessionId, jobId),
         staleTimeoutMs: options.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS,
         staleCheckIntervalMs: options.staleCheckIntervalMs ?? DEFAULT_STALE_CHECK_INTERVAL_MS,
         staleAbortTimeoutMs: options.staleAbortTimeoutMs ?? DEFAULT_STALE_ABORT_TIMEOUT_MS,

--- a/src/workflow/recover.ts
+++ b/src/workflow/recover.ts
@@ -51,7 +51,7 @@ import {
   sessionControllerFromProfile,
   type ProviderSession,
 } from '../sessions/entry.js';
-import { projectionSessionStoredRowSchema, readProjectionProviderSession } from '../sessions/projections.js';
+import { projectionSessionStoredRowSchema } from '../sessions/projections.js';
 import type { ProjectionJobStoredRow } from '../jobs/projection-row.js';
 import type {
   RecoveryDisposition,
@@ -185,6 +185,12 @@ type WorkflowRecoveryContinuation = {
   readonly providerSessions: readonly {
     readonly sessionId: string;
     readonly projectRoot: CanonicalWorkDir;
+    /**
+     * What the session's version was when this recovery hydrated, and nothing more. It has no reader:
+     * the close compares job identity, never versions, because recovery's own work legitimately moves a
+     * session's version between hydration and close. Do not revive a comparison against it — one used to
+     * exist, and it rejected releases that had already succeeded.
+     */
     readonly version: number;
     readonly activeJobId: string | null;
     readonly continuationLease: ProviderSession['continuationLease'] | null;
@@ -1262,29 +1268,25 @@ async function persistWorkflowContinuation(
 }
 
 /**
- * Re-reads the session rather than trusting the launch decision: `resume()` reports which job it created,
- * not whether that job ended up holding the claim. Confirming it here is what makes the recorded child a
- * fact about durable state instead of an inference from a return value — and the version comes back with
- * it, so the continuation stays internally consistent with the projection it mirrors.
+ * Records the replacement as this session's child. It does not verify that the replacement still holds
+ * the claim, and must not: `resume()` starts the provider before it resolves, so a job that terminalizes
+ * quickly releases its own claim first, and requiring the claim here would turn that success into a
+ * failed workflow. What the record has to survive is the close, and the close is idempotent per job —
+ * an already-finished replacement releases as `already_absent` and aborts as a no-op.
  */
 async function checkpointReplacementInContinuation(
   item: HydratedWorkflowRecovery,
   quarantine: RecoveryQuarantinePort,
-  db: Database,
   sessionId: string,
   jobId: string,
 ): Promise<void> {
-  const entry = readProjectionProviderSession(db, sessionId);
-  if (entry === null || entry.activeJobId !== jobId) {
-    throw new Error(`Workflow recovery replacement '${jobId}' did not take the claim on session '${sessionId}'.`);
-  }
   item.continuation = {
     ...item.continuation,
     childIds: item.continuation.childIds.includes(jobId)
       ? item.continuation.childIds
       : [...item.continuation.childIds, jobId],
     providerSessions: item.continuation.providerSessions.map((session) =>
-      session.sessionId === sessionId ? { ...session, activeJobId: jobId, version: entry.version } : session,
+      session.sessionId === sessionId ? { ...session, activeJobId: jobId } : session,
     ),
   };
   await persistWorkflowContinuation(item, quarantine);
@@ -1503,7 +1505,7 @@ async function settleWorkflowRecovery(
         drain: item.drain,
         onProgress: options.onProgress ?? (() => {}),
         checkpointReplacement: (sessionId, jobId) =>
-          checkpointReplacementInContinuation(item, quarantine, options.db, sessionId, jobId),
+          checkpointReplacementInContinuation(item, quarantine, sessionId, jobId),
         staleTimeoutMs: options.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS,
         staleCheckIntervalMs: options.staleCheckIntervalMs ?? DEFAULT_STALE_CHECK_INTERVAL_MS,
         staleAbortTimeoutMs: options.staleAbortTimeoutMs ?? DEFAULT_STALE_ABORT_TIMEOUT_MS,

--- a/src/workflow/recover.ts
+++ b/src/workflow/recover.ts
@@ -51,7 +51,7 @@ import {
   sessionControllerFromProfile,
   type ProviderSession,
 } from '../sessions/entry.js';
-import { projectionSessionStoredRowSchema } from '../sessions/projections.js';
+import { projectionSessionStoredRowSchema, readProjectionProviderSession } from '../sessions/projections.js';
 import type { ProjectionJobStoredRow } from '../jobs/projection-row.js';
 import type {
   RecoveryDisposition,
@@ -136,6 +136,13 @@ type ResumeWorkflowContext = {
   drain: ReturnType<typeof workflowDrainEnteredBodySchema.parse> | null;
   time: Pick<TimePort, 'now'>;
   onProgress: (workflowId: string, message: string) => void;
+  /**
+   * Hands a replacement this pass just committed back to the recovery item, so the durable continuation
+   * names the job that now holds the session instead of the one it replaced. Without it the replacement
+   * is invisible to the close that has to release it: `descendants` is derived from the continuation,
+   * and the continuation was read before this pass created anything.
+   */
+  onReplacementLaunched: (sessionId: string, jobId: string) => Promise<void>;
   staleTimeoutMs: number;
   staleCheckIntervalMs: number;
   staleAbortTimeoutMs: number;
@@ -199,7 +206,6 @@ type HydratedWorkflowRecovery = {
   readonly childRows: readonly ProjectionJobStoredRow[];
   readonly slotDetailsByJob: Map<string, JobProjectionDetail>;
   readonly providerSessionsById: ReadonlyMap<string, ProviderSession>;
-  readonly descendants: readonly WorkflowRecoveryDescendant[];
   readonly completion: ReturnType<typeof workflowCompletedBodySchema.parse> | null;
   readonly drain: ReturnType<typeof workflowDrainEnteredBodySchema.parse> | null;
   readonly eventsBySeq: ReadonlyMap<number, EventsRow>;
@@ -373,6 +379,11 @@ async function resumePendingReplacementIntents(
         `Workflow recovery could not complete replacement intent for slot '${slot.slotId}': ${resumed.message ?? 'unknown error'}.`,
       );
     }
+    // Before any further fallible work — `awaitLaunch` below is the first thing that can throw, and the
+    // close that follows a throw can only release what the continuation names. Recording here is what
+    // keeps a replacement this pass created inside the envelope this pass cleans up.
+    await deps.onReplacementLaunched(launch.sessionId, resumed.jobId);
+
     const readiness = await deps.executionSvc.awaitLaunch(resumed.jobId, BOOTSTRAP_TIMEOUT_MS);
     if (readiness === 'error') {
       throw new Error(`Workflow recovery replacement '${resumed.jobId}' failed to launch for slot '${slot.slotId}'.`);
@@ -1213,7 +1224,6 @@ function hydrateWorkflowRecovery(raw: RawWorkflowRecoveryEnvelope, ctx: StoreRea
     childRows,
     slotDetailsByJob,
     providerSessionsById,
-    descendants: continuationDescendants(continuation),
     completion,
     drain,
     eventsBySeq,
@@ -1252,6 +1262,40 @@ async function persistWorkflowContinuation(
     throw new Error(`Workflow recovery continuation lost authority for '${item.envelope.subject.key}'.`);
   }
   item.continuationDurable = true;
+}
+
+/**
+ * Moves a session's continuation entry onto the replacement this recovery pass just launched, and adds
+ * that replacement to the workflow's child set, then persists the result.
+ *
+ * The version is re-read rather than incremented: `resume()` returns only the job and session ids, and
+ * the claim swap it commits is the only authority on what version the session now carries. Guessing it
+ * would reintroduce the same stale-expectation failure one step later, in the check that exists to
+ * detect exactly that.
+ */
+async function recordWorkflowReplacement(
+  item: HydratedWorkflowRecovery,
+  quarantine: RecoveryQuarantinePort,
+  db: Database,
+  sessionId: string,
+  jobId: string,
+): Promise<void> {
+  const entry = readProjectionProviderSession(db, sessionId);
+  if (entry === null) {
+    throw new Error(`Workflow recovery replacement '${jobId}' left session '${sessionId}' unreadable.`);
+  }
+  item.continuation = {
+    ...item.continuation,
+    childIds: item.continuation.childIds.includes(jobId)
+      ? item.continuation.childIds
+      : [...item.continuation.childIds, jobId],
+    providerSessions: item.continuation.providerSessions.map((session) =>
+      session.sessionId === sessionId
+        ? { ...session, activeJobId: entry.activeJobId ?? null, version: entry.version }
+        : session,
+    ),
+  };
+  await persistWorkflowContinuation(item, quarantine);
 }
 
 function executionWithUnknownOutcome(
@@ -1380,7 +1424,7 @@ function closeRecoveredWorkflow(
     item.descendantReleases = finalizer.atomicClose({
       intent,
       recording: finalizationRecording(item),
-      descendants: item.descendants,
+      descendants: continuationDescendants(item.continuation),
       releaseDescendants,
       clearContinuation: () => clearWorkflowContinuation(item, quarantine),
     });
@@ -1466,6 +1510,9 @@ async function settleWorkflowRecovery(
         completion: item.completion,
         drain: item.drain,
         onProgress: options.onProgress ?? (() => {}),
+        onReplacementLaunched: async (sessionId, jobId) => {
+          await recordWorkflowReplacement(item, quarantine, options.db, sessionId, jobId);
+        },
         staleTimeoutMs: options.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS,
         staleCheckIntervalMs: options.staleCheckIntervalMs ?? DEFAULT_STALE_CHECK_INTERVAL_MS,
         staleAbortTimeoutMs: options.staleAbortTimeoutMs ?? DEFAULT_STALE_ABORT_TIMEOUT_MS,
@@ -1556,7 +1603,7 @@ function createWorkflowRecoveryPolicy(
           };
         }
         try {
-          releaser.cleanup(item.descendants);
+          releaser.cleanup(continuationDescendants(item.continuation));
           item.cleanupRequired = false;
           return { kind: 'released' };
         } catch (error) {

--- a/tests/unit/coordinator/services/workflow-finalization.test.ts
+++ b/tests/unit/coordinator/services/workflow-finalization.test.ts
@@ -98,7 +98,6 @@ describe('selectFinalCauseRef precedence', () => {
         jobId: 'workflow-1:slot:0',
         sessionId: 'session-1',
         projectRoot: fixtureCanonicalWorkDir('/project'),
-        expectedSessionVersion: 4,
       },
     ];
     const releaseDescendants = (() => []) as unknown as AtomicFailedWorkflowDescendantReleaser;

--- a/tests/unit/workflow/recover-branches.test.ts
+++ b/tests/unit/workflow/recover-branches.test.ts
@@ -2029,4 +2029,187 @@ describe('workflow recovery branch rules', () => {
       harness.db.close();
     }
   });
+
+  // Issue #310. Recovery commits a replacement through `executionSvc.resume()` before it has validated
+  // the durable state that follows, and its descendant authority was captured at hydration — so a job
+  // this pass creates is not in the envelope this pass later cleans up.
+  //
+  // Every other replacement test in this file is structurally unable to see it: they pass
+  // `noFailedWorkflowDescendants`, a bare function with no `composeAtomic`, so `atomicReleaser()`
+  // returns null and the production release never runs at all. This one uses the real releaser and a
+  // real `resume()`, because a mocked `resume` leaves the session projection untouched and the defect
+  // is precisely what the real one writes to it.
+  //
+  // The session must hold its claim when the child launches (`appendLaunchRequested` validates the
+  // binding) and must have released it by the time recovery runs (`resumeResolved` rejects
+  // `session_busy` before it ever reaches the replacement branch). That ordering is not incidental —
+  // it is why the replaced session is never itself a descendant, and why the damage is an omission
+  // rather than a rejection.
+  it('cleans up the replacement it launched when recovery then fails', async () => {
+    const backend = createSimulationBackend({ projectRoot: PROJECT_ROOT, pluginRoot: PROJECT_ROOT });
+    const workflowId = 'workflow-replacement-envelope';
+    const plan = buildWorkflowPlan(workflowId, parseExpression('architect'), { defaultProvider: 'codex' });
+    const childJobId = plan.slots[0].slotId;
+    const sessionId = 'session-replacement-envelope';
+    const providerScope = backend.createInvocationContext().providerScope;
+    if (providerScope === undefined) throw new Error('expected simulation provider scope');
+
+    commitWorkflowEvents(
+      backend.progressStore.getDb(),
+      (c) => {
+        c.append(workflowPlanDeclaredEvent(workflowId, plan, providerScope));
+        return undefined;
+      },
+      backend.runtime.time,
+      permissiveProviderLookupPort,
+    );
+    backend.progressStore.appendLaunchRequested(workflowId, {
+      jobId: workflowId,
+      owner: { kind: 'workflow', id: workflowId },
+      sessionId: null,
+      provider: null,
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      jobKind: 'workflow',
+      pool: 'default',
+      enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+      request: { prompt: '', cwd: backend.projectRoot, bypassPermissions: false, coralEnv: {} },
+      createdAt: '2026-04-27T00:00:00.000Z',
+    });
+    backend.progressStore.commit((c) => {
+      c.append({
+        type: 'job.runtime.started',
+        stream: { kind: 'job', id: workflowId },
+        namespace: backend.namespace,
+        project: backend.projectRoot,
+        refs: { jobId: workflowId, workflowId },
+        body: { transport: 'workflow', startedAt: '2026-04-27T00:00:00.000Z' },
+      });
+      return undefined;
+    });
+
+    seedTestSessionProjection(backend.progressStore.getDb(), {
+      sessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      activeJobId: childJobId,
+    });
+    backend.progressStore.appendLaunchRequested(childJobId, {
+      jobId: childJobId,
+      owner: { kind: 'workflow', id: workflowId },
+      sessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      jobKind: 'provider',
+      pool: 'default',
+      enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+      providerAction: 'exec',
+      parentWorkflowJobId: workflowId,
+      workflowSlotId: childJobId,
+      workflowSlotGeneration: 0,
+      request: { prompt: '', cwd: backend.projectRoot, bypassPermissions: false, coralEnv: {} },
+      createdAt: '2026-04-27T00:00:00.000Z',
+    });
+    commitJobTerminal(backend.progressStore, childJobId, sessionId, {
+      content: '',
+      outcome: { kind: 'job_fault', fault: { kind: 'ghost_launch' } },
+      durationMs: 0,
+    });
+
+    // The crashed daemon released the claim and recorded a replacement intent it never completed.
+    const sessionRow = backend.progressStore
+      .getDb()
+      .prepare<[string], { entry: string }>('SELECT entry FROM projection_sessions WHERE session_id = ?')
+      .get(sessionId);
+    if (sessionRow === undefined) throw new Error('expected persisted provider session');
+    const sessionEntry = JSON.parse(sessionRow.entry) as ProviderSession & Record<string, unknown>;
+    delete sessionEntry.activeJobId;
+    sessionEntry.binding = {
+      provider: 'codex',
+      kind: 'profile',
+      binding: {
+        profile: { canonicalLocation: '/tmp/sim/accounts/codex', routing: { kind: 'home' } },
+        guarantee: 'profile-only',
+      },
+    };
+    sessionEntry.continuationLease = {
+      status: 'pending',
+      staleJobId: childJobId,
+      workflowId,
+      workflowSlotId: childJobId,
+      replacementGeneration: 1,
+      reason: 'stale_recovery',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      recordedAt: '2026-04-27T00:00:00.000Z',
+    };
+    sessionEntry.version = Number(sessionEntry.version) + 1;
+    backend.progressStore
+      .getDb()
+      .prepare('UPDATE projection_sessions SET entry = ? WHERE session_id = ?')
+      .run(JSON.stringify(sessionEntry), sessionId);
+
+    const log = vi.fn<(message: string) => void>();
+    const coordinatorCommit = (cb: Parameters<JobStore['commit']>[0]) => backend.progressStore.commit(cb);
+    const releaseFailedWorkflowDescendants = createFailedWorkflowDescendantReleaser({
+      progressStore: backend.progressStore,
+      runtime: backend.runtime,
+      coordinatorCommit,
+      getExecutionService: () => backend.service,
+      createInvocationContext: backend.createInvocationContext,
+      releaseAdoptedJob: () => {},
+      emitSessionReleased: () => {},
+      log,
+    });
+
+    // Fails the step *after* the replacement has already committed — the window the ordering opens.
+    // A Proxy rather than a spread: the execution service is a class instance, so spreading it drops
+    // every prototype method and the run fails on `service.resume is not a function` instead of on the
+    // defect. Methods bind to the target so private fields still resolve.
+    const executionSvc = new Proxy(backend.service as object, {
+      get: (target, property) => {
+        if (property === 'awaitLaunch') return async (): Promise<'error'> => 'error';
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(target) : value;
+      },
+    }) as typeof backend.service;
+
+    try {
+      const settled = await resumeAll({
+        db: backend.progressStore.getDb(),
+        progressStore: backend.progressStore,
+        loadJobDetails: loadJobProjectionDetails,
+        getExecutionService: () => executionSvc as never,
+        createInvocationContext: backend.createInvocationContext,
+        finalizeWorkflow: createWorkflowRecoveryFinalizer({
+          runtime: backend.runtime,
+          progressStore: backend.progressStore,
+          coordinatorCommit,
+          log,
+        }),
+        releaseFailedWorkflowDescendants,
+        log,
+        time: backend.runtime.time,
+      });
+
+      // The workflow does settle, and its close is not rejected. Pinned because the issue predicted the
+      // opposite — that stale descendant authority would fail `composeAtomic` and defer recovery
+      // permanently. It cannot: the replaced session had already released its claim, so it was never in
+      // the descendant set whose version the close checks. The damage is only what is missing from that
+      // set, and a passing close is what makes the omission silent.
+      expect(settled).toEqual([workflowId]);
+      expect(backend.progressStore.readStatus(workflowId)?.phase).toBe('error');
+
+      const replacementJobId = createProjectionSessionLookup(backend.progressStore.getDb()).readProviderSession(
+        sessionId,
+      )?.activeJobId;
+      expect(
+        replacementJobId,
+        'the replacement launched during recovery must be released with the workflow it belongs to, not left holding its session',
+      ).toBeUndefined();
+    } finally {
+      await backend.backend.shutdown('test cleanup');
+    }
+  });
 });

--- a/tests/unit/workflow/recover-branches.test.ts
+++ b/tests/unit/workflow/recover-branches.test.ts
@@ -2575,4 +2575,155 @@ describe('workflow recovery branch rules', () => {
       await backend.backend.shutdown('test cleanup');
     }
   });
+
+  // The third arm of the same result. A close that this pass defers is retried on a later pass, and by
+  // then the launch fence is down — so another job can lawfully hold the session a stale descendant
+  // names. Treating that as a conflict made the close permanently unsatisfiable: the persisted
+  // `ready-to-close` record comes back unchanged every pass, and the descendant it names is never going
+  // to hold that session again. `releaseJob` refusing to touch the other owner is the safety property;
+  // the throw on top of it only converted a benign state into a workflow that never finishes.
+  it('closes when a descendant session has since been claimed by another job', async () => {
+    const backend = createSimulationBackend({ projectRoot: PROJECT_ROOT, pluginRoot: PROJECT_ROOT });
+    const workflowId = 'workflow-descendant-foreign-owner';
+    const plan = buildWorkflowPlan(workflowId, parseExpression('architect'), { defaultProvider: 'codex' });
+    const childJobId = plan.slots[0].slotId;
+    const sessionId = 'session-descendant-foreign-owner';
+    const successorJobId = 'job-unrelated-successor';
+    const providerScope = backend.createInvocationContext().providerScope;
+    if (providerScope === undefined) throw new Error('expected simulation provider scope');
+
+    commitWorkflowEvents(
+      backend.progressStore.getDb(),
+      (c) => {
+        c.append(workflowPlanDeclaredEvent(workflowId, plan, providerScope));
+        return undefined;
+      },
+      backend.runtime.time,
+      permissiveProviderLookupPort,
+    );
+    backend.progressStore.appendLaunchRequested(workflowId, {
+      jobId: workflowId,
+      owner: { kind: 'workflow', id: workflowId },
+      sessionId: null,
+      provider: null,
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      jobKind: 'workflow',
+      pool: 'default',
+      enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+      request: { prompt: '', cwd: backend.projectRoot, bypassPermissions: false, coralEnv: {} },
+      createdAt: '2026-04-27T00:00:00.000Z',
+    });
+    backend.progressStore.commit((c) => {
+      c.append({
+        type: 'job.runtime.started',
+        stream: { kind: 'job', id: workflowId },
+        namespace: backend.namespace,
+        project: backend.projectRoot,
+        refs: { jobId: workflowId, workflowId },
+        body: { transport: 'workflow', startedAt: '2026-04-27T00:00:00.000Z' },
+      });
+      return undefined;
+    });
+
+    seedTestSessionProjection(backend.progressStore.getDb(), {
+      sessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      activeJobId: childJobId,
+    });
+    backend.progressStore.appendLaunchRequested(childJobId, {
+      jobId: childJobId,
+      owner: { kind: 'workflow', id: workflowId },
+      sessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      jobKind: 'provider',
+      pool: 'default',
+      enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+      providerAction: 'exec',
+      parentWorkflowJobId: workflowId,
+      workflowSlotId: childJobId,
+      workflowSlotGeneration: 0,
+      request: { prompt: '', cwd: backend.projectRoot, bypassPermissions: false, coralEnv: {} },
+      createdAt: '2026-04-27T00:00:00.000Z',
+    });
+
+    const log = vi.fn<(message: string) => void>();
+    const coordinatorCommit = (cb: Parameters<JobStore['commit']>[0]) => backend.progressStore.commit(cb);
+    const releaseFailedWorkflowDescendants = createFailedWorkflowDescendantReleaser({
+      progressStore: backend.progressStore,
+      runtime: backend.runtime,
+      coordinatorCommit,
+      getExecutionService: () => backend.service,
+      createInvocationContext: backend.createInvocationContext,
+      releaseAdoptedJob: () => {},
+      emitSessionReleased: () => {},
+      log,
+    });
+
+    // The child releases, an unrelated job claims the session, and only then does recovery fail — the
+    // shape a deferred close finds when it is retried after the launch fence has lifted.
+    const executionSvc = new Proxy(backend.service as object, {
+      get: (target, property) => {
+        if (property === 'waitStream') {
+          return () => {
+            releaseSessionJobClaim({
+              projectRoot: backend.projectRoot,
+              runtime: backend.runtime,
+              db: backend.progressStore.getDb(),
+              commitEvents: coordinatorCommit,
+              emitSessionReleased: () => {},
+              sessionId,
+              jobId: childJobId,
+            });
+            seedTestSessionProjection(backend.progressStore.getDb(), {
+              sessionId,
+              provider: 'codex',
+              projectRoot: backend.projectRoot,
+              backendNamespace: backend.namespace,
+              activeJobId: successorJobId,
+            });
+            throw new Error('workflow recovery failed while an unrelated job held the session');
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(target) : value;
+      },
+    }) as typeof backend.service;
+
+    try {
+      const settled = await resumeAll({
+        db: backend.progressStore.getDb(),
+        progressStore: backend.progressStore,
+        loadJobDetails: loadJobProjectionDetails,
+        getExecutionService: () => executionSvc as never,
+        createInvocationContext: backend.createInvocationContext,
+        finalizeWorkflow: createWorkflowRecoveryFinalizer({
+          runtime: backend.runtime,
+          progressStore: backend.progressStore,
+          coordinatorCommit,
+          log,
+        }),
+        releaseFailedWorkflowDescendants,
+        log,
+        time: backend.runtime.time,
+      });
+
+      expect(settled, 'a session another job now owns must not make this close unsatisfiable forever').toEqual([
+        workflowId,
+      ]);
+      expect(log).toHaveBeenCalledWith(
+        `Workflow recovery child ${childJobId} session claim ${sessionId} disposition: owned by another job.\n`,
+      );
+      // The successor keeps its claim: recovery released nothing it did not own.
+      expect(
+        createProjectionSessionLookup(backend.progressStore.getDb()).readProviderSession(sessionId)?.activeJobId,
+      ).toBe(successorJobId);
+    } finally {
+      await backend.backend.shutdown('test cleanup');
+    }
+  });
 });

--- a/tests/unit/workflow/recover-branches.test.ts
+++ b/tests/unit/workflow/recover-branches.test.ts
@@ -35,6 +35,7 @@ import { composeReducers } from '#src/store/reducers.js';
 import { sessionContinuationLeaseClaimedEvent } from '#src/sessions/continuation-lease-events.js';
 import { jobLaunchRequestedEvent } from '#src/jobs/store.js';
 import type { ProviderSession } from '#src/sessions/entry.js';
+import type { ProviderSessionLaunchDecision } from '#src/jobs/launch.js';
 import { createProjectionSessionLookup } from '#src/sessions/lookup.js';
 import { createWorkflowRecoveryFinalizer } from '#src/coordinator/services/workflow-recovery-finalizer.js';
 import { createRecoveryCoordinator } from '#src/coordinator/services/recovery/index.js';
@@ -2385,6 +2386,191 @@ describe('workflow recovery branch rules', () => {
       expect(log).toHaveBeenCalledWith(
         `Workflow recovery child ${childJobId} session claim ${sessionId} disposition: already absent.\n`,
       );
+    } finally {
+      await backend.backend.shutdown('test cleanup');
+    }
+  });
+
+  // `resume()` starts the provider before it resolves (`activateCommittedProviderLaunch`), so a
+  // replacement that terminalizes quickly has already released its own claim by the time the caller sees
+  // a job id. The checkpoint must record it anyway. An earlier revision required the claim to still be
+  // held there and threw — turning a replacement that had *succeeded* into a failed workflow and
+  // dropping it from the cleanup envelope in the same move, which is the one thing the checkpoint exists
+  // to prevent. It was the same moment-in-time expectation about a moving claim that `composeAtomic`
+  // used to hold, re-introduced one layer up.
+  it('records a replacement that released its claim before the checkpoint ran', async () => {
+    const backend = createSimulationBackend({ projectRoot: PROJECT_ROOT, pluginRoot: PROJECT_ROOT });
+    const workflowId = 'workflow-replacement-fast-terminal';
+    const plan = buildWorkflowPlan(workflowId, parseExpression('architect'), { defaultProvider: 'codex' });
+    const childJobId = plan.slots[0].slotId;
+    const sessionId = 'session-replacement-fast-terminal';
+    const providerScope = backend.createInvocationContext().providerScope;
+    if (providerScope === undefined) throw new Error('expected simulation provider scope');
+
+    commitWorkflowEvents(
+      backend.progressStore.getDb(),
+      (c) => {
+        c.append(workflowPlanDeclaredEvent(workflowId, plan, providerScope));
+        return undefined;
+      },
+      backend.runtime.time,
+      permissiveProviderLookupPort,
+    );
+    backend.progressStore.appendLaunchRequested(workflowId, {
+      jobId: workflowId,
+      owner: { kind: 'workflow', id: workflowId },
+      sessionId: null,
+      provider: null,
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      jobKind: 'workflow',
+      pool: 'default',
+      enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+      request: { prompt: '', cwd: backend.projectRoot, bypassPermissions: false, coralEnv: {} },
+      createdAt: '2026-04-27T00:00:00.000Z',
+    });
+    backend.progressStore.commit((c) => {
+      c.append({
+        type: 'job.runtime.started',
+        stream: { kind: 'job', id: workflowId },
+        namespace: backend.namespace,
+        project: backend.projectRoot,
+        refs: { jobId: workflowId, workflowId },
+        body: { transport: 'workflow', startedAt: '2026-04-27T00:00:00.000Z' },
+      });
+      return undefined;
+    });
+
+    seedTestSessionProjection(backend.progressStore.getDb(), {
+      sessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      activeJobId: childJobId,
+    });
+    backend.progressStore.appendLaunchRequested(childJobId, {
+      jobId: childJobId,
+      owner: { kind: 'workflow', id: workflowId },
+      sessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      jobKind: 'provider',
+      pool: 'default',
+      enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+      providerAction: 'exec',
+      parentWorkflowJobId: workflowId,
+      workflowSlotId: childJobId,
+      workflowSlotGeneration: 0,
+      request: { prompt: '', cwd: backend.projectRoot, bypassPermissions: false, coralEnv: {} },
+      createdAt: '2026-04-27T00:00:00.000Z',
+    });
+    commitJobTerminal(backend.progressStore, childJobId, sessionId, {
+      content: '',
+      outcome: { kind: 'job_fault', fault: { kind: 'ghost_launch' } },
+      durationMs: 0,
+    });
+
+    const sessionRow = backend.progressStore
+      .getDb()
+      .prepare<[string], { entry: string }>('SELECT entry FROM projection_sessions WHERE session_id = ?')
+      .get(sessionId);
+    if (sessionRow === undefined) throw new Error('expected persisted provider session');
+    const sessionEntry = JSON.parse(sessionRow.entry) as ProviderSession & Record<string, unknown>;
+    delete sessionEntry.activeJobId;
+    sessionEntry.binding = {
+      provider: 'codex',
+      kind: 'profile',
+      binding: {
+        profile: { canonicalLocation: '/tmp/sim/accounts/codex', routing: { kind: 'home' } },
+        guarantee: 'profile-only',
+      },
+    };
+    sessionEntry.continuationLease = {
+      status: 'pending',
+      staleJobId: childJobId,
+      workflowId,
+      workflowSlotId: childJobId,
+      replacementGeneration: 1,
+      reason: 'stale_recovery',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      recordedAt: '2026-04-27T00:00:00.000Z',
+    };
+    sessionEntry.version = Number(sessionEntry.version) + 1;
+    backend.progressStore
+      .getDb()
+      .prepare('UPDATE projection_sessions SET entry = ? WHERE session_id = ?')
+      .run(JSON.stringify(sessionEntry), sessionId);
+
+    const log = vi.fn<(message: string) => void>();
+    const coordinatorCommit = (cb: Parameters<JobStore['commit']>[0]) => backend.progressStore.commit(cb);
+    const releaseFailedWorkflowDescendants = createFailedWorkflowDescendantReleaser({
+      progressStore: backend.progressStore,
+      runtime: backend.runtime,
+      coordinatorCommit,
+      getExecutionService: () => backend.service,
+      createInvocationContext: backend.createInvocationContext,
+      releaseAdoptedJob: () => {},
+      emitSessionReleased: () => {},
+      log,
+    });
+
+    // `resume()` returns only after the replacement has already released its own claim — the race the
+    // asynchronous activation makes reachable. `awaitLaunch` then fails so the close runs deterministically.
+    let replacementJobId: string | undefined;
+    const abort = vi.spyOn(backend.service, 'abort');
+    const executionSvc = new Proxy(backend.service as object, {
+      get: (target, property) => {
+        if (property === 'awaitLaunch') return async (): Promise<'error'> => 'error';
+        if (property === 'resume') {
+          return async (...args: unknown[]) => {
+            const decision = await (
+              Reflect.get(target, property, target) as (...a: unknown[]) => Promise<ProviderSessionLaunchDecision>
+            ).apply(target, args);
+            if (decision.status !== 'rejected') {
+              replacementJobId = decision.jobId;
+              releaseSessionJobClaim({
+                projectRoot: backend.projectRoot,
+                runtime: backend.runtime,
+                db: backend.progressStore.getDb(),
+                commitEvents: coordinatorCommit,
+                emitSessionReleased: () => {},
+                sessionId,
+                jobId: decision.jobId,
+              });
+            }
+            return decision;
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(target) : value;
+      },
+    }) as typeof backend.service;
+
+    try {
+      const settled = await resumeAll({
+        db: backend.progressStore.getDb(),
+        progressStore: backend.progressStore,
+        loadJobDetails: loadJobProjectionDetails,
+        getExecutionService: () => executionSvc as never,
+        createInvocationContext: backend.createInvocationContext,
+        finalizeWorkflow: createWorkflowRecoveryFinalizer({
+          runtime: backend.runtime,
+          progressStore: backend.progressStore,
+          coordinatorCommit,
+          log,
+        }),
+        releaseFailedWorkflowDescendants,
+        log,
+        time: backend.runtime.time,
+      });
+
+      expect(replacementJobId, 'recovery must have launched a replacement').toBeDefined();
+      expect(settled).toEqual([workflowId]);
+      expect(
+        abort,
+        'a replacement that finished before it could be checkpointed still belongs in the cleanup envelope',
+      ).toHaveBeenCalledWith([replacementJobId]);
     } finally {
       await backend.backend.shutdown('test cleanup');
     }

--- a/tests/unit/workflow/recover-branches.test.ts
+++ b/tests/unit/workflow/recover-branches.test.ts
@@ -39,6 +39,7 @@ import { createProjectionSessionLookup } from '#src/sessions/lookup.js';
 import { createWorkflowRecoveryFinalizer } from '#src/coordinator/services/workflow-recovery-finalizer.js';
 import { createRecoveryCoordinator } from '#src/coordinator/services/recovery/index.js';
 import { createFailedWorkflowDescendantReleaser } from '#src/coordinator/services/workflow-recovery-descendants.js';
+import { releaseSessionJobClaim } from '#src/sessions/job-release.js';
 import { seedTestSessionProjection } from '#tests/helpers/session.js';
 import { createBoundJobsRecoveryHarness } from '#tests/helpers/bound-jobs-recovery.js';
 import { fixtureCanonicalWorkDir } from '#tests/helpers/canonical-work-dir.js';
@@ -2037,8 +2038,8 @@ describe('workflow recovery branch rules', () => {
   // Every other replacement test in this file is structurally unable to see it: they pass
   // `noFailedWorkflowDescendants`, a bare function with no `composeAtomic`, so `atomicReleaser()`
   // returns null and the production release never runs at all. This one uses the real releaser and a
-  // real `resume()`, because a mocked `resume` leaves the session projection untouched and the defect
-  // is precisely what the real one writes to it.
+  // real `resume()` — the canonical-path mock above does update the session projection, but only to the
+  // shape that test asserts, and the defect is exactly what the real claim swap writes there.
   //
   // The session must hold its claim when the child launches (`appendLaunchRequested` validates the
   // binding) and must have released it by the time recovery runs (`resumeResolved` rejects
@@ -2167,9 +2168,27 @@ describe('workflow recovery branch rules', () => {
     // A Proxy rather than a spread: the execution service is a class instance, so spreading it drops
     // every prototype method and the run fails on `service.resume is not a function` instead of on the
     // defect. Methods bind to the target so private fields still resolve.
+    //
+    // The override also records what it was called with, because the assertions below cannot tell a
+    // launched-then-abandoned replacement from a `resume()` that never launched one: if `resume()`
+    // returned `rejected`, recovery still settles the workflow as failed and the session still ends with
+    // no claim, so every assertion would pass while nothing was exercised. That is not hypothetical —
+    // an earlier revision of this test kept the session's claim, `resumeResolved` rejected it as
+    // `session_busy` before the replacement branch, and the test passed against the unfixed code.
+    let replacementJobId: string | undefined;
+    let claimWhileLaunching: string | undefined;
+    const abort = vi.spyOn(backend.service, 'abort');
     const executionSvc = new Proxy(backend.service as object, {
       get: (target, property) => {
-        if (property === 'awaitLaunch') return async (): Promise<'error'> => 'error';
+        if (property === 'awaitLaunch') {
+          return async (jobId: string): Promise<'error'> => {
+            replacementJobId = jobId;
+            claimWhileLaunching = createProjectionSessionLookup(backend.progressStore.getDb()).readProviderSession(
+              sessionId,
+            )?.activeJobId;
+            return 'error';
+          };
+        }
         const value = Reflect.get(target, property, target) as unknown;
         return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(target) : value;
       },
@@ -2201,13 +2220,171 @@ describe('workflow recovery branch rules', () => {
       expect(settled).toEqual([workflowId]);
       expect(backend.progressStore.readStatus(workflowId)?.phase).toBe('error');
 
-      const replacementJobId = createProjectionSessionLookup(backend.progressStore.getDb()).readProviderSession(
-        sessionId,
-      )?.activeJobId;
-      expect(
+      // A replacement really launched, and really held the session — without this the assertions below
+      // are satisfied by a `resume()` that never launched anything.
+      expect(replacementJobId, 'recovery must have launched a replacement').toBeDefined();
+      expect(replacementJobId).not.toBe(childJobId);
+      expect(claimWhileLaunching, 'the replacement must hold the session claim while it launches').toBe(
         replacementJobId,
+      );
+
+      // Two obligations, and reverting either one alone must fail here. The claim release is what the
+      // atomic close performs; the abort is what process-local cleanup performs. Asserting only the
+      // first would let a reverted cleanup site pass while the replacement kept running.
+      expect(
+        createProjectionSessionLookup(backend.progressStore.getDb()).readProviderSession(sessionId)?.activeJobId,
         'the replacement launched during recovery must be released with the workflow it belongs to, not left holding its session',
       ).toBeUndefined();
+      expect(abort, 'the replacement must also be stopped, not merely unclaimed').toHaveBeenCalledWith([
+        replacementJobId,
+      ]);
+    } finally {
+      await backend.backend.shutdown('test cleanup');
+    }
+  });
+
+  // The sibling of the case above, and the one that was live on main before it: recovery's own lawful
+  // work moves a claim it is going to release. Waiting for a child to terminate releases that child's
+  // claim; completing a replacement intent swaps it. The close then has to release a descendant whose
+  // claim has already moved.
+  //
+  // `composeAtomic` used to re-derive that judgement from a projection read and reject it — treating an
+  // already-released claim as a conflict, and comparing a session version captured at hydration against
+  // one this pass had itself advanced. A rejected close is not retried into a fresh read: the persisted
+  // `ready-to-close` continuation comes back unchanged, so the workflow deferred forever.
+  //
+  // Nothing pinned it because the release primitive's own `already_absent` result was unreachable —
+  // `describeSessionJobClaimReleaseResult` has carried a string for it that no run could produce.
+  it('closes when a descendant claim was already released by recovery itself', async () => {
+    const backend = createSimulationBackend({ projectRoot: PROJECT_ROOT, pluginRoot: PROJECT_ROOT });
+    const workflowId = 'workflow-descendant-already-released';
+    const plan = buildWorkflowPlan(workflowId, parseExpression('architect'), { defaultProvider: 'codex' });
+    const childJobId = plan.slots[0].slotId;
+    const sessionId = 'session-descendant-already-released';
+    const providerScope = backend.createInvocationContext().providerScope;
+    if (providerScope === undefined) throw new Error('expected simulation provider scope');
+
+    commitWorkflowEvents(
+      backend.progressStore.getDb(),
+      (c) => {
+        c.append(workflowPlanDeclaredEvent(workflowId, plan, providerScope));
+        return undefined;
+      },
+      backend.runtime.time,
+      permissiveProviderLookupPort,
+    );
+    backend.progressStore.appendLaunchRequested(workflowId, {
+      jobId: workflowId,
+      owner: { kind: 'workflow', id: workflowId },
+      sessionId: null,
+      provider: null,
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      jobKind: 'workflow',
+      pool: 'default',
+      enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+      request: { prompt: '', cwd: backend.projectRoot, bypassPermissions: false, coralEnv: {} },
+      createdAt: '2026-04-27T00:00:00.000Z',
+    });
+    backend.progressStore.commit((c) => {
+      c.append({
+        type: 'job.runtime.started',
+        stream: { kind: 'job', id: workflowId },
+        namespace: backend.namespace,
+        project: backend.projectRoot,
+        refs: { jobId: workflowId, workflowId },
+        body: { transport: 'workflow', startedAt: '2026-04-27T00:00:00.000Z' },
+      });
+      return undefined;
+    });
+
+    // A running child still holding its claim — this is what makes it a descendant.
+    seedTestSessionProjection(backend.progressStore.getDb(), {
+      sessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      activeJobId: childJobId,
+    });
+    backend.progressStore.appendLaunchRequested(childJobId, {
+      jobId: childJobId,
+      owner: { kind: 'workflow', id: workflowId },
+      sessionId,
+      provider: 'codex',
+      projectRoot: backend.projectRoot,
+      backendNamespace: backend.namespace,
+      jobKind: 'provider',
+      pool: 'default',
+      enqueueSequence: backend.progressStore.nextEnqueueSequence(),
+      providerAction: 'exec',
+      parentWorkflowJobId: workflowId,
+      workflowSlotId: childJobId,
+      workflowSlotGeneration: 0,
+      request: { prompt: '', cwd: backend.projectRoot, bypassPermissions: false, coralEnv: {} },
+      createdAt: '2026-04-27T00:00:00.000Z',
+    });
+
+    const log = vi.fn<(message: string) => void>();
+    const coordinatorCommit = (cb: Parameters<JobStore['commit']>[0]) => backend.progressStore.commit(cb);
+    const releaseFailedWorkflowDescendants = createFailedWorkflowDescendantReleaser({
+      progressStore: backend.progressStore,
+      runtime: backend.runtime,
+      coordinatorCommit,
+      getExecutionService: () => backend.service,
+      createInvocationContext: backend.createInvocationContext,
+      releaseAdoptedJob: () => {},
+      emitSessionReleased: () => {},
+      log,
+    });
+
+    // Recovery releases the claim itself — through the production primitive, not a hand-written row —
+    // and then fails, so the close runs against a descendant that is already absent.
+    const executionSvc = new Proxy(backend.service as object, {
+      get: (target, property) => {
+        if (property === 'waitStream') {
+          return () => {
+            releaseSessionJobClaim({
+              projectRoot: backend.projectRoot,
+              runtime: backend.runtime,
+              db: backend.progressStore.getDb(),
+              commitEvents: coordinatorCommit,
+              emitSessionReleased: () => {},
+              sessionId,
+              jobId: childJobId,
+            });
+            throw new Error('workflow recovery failed after its own claim release');
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(target) : value;
+      },
+    }) as typeof backend.service;
+
+    try {
+      const settled = await resumeAll({
+        db: backend.progressStore.getDb(),
+        progressStore: backend.progressStore,
+        loadJobDetails: loadJobProjectionDetails,
+        getExecutionService: () => executionSvc as never,
+        createInvocationContext: backend.createInvocationContext,
+        finalizeWorkflow: createWorkflowRecoveryFinalizer({
+          runtime: backend.runtime,
+          progressStore: backend.progressStore,
+          coordinatorCommit,
+          log,
+        }),
+        releaseFailedWorkflowDescendants,
+        log,
+        time: backend.runtime.time,
+      });
+
+      expect(settled, 'a claim recovery released itself must not make its own close unsatisfiable').toEqual([
+        workflowId,
+      ]);
+      expect(backend.progressStore.readStatus(workflowId)?.phase).toBe('error');
+      expect(log).toHaveBeenCalledWith(
+        `Workflow recovery child ${childJobId} session claim ${sessionId} disposition: already absent.\n`,
+      );
     } finally {
       await backend.backend.shutdown('test cleanup');
     }


### PR DESCRIPTION
Closes #310 — with one correction to what that issue described.

## The defect

Recovery completes a pending replacement intent by committing a new job through `executionSvc.resume()`, but its descendant authority came from the continuation read at hydration. The job this pass **creates** is therefore not in the set this pass later **releases**. When anything after the replacement fails, the workflow finalizes cleanly and the replacement keeps holding its session claim, un-aborted and un-released. A recovery that exists to clean up after a dead daemon leaves a live one behind.

## Correction to #310

The issue predicted a stale `expectedSessionVersion` failing `composeAtomic` and deferring recovery permanently. **That is not reachable.** `resumeResolved` rejects `session_busy` (`job-launch.ts:360`) before it ever reaches the workflow-replacement branch, so the replaced session had already released its claim and was never in the descendant set whose version the close checks. Nothing in that set moves. The damage is only what is **missing** from it, and a close that passes cleanly is what makes the omission silent.

Verified by test, not by reading: an earlier revision of the regression kept the session's claim, `resume()` was rejected as `session_busy`, and the test passed against unfixed code.

## What changed

| Commit | Change |
|---|---|
| `1a2e7fe3` | `descendants` stops being a field frozen at hydration and becomes a projection of the continuation at each use; a `checkpointReplacement` hook records the replacement and persists before `awaitLaunch` — the first thing that can throw |
| `51b60f2f` | `composeAtomic` stops re-deriving a judgement `SessionManager.releaseJob` already owns; `expectedSessionVersion` deleted with its sole reader |
| `6a46b336` | the checkpoint records unconditionally — `resume()` starts the provider asynchronously, so a fast replacement can lawfully release its own claim first |
| `92b358f9` | `owned_by_another_job` stops being fatal, completing the same semantics on the third result |

### The shape of the root cause

`releaseJob` (`sessions/shell.ts:814`) already separates the cases:

```ts
if (!entry || entry.activeJobId === undefined) return 'already_absent';
if (entry.activeJobId !== jobId)               return 'owned_by_another_job';
```

`composeAtomic` re-derived that from a projection read, collapsed both non-`released` results into one throw, and added a session-version comparison the owner does not have. **Both halves fire on recovery's own lawful work** — waiting for a child to terminate releases its claim, completing a replacement intent swaps it.

All three results say the same thing about the obligation: afterwards, `jobId` does not hold `sessionId`. None is a conflict. The safety property is `releaseJob` refusing to touch another owner, and it holds without the throw.

Evidence the correct behaviour was designed and then walled off: `describeSessionJobClaimReleaseResult` has always carried an `already absent` string that **no run could produce**, because the pre-check threw first.

## Each fix has a regression that fails without it

Verified by reverting each production change in isolation:

| Reverted | Failure |
|---|---|
| checkpoint call | `expected '…0002' to be undefined` |
| `composeAtomic` relaxation | `expected [] to deeply equal [ Array(1) ]` |
| unconditional recording | `expected "abort" to be called with arguments: [ Array(1) ]` |
| `owned_by_another_job` non-fatal | `expected [] to deeply equal [ 'workflow-descendant-foreign-owner' ]` |

The regressions need the **real** releaser and a **real** `resume()`. Every pre-existing replacement test passes `noFailedWorkflowDescendants` — a bare function with no `composeAtomic` — so `atomicReleaser()` returns null and the production release path never runs at all; and a mocked `resume` leaves the session projection untouched when what it writes there is the defect.

## Review history

Three guardian passes. Round 1 raised two BLOCKING; round 2 confirmed one resolved and one pre-existing, and found a new one that `6a46b336` fixes; round 3 found the third-result inconsistency that `92b358f9` fixes. **`92b358f9` itself has not been reviewed** — it removes a throw rather than adding a check, which is the lowest-risk shape, but it is the newest change here.

## Left open deliberately

- A replacement committed inside `launchWorkflowReplacement` can still fail activation before `resume()` returns, and a crash between that commit and the checkpoint still loses it. Both predate this branch (those launch files are unchanged from `main`) and need the commit and the record to be one atomic step.
- `recovery/index.ts:274,317` constructs `session.claim.released` directly instead of consuming `releaseJob`'s result — the only remaining production sibling that duplicates the judgement. Presently safe: each walk supplies a fresh item and the event validator rejects a wrong live owner.

## Gates

tsc · typecheck:tests · lint · format:check · knip · `npm test` **5990** · build · test:integration **543**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)