### PR TITLE
docs: record what a live daemon showed, and correct two entries it disproved

### DIFF
--- a/docs/todo/README.md
+++ b/docs/todo/README.md
@@ -22,19 +22,22 @@ rather than an edited-clean text, because the corrections are the part that does
 
 ## Build identity — one build's records read by another
 
-|                                                                    |                                                                                                                                                                                                                                                                                                    |
-| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`build-identity-and-upgrade.md`](./build-identity-and-upgrade.md) | **Re-scored down.** Updating the plugin swaps CLI and skills immediately while the running coordinator does not swap, so two builds are live at once. Nothing has been observed to break because of it — the 2026-08-15 job losses it was written for were a single-build defect (#318), not skew. |
+|                                                                                      |                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`build-identity-and-upgrade.md`](./build-identity-and-upgrade.md)                   | **Re-scored back up, for a different reason than it was written for.** The replacement machinery exists and is never triggered: nothing compares the installed build against the live coordinator, so an old daemon serves a new install indefinitely and that release's fixes never run. Observed 2026-08-15 — a four-hour-old `0.10.6` daemon serving `0.10.8`, with 27 quarantine rows and none of the fixes in effect. |
+| [`quarantine-terminal-without-session.md`](./quarantine-terminal-without-session.md) | **Actively accumulating.** Recovery quarantines a new row every so often for a terminal event carrying no `refs.sessionId`. Survived a restart onto the build whose fix was assumed to cover it, so the old-daemon explanation is false.                                                                                                                                                                                   |
 
-Its first half — a record this build cannot parse must not become a job this build destroys — shipped
-as #316. What remains splits in two: the **record** direction shares a compatibility policy with
+`build-identity`'s first half — a record this build cannot parse must not become a job this build
+destroys — shipped as #316. What remains is three things, not two: **finishing the takeover** (above,
+now the front item), the **record** direction, which shares a compatibility policy with
 [`jobs-read-contract-schema-first.md`](./jobs-read-contract-schema-first.md) and
-[`result-artifact-availability.md`](./result-artifact-availability.md), settle it once across all
-three; the **output** direction — a live session holding old skill text driving a new CLI — has no
-defense today and is what actually blocks the `wait` change below.
+[`result-artifact-availability.md`](./result-artifact-availability.md), and the **output** direction —
+a live session holding old skill text driving a new CLI — which has no defense today and is what
+actually blocks the `wait` change below.
 
-Read its correction section before citing it. It named a cause it had inferred from a bundle-string
-diff rather than reproduced, which is the same defect this index was rewritten to remove.
+Read its correction sections before citing it. It has now been wrong twice about this subject: once
+naming a cause inferred from a bundle-string diff rather than reproduced, and once calling the mixed
+window "permitted by design" when the design is present and simply unreached.
 
 ---
 
@@ -61,10 +64,10 @@ landing does not unblock it — that was the record direction.
 
 ## Provider proxy
 
-|                                                                                            |                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`proxy-set-acquisition.md`](./proxy-set-acquisition.md)                                   | Acquisition fails on an exact-equality comparison of `processStartedAtSeconds` across a spawn. A three-second skew is enough, which is the most plausible reason two machines on one build behave differently. |
-| [`provider-operation-shutdown-quiescence.md`](./provider-operation-shutdown-quiescence.md) | Shutdown fences only part of the mutation surface.                                                                                                                                                             |
+|                                                                                            |                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`proxy-set-acquisition.md`](./proxy-set-acquisition.md)                                   | Acquisition fails on an exact-equality comparison of `processStartedAtSeconds` across a spawn. Measured disagreements run from **2 to 670 seconds**, which is too wide for spawn latency and points at the two sides using different clock bases. |
+| [`provider-operation-shutdown-quiescence.md`](./provider-operation-shutdown-quiescence.md) | Shutdown fences only part of the mutation surface.                                                                                                                                                                                                |
 
 ---
 
@@ -104,6 +107,16 @@ would have to satisfy both, and their requirements are opposites.
 |                                                        |                                                                                                                 |
 | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
 | [`store-format-routing.md`](./store-format-routing.md) | **Dormant.** Its one live defect was extracted to `coordinator-socket-identity.md`. Read it as a design record. |
+
+---
+
+---
+
+## Environment, not Coral
+
+|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Sandboxed hooks cannot find the backend bundle.** 252 occurrences of `Cannot find module '/tmp/coral-hooks-<rand>/plugin-root/bridge/coral-backend.cjs'` in one coordinator log. Neither `coral-hooks` nor that path shape exists anywhere in this repository or in a built bundle, so the mirrored plugin root is the host harness's, and it omits `bridge/`. The hooks fail open, so nothing breaks — but every occurrence is a spawned process that dies, and the noise buries real errors in the same log. Worth a line in `docs/hooks.md` about what a hook may assume about its plugin root, and worth confirming against the harness rather than guessing. |
 
 ---
 

--- a/docs/todo/build-identity-and-upgrade.md
+++ b/docs/todo/build-identity-and-upgrade.md
@@ -65,6 +65,36 @@ bounded only by its next restart. The evidence for this is independent of the in
 log line showed the daemon reporting `0.10.6` while the environment it handed to spawned children
 carried `…/coral/0.10.8/bin` on `PATH`.
 
+### The replacement is designed, built, and never triggered
+
+Observed 2026-08-15, four hours after `0.10.8` was installed: the live coordinator was still `0.10.6`,
+pid unchanged since boot, serving a `0.10.8` CLI. It had accumulated 27 unresolved quarantine rows,
+none of the release's fixes in effect, and the operator's report was that the tool had become unstable.
+Nothing was wrong with the fixes. They had never run.
+
+The intended behaviour exists: `createReplacementBackendOwnershipChecker`
+(`src/coordinator/ownership-checker.ts:27-47`) polls the discovery record every 30s and, on seeing a
+**different `instanceId`**, calls `idleTimer.requestDrain('replaced')`, which `shutdownModeFromReason`
+routes to a handoff-mode drain. An incumbent yielding to a successor is a solved problem.
+
+What is missing is anything that makes a successor start. Three entry points could, and none compares
+build identity:
+
+| Entry point                                              | What it decides on                                                 |
+| -------------------------------------------------------- | ------------------------------------------------------------------ |
+| `clients/hooks/session-start.mjs` (`isCoordinatorAlive`) | pid liveness only — no version, no bundle hash                     |
+| `routeLiveIncumbent` (`src/infra/backend-routing.ts:40`) | a newer invoking CLI is told to **use the incumbent**              |
+| `src/transport/ipc/ensure.ts`                            | discovery-record ↔ health self-consistency, not "is this my build" |
+
+So the incumbent can only learn it has been replaced by seeing a successor's `instanceId`; a successor
+only appears if one starts; and nothing starts one. The loop never closes, and the old daemon serves
+until something unrelated kills it.
+
+**An earlier revision of this document called that "permitted by design."** It is not — the design is
+present and unreached. The corrected reading is that the mixed window is not a policy choice but an
+unfinished path, which also changes its severity: this is not a latent compatibility question, it is the
+reason a shipped fix can sit installed and inert for as long as a daemon stays up.
+
 Two consequences, and they are not the same problem:
 
 **The record direction — a new CLI writes what an old coordinator reads.** No rule anywhere says a
@@ -87,11 +117,15 @@ about. Treat it as motivation, not as evidence.
 
 ## Options, none costless
 
-- **Refuse the mixed window.** A CLI whose build differs from the live coordinator hands off or refuses
-  rather than writing records the coordinator cannot read. `runCliHandoffPreflight`
-  (`src/cli/program.ts:45`) already exists and already runs on every invocation; whether it fires when
-  the _sibling bundle_ differs is the one cheap fact that has never been checked, and it decides
-  between these options.
+- **Finish the takeover.** Give one entry point a build comparison that starts a successor when the
+  installed build is newer than the live coordinator, and let the existing ownership checker drain the
+  incumbent as `'replaced'`. This is the option the machinery was built for, and it is the only one that
+  makes an installed fix take effect without an operator noticing. It needs a decision about **which**
+  entry point owns it — the session-start hook sees every new session, `routeLiveIncumbent` sees every
+  invocation — and about what happens to work in flight, which the handoff drain already answers.
+- ~~**Refuse the mixed window.**~~ Ruled out earlier and still ruled out: refusing is a cold upgrade,
+  and handing off backwards makes the upgrade silently not take effect. Note that this is a different
+  question from the takeover above — refusing keeps the old daemon, finishing the takeover replaces it.
 - **Make durable records forward-readable.** Additive-only shapes with unknown-key tolerance, so an
   older reader can adopt a newer record. This is the same compatibility rule the jobs read contract
   needs — see `jobs-read-contract-schema-first.md` and `result-artifact-availability.md`, and settle
@@ -116,11 +150,42 @@ before any retention window removes them.
 The recovery boundary, the handoff protocol, and the store fingerprint are not redesigned here. Nor is
 the continuity defect — it is fixed, and this document is not its home.
 
+## What the preflight actually does, since it keeps being assumed
+
+`runCliHandoffPreflight` runs on every invocation and does reach a build comparison. The decision is
+`routeLiveIncumbent` (`src/infra/backend-routing.ts:33-49`): same build set → use the incumbent; then
+`compareProductVersions`, and **a newer or equal invoker also uses the incumbent**. Only an older
+invoker hands off, to the newer bundle. Confirmed live against a machine in the window: the `0.10.8`
+CLI ran against the `0.10.6` daemon, exited 0, and reported `Version: 0.10.6` with no notice.
+
+`useLiveIncumbent()` returns `createUseCurrentBackendRouting()` — literally the same value the preflight
+returns when no coordinator is running at all. Three gates fall back to it with no trace:
+
+| Fallback                                                           | Site                        |
+| ------------------------------------------------------------------ | --------------------------- |
+| incumbent omits `manifest`/`bundleDir` (older or non-strict build) | `handoff-runner.ts:214-221` |
+| invoking bundle's strict identity does not resolve                 | `handoff-runner.ts:218-221` |
+| foreign-target validation rejects the incumbent's bundle           | `backend-routing.ts:44-47`  |
+
+So a process can be in the mixed window for four different reasons and nothing distinguishes them.
+Observed and unresolved: a `0.10.5` CLI against the `0.10.6` daemon should hand off by that code and
+printed no handoff notice, and which fallback fired is not determinable from outside. That is the defect.
+
+At the far end, a `0.10.4` CLI reports **`Backend not running`** against a live daemon — it predates the
+strict-identity protocol entirely. Its own message then says a mutating command relaunches the backend,
+which points at two coordinators over one journal. Not tested, deliberately; see
+`coordinator-socket-identity.md`.
+
 ## Start condition
 
-Establish `runCliHandoffPreflight`'s behaviour when the sibling bundle differs. It is a single
-observation, it is the only unknown gating the record direction's option choice, and it costs nothing.
-
-Then decide whether the record direction is worth doing at all at its re-scored severity, or whether it
-should simply be folded into the one compatibility policy shared with the two wire-contract entries.
-The output direction does not wait on any of that — it is already the constraint blocking `wait`.
+1. **Finish the takeover.** This moved to the front on 2026-08-15, when a four-hour-old `0.10.6` daemon
+   was found serving a `0.10.8` install with none of that release's fixes in effect. It is the only item
+   here whose absence makes every other fix conditional on a daemon restart nobody schedules. Pick the
+   owning entry point first; the drain side already works.
+2. **Make the window observable.** Carry the reason on the routing result instead of collapsing four
+   situations into one `use-current`, and surface it in `backend status`. Small, blocks nothing, and it
+   is why the August incident stayed misattributed as long as it did.
+3. **Fold the record direction into the one compatibility policy** shared with
+   `jobs-read-contract-schema-first.md` and `result-artifact-availability.md`. It is a consumer of a
+   policy those two need anyway, not a driver.
+4. **The output direction** waits on none of that — it is already the constraint blocking `wait`.

--- a/docs/todo/proxy-set-acquisition.md
+++ b/docs/todo/proxy-set-acquisition.md
@@ -49,6 +49,24 @@ its expectation before the process exists; the process reports its own start aft
 between those two moments that crosses a second boundary — a slow spawn, a loaded machine, a cold
 filesystem — makes them disagree, and the acquisition fails.
 
+### The observed spread is much wider than a spawn, and that changes the suspect
+
+Thirty-one failures on one daemon over four hours, with disagreements of **2, 3, 42, 85, 91, 123, 171,
+234, 236, 325, 349, 373, 375, 402, 404, 406, 410, 497, 533, 545, 550, 567, 576, 585, 629, 634 and 670
+seconds**. The earlier revision of this document generalised from a single three-second sample and
+called spawn latency the cause. Two seconds is a spawn crossing a boundary. **Six hundred is not.**
+
+A spread that reaches eleven minutes points at the two sides deriving the value from different clock
+bases rather than at either side being slow. `probeProcessStartedAtSeconds` converts a per-process tick
+count into an absolute time using a boot reference; if that reference moves — WSL2 suspend/resume is the
+obvious local candidate, and this host is WSL2 — every process started before the move reports a start
+time in a different frame from one computed after it. That would produce exactly this: a roughly
+constant offset within a run, drifting across runs, unrelated to load.
+
+Which means fix option 1 below is not merely preferable, it may be the only one that works: comparing
+two values read the same way is well-defined even when the clock base moves, and comparing an issued
+value against a read one is not.
+
 This is the most plausible explanation for the machine-to-machine divergence that has been read as
 environment weirdness: a fast machine acquires, a slow one does not, on the same build.
 
@@ -71,6 +89,12 @@ This does not change the local-authorized fallback, the control protocol, the co
 
 ## Start condition
 
-Reproduce the disagreement deliberately — delay the spawn past a second boundary and confirm the
-acquisition fails — before changing the comparison. The failure has been observed but not yet produced
-on demand, and this document has already been wrong once about a cause inferred rather than reproduced.
+Reproduce the disagreement deliberately before changing the comparison. The document has already been
+wrong twice about this cause — once inferring silent abandonment from an absent log, once generalising
+spawn latency from a single sample — so a reproduction is the entry price, not a formality.
+
+Delaying a spawn past a second boundary reproduces the two-second end of the range and proves the
+comparison is fragile. It does **not** reproduce the six-hundred-second end, and a fix validated only
+against the cheap case would leave the common one live. Start instead by reading both sides' derivation
+of `processStartedAtSeconds` and establishing whether they share a clock base at all; if they do not,
+the reproduction is a clock move, not a slow spawn.

--- a/docs/todo/quarantine-terminal-without-session.md
+++ b/docs/todo/quarantine-terminal-without-session.md
@@ -1,0 +1,67 @@
+# TODO — recovery quarantines a growing pile of terminals that carry no `refs.sessionId`
+
+**Status**: open, **and actively accumulating**. Recorded 2026-08-15 while the count was still climbing
+on a live daemon. This is the only entry in this directory whose subject is growing while it is being
+written.
+
+## What is observed
+
+`backend status` reports recovery as degraded:
+
+```
+recovery: degraded
+  reason: recovery-quarantine (27 unresolved rows)
+  last error: Job terminal event 62029 has no refs.sessionId.
+```
+
+The count went 21 → 25 → 26 → 27 over roughly four hours of ordinary use, and the event sequence in the
+message advanced each time. It is not a fixed backlog from one incident; something produces a new one
+regularly.
+
+## What it is not
+
+**It is not the `0.10.6` daemon lacking #311.** That was the first hypothesis, because the machine had
+been running an old coordinator against a new install for hours (see `build-identity-and-upgrade.md`).
+It survived a restart onto `0.10.8`: the fresh daemon reported the same degraded reason and the count
+kept rising. #311 narrowed the retention-pair source's SQL to terminals that **have** a `sessionId`;
+whatever is producing these reaches the same complaint by another route.
+
+Recorded explicitly because the wrong attribution is cheap to repeat: an old-daemon explanation fits the
+symptom, was believed, and is false.
+
+## The shape worth checking first
+
+A workflow root job has no provider session — `sessionId` is `null` on its launch record by
+construction. A terminal for such a job legitimately carries no `refs.sessionId`. Any consumer that
+treats "job terminal" as implying "has a session" will therefore fail on every workflow terminal, and
+will keep failing as long as workflows keep running. That matches the accumulation rate.
+
+So the first question is not "which record is malformed" but **which reader is asserting a session that
+the emitting job never had**. The answer decides whether the fix is at the reader, at the enumeration
+that selects records for it, or at the event's own refs.
+
+## What to gather before deciding
+
+- `coral-cli backend recovery-quarantine list` — the boundary, subject kind, and revision of the rows.
+  If they are all one boundary, the enumeration is the suspect; if they span boundaries, the emitting
+  side is.
+- For one named event sequence, the event's `stream_kind`, `refs`, and the `jobKind` of the job it names.
+  A `jobKind: 'workflow'` row confirms the shape above and ends the investigation early.
+- Whether the rows are retryable or terminal in the quarantine's own vocabulary. Deferred work that a
+  later build resolves is a different severity from work nothing will ever resolve.
+
+## Why it matters beyond the count
+
+Quarantine is the disposition #316 introduced so that a record this build cannot read stops destroying
+the job it describes. That is the right trade, and it is working. But it converts an unreadable record
+into **deferred** work, and nothing tells the operator that a job stopped moving for that reason. A
+pile that only grows is the failure mode that trade accepts, and it needs an owner.
+
+## Explicitly out of scope
+
+The quarantine mechanism itself, the recovery enumeration boundary, and #316's disposition. This item is
+only about what keeps producing rows and whether the reader or the record is wrong.
+
+## Start condition
+
+None — the data is on any machine that has run workflows, and the first two commands above are reads.


### PR DESCRIPTION
Four findings from **operating** the tool, on a machine that had been running a `0.10.6` coordinator against a `0.10.8` install for four hours.

## The correction that matters

`build-identity-and-upgrade.md` called the mixed window **"permitted by design."** It isn't. The replacement is designed *and built* — `createReplacementBackendOwnershipChecker` (`ownership-checker.ts:27-47`) polls the discovery record and drains an incumbent that sees a different `instanceId`, routed through `shutdownModeFromReason` as a handoff. **Nothing ever starts the successor that would produce that `instanceId`.**

Three entry points could, and none compares build identity:

| Entry point | Decides on |
|---|---|
| `clients/hooks/session-start.mjs` (`isCoordinatorAlive`) | pid liveness only |
| `routeLiveIncumbent` (`backend-routing.ts:40`) | a newer CLI is told to **use the incumbent** |
| `ensure.ts` | discovery ↔ health self-consistency, not "is this my build" |

The loop never closes.

**That reframes the severity.** It is not a latent compatibility question — it is the reason a shipped fix can sit installed and inert for as long as a daemon stays up. Which is what was observed: a four-hour-old `0.10.6` daemon, 27 quarantine rows, and **none of that release's fixes running**. The entry had been scored *down*; it is now the front item, with "finish the takeover" as a first option the earlier revision did not contain.

The preflight observation is restored with correct framing — including that `useLiveIncumbent()` returns the *same value* as "no coordinator running", the three gates that silently fall back to it, and the `0.10.4` CLI that reports `Backend not running` against a live daemon.

## Proxy-set acquisition: the sample was not representative

The entry generalised spawn latency from a single **three-second** sample. Thirty-one failures on that daemon disagreed by:

`2, 3, 42, 85, 91, 123, 171, 234, 236, 325, 349, 373, 375, 402, 404, 406, 410, 497, 533, 545, 550, 567, 576, 585, 629, 634, 670` seconds.

Two seconds is a spawn crossing a boundary. **Six hundred is not.** A spread reaching eleven minutes points at the two sides deriving `processStartedAtSeconds` from different clock bases — WSL2 suspend/resume being the local candidate, and this host is WSL2.

Its start condition now says so: delaying a spawn reproduces the cheap end and would validate a fix that leaves the common case live.

## New entry — and it is still growing

`quarantine-terminal-without-session.md`. Recovery quarantines a new row every so often for a terminal event carrying no `refs.sessionId`; the count went 21 → 27 in four hours.

**It is not the old daemon.** That was the first hypothesis and it is false — a restart onto `0.10.8` kept producing them. Recorded explicitly, because the wrong attribution is cheap to repeat.

First thing to check: a workflow root job has no provider session by construction, so any reader treating "job terminal" as implying "has a session" fails on every workflow terminal — which matches the accumulation rate.

## Also recorded

Sandboxed hooks resolve a plugin root with no `bridge/` — 252× `Cannot find module '/tmp/coral-hooks-<rand>/plugin-root/bridge/coral-backend.cjs'` in one log. Neither that string nor that path shape exists in this repo or a built bundle, so it is the host harness's mirror. Fails open, but buries real errors.

Docs only. `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)