### PR TITLE
refactor: move three doc blocks onto the symbols they describe, and correct the ledger

### DIFF
--- a/docs/todo/comment-sweep-bug-ledger.md
+++ b/docs/todo/comment-sweep-bug-ledger.md
@@ -172,25 +172,12 @@ or drop the reference is not a keep-or-delete call this sweep is authorized to m
 
 ## Sector 6 — `src/coordinator`
 
-- **What is wrong**: `registerRunningRecovery` settles (terminalizes) a job whose provider-binding capture
-  failed for an operator-repairable reason (`profile-unavailable`, `identity-unavailable`,
-  `subject-mismatch`) even when its durable carrier process may still be alive, instead of quarantining
-  with a live-carrier custody transfer. The comment at this site states the gap plainly and is the
-  ruling-7 case for this sector: a comment stating a rule the code currently violates, kept rather than
-  deleted.
-- **Where**: `registerRunningRecovery` in `src/coordinator/services/recovery/actions.ts`.
-- **Evidence**: Read directly. The comment cites `docs/todo/coordinator-process-disposition.md`, which
-  exists and already tracks this exact gap in full — including why an earlier quarantine attempt
-  (`0e59ac52`) was reverted for stranding process ownership, and the Principle 11 clause it violates
-  ("A boundary may release local ownership of a still-live or not-proven-absent obligation only after the
-  returned disposition names a successor owner..."). This sweep did not discover a new defect; it
-  confirmed the comment is accurate and correctly left in place per ruling 7.
-- **Why it was not fixed**: Comment-only sweep scope, and the fix (a two-part custody-transfer mechanism)
-  is already fully specified in `docs/todo/coordinator-process-disposition.md`. Recorded here only to
-  confirm the sweep found and preserved this ruling-7 case — not duplicated in full, since the linked
-  TODO is the authoritative record.
-- **Severity, as observed**: Already tracked as an open, current TODO with its own reproduction plan; no
-  new severity assessment needed from this sweep.
+Graduated to [`coordinator-process-disposition.md`](./coordinator-process-disposition.md), which already
+carried it. The sweep's finding — `registerRunningRecovery` settling a job whose carrier may still be alive
+after an operator-repairable binding failure — is that entry's own opening paragraph, down to the symbol, the
+file and the three refusal codes. Nothing was added there and the entry here is struck, because two homes for
+one finding is the shape this corpus exists to avoid. What the sweep contributed is the confirmation that the
+comment at that site is accurate and was correctly kept rather than deleted.
 
 Two comments were found and corrected as factually wrong under the "certain delete" rule (comment wrong,
 code correct — not ledger-worthy per that rule): `src/coordinator/live/kb-daemon-supervisor.ts`'s
@@ -250,6 +237,11 @@ deleted; the code itself was correct in both cases, so nothing else was ledgered
   depends on `clock.earlier(pairingLossAt, now)` ever running. Reachability is a future reader trusting the
   ternary's second arm as live logic (for example, while modifying it under the belief that pairing loss can
   be recorded more than once), or a coverage tool flagging it once the justifying comment is gone.
+- **Re-checked, and the disposition is now "keep"**: the unreachability argument above was re-derived
+  independently and holds. Deleting the arm anyway is refused, and the reason generalizes: `earliest wins`
+  is true today _whatever_ `adoptionDeadline` does, and true only _because of_ the latch argument once the
+  arm is gone. That trades a property for a proof, and the proof lives in another function. The arm stays;
+  this entry now records a deliberate keep rather than pending work.
 
 Nine comments were found and corrected as factually wrong under the "certain delete" rule (comment wrong,
 code correct — not ledger-worthy per that rule), spread across the sector: `handoff-capsule.ts`'s
@@ -400,6 +392,16 @@ Recorded once here rather than per sector, because it is one finding with 48 sit
   deciding whether to delete unreachable defensive branches is a design decision outside this sweep's mandate.
 - **Severity, as observed**: No runtime effect — the branch is simply unreached. A future caller that routes
   either code through `buildErrorEnvelope` instead of `encodeInstallError` would depend on it; today none does.
+- **Correction — this entry is wrong, and it is kept in place because how it was wrong is the lesson.** The
+  trace above enumerates where the two codes are _constructed in this process_, and concludes from that alone
+  that nothing reaches the branch. The comment sitting directly above the branch says otherwise, in the file
+  the entry is about: `code` is a bare `string` rather than a documented setup-error code precisely because it
+  "also carries raw wire codes from `IpcRpcError`/`BackendToolHttpError` bodies". A peer process is free to put
+  either string in an error body, and the branch is what maps it to exit 75. So the branch is reachable, the
+  disposition is keep, and there is no work here. The failure was scoping a reachability claim to local
+  construction while the value's own documented origin is remote — the same shape as the capsule-reachability
+  argument recorded in `.claude/rules/design-philosophy.md` §10, which also surveyed one end of a channel and
+  called the population empty.
 
 ## Sector 10 — `src/kb`, `src/kb-daemon`
 
@@ -749,6 +751,10 @@ principle requires. The inline comment there already says so. No defect, so no e
   component alone is already strictly increasing on every call. Reachability is a future edit that leans on
   `subTickCounter` actually incrementing (for example, sub-millisecond ordering among calls sharing one
   `mtimeMs`), which this implementation cannot deliver as written.
+- **Re-checked, and the fix is larger than the entry implies**: `subTickCounter` is not only a branch. It is a
+  field of the serialized snapshot type in the same file, so removing the dead arm without removing the field
+  leaves a counter nothing advances, and removing both changes the snapshot's shape. Whoever takes this decides
+  what the simulation's sub-millisecond ordering guarantee is first, and edits second.
 
 Two comments were found and corrected as factually wrong under the "certain delete" rule (comment wrong, code
 correct — not ledger-worthy per the sector 7 precedent), both outside the bug this sector ledgers:

--- a/src/infra/node-process.ts
+++ b/src/infra/node-process.ts
@@ -128,25 +128,6 @@ function probeLinuxProcessIncarnation(pid: number): ProcessIncarnation | null {
 }
 
 /**
- * This boot's identity on macOS — `kern.bootsessionuuid`, not `kern.boottime`.
- *
- * The two are not interchangeable and the difference is the whole point. `kern.boottime` is *derived* from
- * calendar time, so XNU adjusts it whenever the wall clock is set; a frame that moves with the clock cannot
- * frame a wall-clock start time, because both sides shift together and a later process can land on an earlier
- * one's coordinates. The session UUID is minted once per boot and never moves.
- *
- * Read fresh every time, exactly as `readLinuxBootId` is. The only thing that changes a boot session id
- * is a reboot, and no process survives one, so a successful read is constant for as long as anything can ask.
- * Caching it would be sound.
- *
- * It is not cached for two smaller reasons. Remembering a *failure* is genuinely wrong — a transient `sysctl`
- * error would blind every later probe until restart — so a cache here is a cache of successes only, which is
- * module-level state that outlives the test scripting a different boot around it. And the cost that made it
- * tempting is gone: the hot caller was the health response, which now reads this process's own incarnation
- * once at composition rather than per request. What remains are probes of *other* pids, where the `ps` call
- * has to happen anyway and saving one of two forks buys little.
- */
-/**
  * Whether an incarnation from this platform is strong enough to authorize a signal.
  *
  * Linux's is boot-relative. `startTicks` counts from boot, so no wall-clock change can move it, and two
@@ -166,6 +147,25 @@ export function incarnationMayAuthorizeSignal(platform: NodeJS.Platform): boolea
   return platform === 'linux';
 }
 
+/**
+ * This boot's identity on macOS — `kern.bootsessionuuid`, not `kern.boottime`.
+ *
+ * The two are not interchangeable and the difference is the whole point. `kern.boottime` is *derived* from
+ * calendar time, so XNU adjusts it whenever the wall clock is set; a frame that moves with the clock cannot
+ * frame a wall-clock start time, because both sides shift together and a later process can land on an earlier
+ * one's coordinates. The session UUID is minted once per boot and never moves.
+ *
+ * Read fresh every time, exactly as `readLinuxBootId` is. The only thing that changes a boot session id
+ * is a reboot, and no process survives one, so a successful read is constant for as long as anything can ask.
+ * Caching it would be sound.
+ *
+ * It is not cached for two smaller reasons. Remembering a *failure* is genuinely wrong — a transient `sysctl`
+ * error would blind every later probe until restart — so a cache here is a cache of successes only, which is
+ * module-level state that outlives the test scripting a different boot around it. And the cost that made it
+ * tempting is gone: the hot caller was the health response, which now reads this process's own incarnation
+ * once at composition rather than per request. What remains are probes of *other* pids, where the `ps` call
+ * has to happen anyway and saving one of two forks buys little.
+ */
 function readMacBootSessionId(): string | null {
   try {
     const raw = execFileSync('sysctl', ['-n', 'kern.bootsessionuuid'], PROBE_EXEC_OPTIONS).trim();

--- a/src/provider-proxy/semantic-operation-runner.ts
+++ b/src/provider-proxy/semantic-operation-runner.ts
@@ -155,11 +155,6 @@ function derivePersistedContinuity(prepared: ProxyPreparedAppServerOperation): D
   return raw as DerivedPersistedContinuity;
 }
 
-/**
- * Rebuilds the `BoundProvider` this operation names from its binding envelope. A fresh built-in registry per
- * call is cheap (pure registration, no I/O) and keeps this function free of shared mutable module state; the
- * host authority it connects is the one live thing every call shares.
- */
 type BoundProviderReconstruction =
   | Readonly<{ state: 'reconstructed'; bound: BoundProvider }>
   | ProviderOperationPreparePermanentRefusal;
@@ -183,6 +178,10 @@ function boundedRefusalReason(error: unknown, fallback: string): string {
   return (reason.length === 0 ? fallback : reason).slice(0, 4096);
 }
 
+/**
+ * A fresh built-in registry per call is cheap (pure registration, no I/O) and keeps this function free of
+ * shared mutable module state; the host authority it connects is the one live thing every call shares.
+ */
 function rebuildBoundProvider(
   prepared: ProxyPreparedAppServerOperation,
   authority: AppServerHostAuthority,

--- a/src/store/provider-operation-journal.ts
+++ b/src/store/provider-operation-journal.ts
@@ -571,13 +571,6 @@ function claimedOperationIdentities(value: string | undefined): Readonly<{
 }
 
 /**
- * Every row under `prefix`, the bare prefix itself included.
- *
- * A key that is *exactly* the prefix is malformed — it names no operation — and a row invisible to the scan
- * cannot fence anything, which is precisely the opposite of what an unaddressable key is supposed to do.
- * Subsequent pages advance strictly past the cursor, or the last row of each page would be visited forever.
- */
-/**
  * The first key that is *not* under `prefix`, in SQLite's BINARY collation.
  *
  * A row nothing scans cannot be reported, cannot fence and cannot be retired: it is invisible, which is the one
@@ -589,6 +582,13 @@ function keyPrefixUpperBound(prefix: string): string {
   return `${prefix.slice(0, -1)}${String.fromCharCode(prefix.charCodeAt(prefix.length - 1) + 1)}`;
 }
 
+/**
+ * Every row under `prefix`, the bare prefix itself included.
+ *
+ * A key that is *exactly* the prefix is malformed — it names no operation — and a row invisible to the scan
+ * cannot fence anything, which is precisely the opposite of what an unaddressable key is supposed to do.
+ * Subsequent pages advance strictly past the cursor, or the last row of each page would be visited forever.
+ */
 function forEachRowUnderPrefix(db: Database, prefix: string, visit: (row: MetaRow) => void): void {
   const page = db.prepare<[string, string, number], MetaRow>(
     `SELECT key, value FROM meta


### PR DESCRIPTION
The mechanical half of the comment sweep's bug ledger (#327), plus the ledger correcting itself. **Comment and documentation only — no behaviour changed.**

## Three doc blocks now sit on the symbols they describe

The sweep could only keep or delete a comment, so a block sitting above the *wrong* symbol survived it — three times, found independently in three sectors:

| File | Block | Was above | Now above |
|---|---|---|---|
| `src/infra/node-process.ts` | why the macOS boot-session id is read fresh, and why `kern.boottime` is not interchangeable | `incarnationMayAuthorizeSignal` | `readMacBootSessionId` |
| `src/store/provider-operation-journal.ts` | the inclusive-first-page pagination contract | `keyPrefixUpperBound` | `forEachRowUnderPrefix` |
| `src/provider-proxy/semantic-operation-runner.ts` | why a fresh registry per call is cheap | the `BoundProviderReconstruction` type alias | `rebuildBoundProvider` |

Each was stacked directly against another block that *did* belong where it sat, which is what made them survive review: the pair reads as one long doc until you check which function follows. The third also carried a sentence restating the type below it; that went.

## One ledger entry graduates, one is wrong, two change disposition

This is the part worth reviewing.

**Graduated.** `registerRunningRecovery` settling a job whose carrier may still be alive after an operator-repairable binding failure is `docs/todo/coordinator-process-disposition.md`'s own opening paragraph — same symbol, same file, same three refusal codes. Struck from the ledger with a note rather than kept in two places.

**Wrong, and kept marked because how it was wrong is the lesson.** The ledger recorded `errorCodeToExit`'s `NOT_OBSERVED_CORAL_SETUP_ERROR_CODES` branch as unreachable, having traced where those two codes are constructed *in this process*. The comment sitting directly above that branch says the opposite, in the same file: `code` is a bare `string` rather than a documented setup-error code precisely because it "also carries raw wire codes from `IpcRpcError`/`BackendToolHttpError` bodies". A peer process can put either string in an error body, and this branch is what maps it to exit 75.

So the branch is reachable and there is no work there. The entry stays, marked, because the failure generalizes: it scoped a reachability claim to local construction while the value's own documented origin is remote. That is the same shape as the capsule-reachability argument recorded in `.claude/rules/design-philosophy.md` §10 — which also surveyed one end of a channel and called the population empty, and which #326 spent a PR undoing.

**Two now record a deliberate keep.**

- `observePairingLoss`'s ternary second arm really is unreachable — re-derived independently, and the algebra holds. Deleting it is refused anyway: `earliest wins` is true today *whatever* `adoptionDeadline` does, and true only *because of* the latch argument once the arm is gone. That trades a property for a proof, and the proof lives in another function.
- `InMemoryStorage#nextStamps`'s `subTickCounter` is not only a dead branch; it is also a field of the serialized snapshot type in the same file. Removing the arm alone leaves a counter nothing advances, and removing both changes the snapshot's shape. That is a decision about the simulation's sub-millisecond ordering guarantee, not a deletion.

## What was deliberately not distributed

Only one ledger entry had an existing home. `invariant-scans-stop-at-src.md` was the obvious candidate for the three "an invariant covers less than it claims" findings — a missing engine id in an allowlist, a fixture exercising ten of sixteen event kinds, a duplicated type nothing pins — but that entry's subject is specifically *two named scans that stop at `src/`*. Widening it to hold any invariant-coverage finding would turn a scoped entry into a bucket, which is what the naming policy in `docs/design-rationale.md` §9 exists to prevent. They stay in the ledger until someone opens an entry that is actually about them.

The remaining ledger items are also unmoved and unchanged, including the 48 comments deferring to a specification this repository does not contain — that one needs a decision about whether the material still exists, which is not a keep-or-delete call.

## Verification

`typecheck:tests`, `lint`, `format:check`, `knip`, `build`, and 571 test files / 6483 tests — all green. The `src/` diff was filtered to prove it contains no non-comment line.

Two files under `docs/todo/` fail `prettier --check` and are untouched here; confirmed pre-existing by checking the same files at `HEAD` inside the repo tree. `format:check` covers `.ts` only, so CI is unaffected.

Source only: no version bump, no `clients/bridge/` rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
